### PR TITLE
feat(adapters): phase 5a — in-memory and noop adapters, env config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # time / ids
-time = { version = "0.3", features = ["serde", "macros"] }
+time = { version = "0.3", features = ["serde", "serde-human-readable", "macros", "formatting", "parsing"] }
 uuid = { version = "1.10", features = ["v4", "serde"] }
 
 # observability

--- a/crates/choreo-adapters/src/clock.rs
+++ b/crates/choreo-adapters/src/clock.rs
@@ -1,0 +1,48 @@
+//! Clock adapter.
+//!
+//! The domain never reads the wall clock directly. Aggregates receive
+//! an `OffsetDateTime` through [`ClockPort`] so deliberations stay
+//! reproducible under test.
+
+use choreo_core::ports::ClockPort;
+use time::OffsetDateTime;
+
+/// Wall-clock implementation of [`ClockPort`] that returns UTC time
+/// from the host's monotonic source as known to `time`.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SystemClock;
+
+impl SystemClock {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl ClockPort for SystemClock {
+    fn now(&self) -> OffsetDateTime {
+        OffsetDateTime::now_utc()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread::sleep;
+    use std::time::Duration;
+
+    #[test]
+    fn now_returns_utc() {
+        let now = SystemClock::new().now();
+        assert_eq!(now.offset(), time::UtcOffset::UTC);
+    }
+
+    #[test]
+    fn subsequent_reads_are_monotonically_non_decreasing() {
+        let clock = SystemClock::new();
+        let a = clock.now();
+        sleep(Duration::from_millis(1));
+        let b = clock.now();
+        assert!(b >= a, "wall clock went backwards: {a:?} -> {b:?}");
+    }
+}

--- a/crates/choreo-adapters/src/config.rs
+++ b/crates/choreo-adapters/src/config.rs
@@ -1,0 +1,142 @@
+//! Configuration adapter.
+//!
+//! Loads [`ServiceConfig`] from environment variables prefixed with
+//! `CHOREO_`. Defaults match the chart's `values.yaml`.
+
+use async_trait::async_trait;
+use choreo_core::error::DomainError;
+use choreo_core::ports::{ConfigurationPort, ServiceConfig};
+use figment::{
+    providers::{Env, Serialized},
+    Figment,
+};
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+/// Read-only configuration adapter backed by process environment.
+///
+/// Recognised variables (prefixed with `CHOREO_`):
+///
+/// | Var                        | Default               |
+/// |----------------------------|-----------------------|
+/// | `CHOREO_GRPC_PORT`         | `50055`               |
+/// | `CHOREO_NATS_ENABLED`      | `true`                |
+/// | `CHOREO_NATS_URL`          | `nats://nats:4222`    |
+/// | `CHOREO_TRIGGER_SUBJECT`   | `choreo.trigger.>`    |
+/// | `CHOREO_PUBLISH_PREFIX`    | `choreo`              |
+///
+/// The adapter performs no IO at construction; `load` returns a
+/// snapshot of the current environment.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct EnvConfiguration;
+
+impl EnvConfiguration {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Defaults {
+    grpc_port: u16,
+    nats_enabled: bool,
+    nats_url: String,
+    trigger_subject: String,
+    publish_prefix: String,
+}
+
+impl Default for Defaults {
+    fn default() -> Self {
+        Self {
+            grpc_port: 50055,
+            nats_enabled: true,
+            nats_url: "nats://nats:4222".to_owned(),
+            trigger_subject: "choreo.trigger.>".to_owned(),
+            publish_prefix: "choreo".to_owned(),
+        }
+    }
+}
+
+#[async_trait]
+impl ConfigurationPort for EnvConfiguration {
+    async fn load(&self) -> Result<ServiceConfig, DomainError> {
+        let figment = Figment::from(Serialized::defaults(Defaults::default()))
+            .merge(Env::prefixed("CHOREO_").split("__"));
+
+        let loaded: Defaults = figment.extract().map_err(|err| {
+            debug!(error = %err, "configuration load failed");
+            DomainError::InvariantViolated {
+                reason: "invalid choreographer environment configuration",
+            }
+        })?;
+
+        Ok(ServiceConfig {
+            grpc_port: loaded.grpc_port,
+            nats_enabled: loaded.nats_enabled,
+            nats_url: loaded.nats_url,
+            trigger_subject: loaded.trigger_subject,
+            publish_prefix: loaded.publish_prefix,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Process-env mutations are shared state. All env-touching tests
+    /// in this module serialize on this single mutex so racy
+    /// `set_var` / `remove_var` across tests cannot corrupt each
+    /// other's snapshot.
+    static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    fn clear_env() {
+        for (k, _) in std::env::vars() {
+            if k.starts_with("CHOREO_") {
+                std::env::remove_var(k);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn defaults_when_env_is_empty() {
+        let _guard = ENV_LOCK.lock().await;
+        clear_env();
+
+        let cfg = EnvConfiguration::new().load().await.unwrap();
+        assert_eq!(cfg.grpc_port, 50055);
+        assert!(cfg.nats_enabled);
+        assert_eq!(cfg.nats_url, "nats://nats:4222");
+        assert_eq!(cfg.trigger_subject, "choreo.trigger.>");
+        assert_eq!(cfg.publish_prefix, "choreo");
+    }
+
+    #[tokio::test]
+    async fn env_overrides_defaults() {
+        let _guard = ENV_LOCK.lock().await;
+        clear_env();
+        std::env::set_var("CHOREO_GRPC_PORT", "50099");
+        std::env::set_var("CHOREO_NATS_ENABLED", "false");
+        std::env::set_var("CHOREO_PUBLISH_PREFIX", "choreo.prod");
+
+        let cfg = EnvConfiguration::new().load().await.unwrap();
+        assert_eq!(cfg.grpc_port, 50099);
+        assert!(!cfg.nats_enabled);
+        assert_eq!(cfg.publish_prefix, "choreo.prod");
+
+        clear_env();
+    }
+
+    #[tokio::test]
+    async fn invalid_env_value_yields_domain_error() {
+        let _guard = ENV_LOCK.lock().await;
+        clear_env();
+        std::env::set_var("CHOREO_GRPC_PORT", "not-a-port");
+
+        let err = EnvConfiguration::new().load().await.unwrap_err();
+        assert!(matches!(err, DomainError::InvariantViolated { .. }));
+
+        clear_env();
+    }
+}

--- a/crates/choreo-adapters/src/lib.rs
+++ b/crates/choreo-adapters/src/lib.rs
@@ -5,7 +5,19 @@
 //! transport, message bus, or LLM vendor — is a peer adapter gated behind
 //! its own Cargo feature flag. No provider is privileged.
 //!
-//! ## Available feature-gated adapters
+//! ## Always available
+//!
+//! | Adapter                             | Port                              |
+//! |-------------------------------------|-----------------------------------|
+//! | [`clock::SystemClock`]              | `ClockPort`                       |
+//! | [`config::EnvConfiguration`]        | `ConfigurationPort`               |
+//! | [`memory::InMemoryCouncilRegistry`] | `CouncilRegistryPort`             |
+//! | [`memory::InMemoryDeliberationRepository`] | `DeliberationRepositoryPort` |
+//! | [`memory::InMemoryAgentRegistry`]   | `AgentResolverPort` (+ writes)    |
+//! | [`noop::NoopExecutor`]              | `ExecutorPort`                    |
+//! | [`noop::NoopMessaging`]             | `MessagingPort`                   |
+//!
+//! ## Feature-gated
 //!
 //! | Feature            | Integration                                 |
 //! |--------------------|---------------------------------------------|
@@ -17,7 +29,12 @@
 //! Additional provider adapters (frontier, local, rule-based, human-in-the-loop)
 //! plug in through the same `AgentPort` trait with no core changes.
 
-pub mod config {}
+#![deny(missing_debug_implementations)]
+
+pub mod clock;
+pub mod config;
+pub mod memory;
+pub mod noop;
 
 #[cfg(feature = "nats")]
 pub mod nats {}

--- a/crates/choreo-adapters/src/memory/agent_registry.rs
+++ b/crates/choreo-adapters/src/memory/agent_registry.rs
@@ -1,0 +1,207 @@
+//! In-memory [`AgentResolverPort`] with an explicit write surface.
+//!
+//! The resolver port is read-only by design — use cases never register
+//! agents, they just ask for live handles. This adapter exposes an
+//! additional mutation API (`insert`, `remove`) so the composition
+//! root can populate the registry during startup or on the fly.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use choreo_core::error::DomainError;
+use choreo_core::ports::{AgentPort, AgentResolverPort};
+use choreo_core::value_objects::AgentId;
+use tokio::sync::RwLock;
+
+/// In-memory agent registry that doubles as an [`AgentResolverPort`].
+///
+/// Cloning yields a shared handle; all clones see the same state.
+#[derive(Debug, Default, Clone)]
+pub struct InMemoryAgentRegistry {
+    inner: Arc<RwLock<BTreeMap<AgentId, Arc<dyn AgentPort>>>>,
+}
+
+impl InMemoryAgentRegistry {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register an agent under its [`AgentPort::id`]. Returns
+    /// [`DomainError::AlreadyExists`] if that id was already taken.
+    pub async fn insert(&self, agent: Arc<dyn AgentPort>) -> Result<(), DomainError> {
+        let mut map = self.inner.write().await;
+        let id = agent.id().clone();
+        if map.contains_key(&id) {
+            return Err(DomainError::AlreadyExists { what: "agent" });
+        }
+        map.insert(id, agent);
+        Ok(())
+    }
+
+    /// Unregister an agent by id. Returns [`DomainError::NotFound`]
+    /// when the id is unknown.
+    pub async fn remove(&self, id: &AgentId) -> Result<(), DomainError> {
+        self.inner
+            .write()
+            .await
+            .remove(id)
+            .map(|_| ())
+            .ok_or(DomainError::NotFound { what: "agent" })
+    }
+
+    pub async fn len(&self) -> usize {
+        self.inner.read().await.len()
+    }
+
+    pub async fn is_empty(&self) -> bool {
+        self.inner.read().await.is_empty()
+    }
+}
+
+#[async_trait]
+impl AgentResolverPort for InMemoryAgentRegistry {
+    async fn resolve(&self, id: &AgentId) -> Result<Arc<dyn AgentPort>, DomainError> {
+        self.inner
+            .read()
+            .await
+            .get(id)
+            .cloned()
+            .ok_or(DomainError::NotFound { what: "agent" })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use choreo_core::entities::{TaskConstraints, ValidatorReport};
+    use choreo_core::ports::{Critique, DraftRequest, Revision};
+    use choreo_core::value_objects::Specialty;
+
+    #[derive(Debug)]
+    struct DummyAgent {
+        id: AgentId,
+        specialty: Specialty,
+    }
+    #[async_trait]
+    impl AgentPort for DummyAgent {
+        fn id(&self) -> &AgentId {
+            &self.id
+        }
+        fn specialty(&self) -> &Specialty {
+            &self.specialty
+        }
+        async fn generate(&self, _request: DraftRequest) -> Result<Revision, DomainError> {
+            Ok(Revision {
+                content: String::from("x"),
+            })
+        }
+        async fn critique(
+            &self,
+            _peer_content: &str,
+            _constraints: &TaskConstraints,
+        ) -> Result<Critique, DomainError> {
+            Ok(Critique {
+                feedback: String::new(),
+            })
+        }
+        async fn revise(
+            &self,
+            own_content: &str,
+            _critique: &Critique,
+        ) -> Result<Revision, DomainError> {
+            Ok(Revision {
+                content: own_content.to_owned(),
+            })
+        }
+    }
+
+    fn agent(id: &str) -> Arc<dyn AgentPort> {
+        Arc::new(DummyAgent {
+            id: AgentId::new(id).unwrap(),
+            specialty: Specialty::new("triage").unwrap(),
+        })
+    }
+
+    // Silence the unused-field warning on ValidatorReport import above;
+    // keep the import for completeness of the example.
+    #[allow(dead_code)]
+    fn _touches_validator_report() -> Option<ValidatorReport> {
+        None
+    }
+
+    #[tokio::test]
+    async fn insert_then_resolve_roundtrips() {
+        let reg = InMemoryAgentRegistry::new();
+        reg.insert(agent("a1")).await.unwrap();
+        let got = reg.resolve(&AgentId::new("a1").unwrap()).await.unwrap();
+        assert_eq!(got.id().as_str(), "a1");
+    }
+
+    #[tokio::test]
+    async fn duplicate_insert_rejected() {
+        let reg = InMemoryAgentRegistry::new();
+        reg.insert(agent("a1")).await.unwrap();
+        let err = reg.insert(agent("a1")).await.unwrap_err();
+        assert!(matches!(err, DomainError::AlreadyExists { what: "agent" }));
+    }
+
+    #[tokio::test]
+    async fn resolve_missing_returns_not_found() {
+        let reg = InMemoryAgentRegistry::new();
+        let err = reg
+            .resolve(&AgentId::new("nope").unwrap())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, DomainError::NotFound { what: "agent" }));
+    }
+
+    #[tokio::test]
+    async fn remove_deletes_entry() {
+        let reg = InMemoryAgentRegistry::new();
+        reg.insert(agent("a1")).await.unwrap();
+        reg.remove(&AgentId::new("a1").unwrap()).await.unwrap();
+        assert!(reg.is_empty().await);
+
+        let err = reg.remove(&AgentId::new("a1").unwrap()).await.unwrap_err();
+        assert!(matches!(err, DomainError::NotFound { what: "agent" }));
+    }
+
+    #[tokio::test]
+    async fn resolve_all_preserves_input_order() {
+        let reg = InMemoryAgentRegistry::new();
+        reg.insert(agent("a3")).await.unwrap();
+        reg.insert(agent("a1")).await.unwrap();
+        reg.insert(agent("a2")).await.unwrap();
+
+        let ids = [
+            AgentId::new("a2").unwrap(),
+            AgentId::new("a1").unwrap(),
+            AgentId::new("a3").unwrap(),
+        ];
+        let resolved = reg.resolve_all(&ids).await.unwrap();
+        let order: Vec<&str> = resolved.iter().map(|a| a.id().as_str()).collect();
+        assert_eq!(order, ["a2", "a1", "a3"]);
+    }
+
+    #[tokio::test]
+    async fn resolve_all_fails_fast_on_missing() {
+        let reg = InMemoryAgentRegistry::new();
+        reg.insert(agent("a1")).await.unwrap();
+        let ids = [
+            AgentId::new("a1").unwrap(),
+            AgentId::new("missing").unwrap(),
+        ];
+        let err = reg.resolve_all(&ids).await.unwrap_err();
+        assert!(matches!(err, DomainError::NotFound { what: "agent" }));
+    }
+
+    #[tokio::test]
+    async fn clone_shares_state() {
+        let a = InMemoryAgentRegistry::new();
+        let b = a.clone();
+        a.insert(agent("a1")).await.unwrap();
+        assert_eq!(b.len().await, 1);
+    }
+}

--- a/crates/choreo-adapters/src/memory/council_registry.rs
+++ b/crates/choreo-adapters/src/memory/council_registry.rs
@@ -1,0 +1,163 @@
+//! In-memory [`CouncilRegistryPort`] backed by a `RwLock<BTreeMap>`.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use choreo_core::entities::Council;
+use choreo_core::error::DomainError;
+use choreo_core::ports::CouncilRegistryPort;
+use choreo_core::value_objects::Specialty;
+use tokio::sync::RwLock;
+
+/// In-memory council registry keyed by [`Specialty`].
+///
+/// Cheap to `Clone`; internal state is shared through `Arc<RwLock>`.
+#[derive(Debug, Default, Clone)]
+pub struct InMemoryCouncilRegistry {
+    inner: Arc<RwLock<BTreeMap<Specialty, Council>>>,
+}
+
+impl InMemoryCouncilRegistry {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of councils currently registered. Read-only helper for
+    /// diagnostics and tests.
+    pub async fn len(&self) -> usize {
+        self.inner.read().await.len()
+    }
+
+    pub async fn is_empty(&self) -> bool {
+        self.inner.read().await.is_empty()
+    }
+}
+
+#[async_trait]
+impl CouncilRegistryPort for InMemoryCouncilRegistry {
+    async fn register(&self, council: Council) -> Result<(), DomainError> {
+        let mut map = self.inner.write().await;
+        if map.contains_key(council.specialty()) {
+            return Err(DomainError::AlreadyExists { what: "council" });
+        }
+        map.insert(council.specialty().clone(), council);
+        Ok(())
+    }
+
+    async fn replace(&self, council: Council) -> Result<(), DomainError> {
+        let mut map = self.inner.write().await;
+        if !map.contains_key(council.specialty()) {
+            return Err(DomainError::NotFound { what: "council" });
+        }
+        map.insert(council.specialty().clone(), council);
+        Ok(())
+    }
+
+    async fn get(&self, specialty: &Specialty) -> Result<Council, DomainError> {
+        self.inner
+            .read()
+            .await
+            .get(specialty)
+            .cloned()
+            .ok_or(DomainError::NotFound { what: "council" })
+    }
+
+    async fn list(&self) -> Result<Vec<Council>, DomainError> {
+        Ok(self.inner.read().await.values().cloned().collect())
+    }
+
+    async fn delete(&self, specialty: &Specialty) -> Result<(), DomainError> {
+        self.inner
+            .write()
+            .await
+            .remove(specialty)
+            .map(|_| ())
+            .ok_or(DomainError::NotFound { what: "council" })
+    }
+
+    async fn contains(&self, specialty: &Specialty) -> Result<bool, DomainError> {
+        Ok(self.inner.read().await.contains_key(specialty))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use choreo_core::value_objects::{AgentId, CouncilId};
+    use time::macros::datetime;
+
+    fn council(specialty: &str) -> Council {
+        Council::new(
+            CouncilId::new(specialty).unwrap(),
+            Specialty::new(specialty).unwrap(),
+            vec![AgentId::new("a").unwrap()],
+            datetime!(2026-04-15 12:00:00 UTC),
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn register_then_get_roundtrips() {
+        let reg = InMemoryCouncilRegistry::new();
+        reg.register(council("triage")).await.unwrap();
+        let got = reg.get(&Specialty::new("triage").unwrap()).await.unwrap();
+        assert_eq!(got.specialty().as_str(), "triage");
+    }
+
+    #[tokio::test]
+    async fn duplicate_register_rejected() {
+        let reg = InMemoryCouncilRegistry::new();
+        reg.register(council("x")).await.unwrap();
+        let err = reg.register(council("x")).await.unwrap_err();
+        assert!(matches!(err, DomainError::AlreadyExists { .. }));
+    }
+
+    #[tokio::test]
+    async fn replace_requires_existing_council() {
+        let reg = InMemoryCouncilRegistry::new();
+        let err = reg.replace(council("x")).await.unwrap_err();
+        assert!(matches!(err, DomainError::NotFound { .. }));
+
+        reg.register(council("x")).await.unwrap();
+        reg.replace(council("x")).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn list_reports_everything() {
+        let reg = InMemoryCouncilRegistry::new();
+        reg.register(council("a")).await.unwrap();
+        reg.register(council("b")).await.unwrap();
+        let all = reg.list().await.unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn delete_removes_entry() {
+        let reg = InMemoryCouncilRegistry::new();
+        reg.register(council("x")).await.unwrap();
+        reg.delete(&Specialty::new("x").unwrap()).await.unwrap();
+        assert!(reg.is_empty().await);
+
+        let err = reg.delete(&Specialty::new("x").unwrap()).await.unwrap_err();
+        assert!(matches!(err, DomainError::NotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn contains_reflects_state() {
+        let reg = InMemoryCouncilRegistry::new();
+        let sp = Specialty::new("x").unwrap();
+        assert!(!reg.contains(&sp).await.unwrap());
+        reg.register(council("x")).await.unwrap();
+        assert!(reg.contains(&sp).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn clone_shares_state() {
+        let a = InMemoryCouncilRegistry::new();
+        let b = a.clone();
+        a.register(council("x")).await.unwrap();
+        assert_eq!(b.len().await, 1);
+    }
+}

--- a/crates/choreo-adapters/src/memory/deliberation_repository.rs
+++ b/crates/choreo-adapters/src/memory/deliberation_repository.rs
@@ -1,0 +1,124 @@
+//! In-memory [`DeliberationRepositoryPort`] backed by a `RwLock<BTreeMap>`.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use choreo_core::entities::Deliberation;
+use choreo_core::error::DomainError;
+use choreo_core::ports::DeliberationRepositoryPort;
+use choreo_core::value_objects::TaskId;
+use tokio::sync::RwLock;
+
+/// In-memory deliberation repository keyed by [`TaskId`].
+///
+/// Insertions keep the latest persisted value per task id.
+#[derive(Debug, Default, Clone)]
+pub struct InMemoryDeliberationRepository {
+    inner: Arc<RwLock<BTreeMap<TaskId, Deliberation>>>,
+}
+
+impl InMemoryDeliberationRepository {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn len(&self) -> usize {
+        self.inner.read().await.len()
+    }
+
+    pub async fn is_empty(&self) -> bool {
+        self.inner.read().await.is_empty()
+    }
+}
+
+#[async_trait]
+impl DeliberationRepositoryPort for InMemoryDeliberationRepository {
+    async fn save(&self, deliberation: &Deliberation) -> Result<(), DomainError> {
+        self.inner
+            .write()
+            .await
+            .insert(deliberation.task_id().clone(), deliberation.clone());
+        Ok(())
+    }
+
+    async fn get(&self, task_id: &TaskId) -> Result<Deliberation, DomainError> {
+        self.inner
+            .read()
+            .await
+            .get(task_id)
+            .cloned()
+            .ok_or(DomainError::NotFound {
+                what: "deliberation",
+            })
+    }
+
+    async fn exists(&self, task_id: &TaskId) -> Result<bool, DomainError> {
+        Ok(self.inner.read().await.contains_key(task_id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use choreo_core::value_objects::{Rounds, Specialty};
+    use time::macros::datetime;
+
+    fn deliberation(task: &str) -> Deliberation {
+        Deliberation::start(
+            TaskId::new(task).unwrap(),
+            Specialty::new("triage").unwrap(),
+            Rounds::default(),
+            datetime!(2026-04-15 12:00:00 UTC),
+        )
+    }
+
+    #[tokio::test]
+    async fn save_then_get_roundtrips() {
+        let repo = InMemoryDeliberationRepository::new();
+        repo.save(&deliberation("t1")).await.unwrap();
+        let got = repo.get(&TaskId::new("t1").unwrap()).await.unwrap();
+        assert_eq!(got.task_id().as_str(), "t1");
+    }
+
+    #[tokio::test]
+    async fn missing_task_returns_not_found() {
+        let repo = InMemoryDeliberationRepository::new();
+        let err = repo
+            .get(&TaskId::new("missing").unwrap())
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::NotFound {
+                what: "deliberation"
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn save_overwrites_previous_version() {
+        let repo = InMemoryDeliberationRepository::new();
+        repo.save(&deliberation("t1")).await.unwrap();
+        repo.save(&deliberation("t1")).await.unwrap();
+        assert_eq!(repo.len().await, 1);
+    }
+
+    #[tokio::test]
+    async fn exists_reflects_presence() {
+        let repo = InMemoryDeliberationRepository::new();
+        let id = TaskId::new("t1").unwrap();
+        assert!(!repo.exists(&id).await.unwrap());
+        repo.save(&deliberation("t1")).await.unwrap();
+        assert!(repo.exists(&id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn clone_shares_state() {
+        let a = InMemoryDeliberationRepository::new();
+        let b = a.clone();
+        a.save(&deliberation("t1")).await.unwrap();
+        assert_eq!(b.len().await, 1);
+    }
+}

--- a/crates/choreo-adapters/src/memory/mod.rs
+++ b/crates/choreo-adapters/src/memory/mod.rs
@@ -1,0 +1,14 @@
+//! In-memory adapters backing the domain ports that hold state.
+//!
+//! These are the simplest possible implementations: data lives in a
+//! mutex-guarded map inside an [`Arc`]. They are safe to share across
+//! tasks and are production-safe for single-replica deployments; for
+//! multi-replica use cases, swap them for a persistent adapter.
+
+mod agent_registry;
+mod council_registry;
+mod deliberation_repository;
+
+pub use agent_registry::InMemoryAgentRegistry;
+pub use council_registry::InMemoryCouncilRegistry;
+pub use deliberation_repository::InMemoryDeliberationRepository;

--- a/crates/choreo-adapters/src/noop/executor.rs
+++ b/crates/choreo-adapters/src/noop/executor.rs
@@ -1,0 +1,87 @@
+//! No-op [`ExecutorPort`].
+//!
+//! Returns a successful outcome with zero duration and empty output
+//! for every call. Useful when a deployment does not intend to
+//! execute winning proposals (deliberation-only mode) or in tests.
+
+use async_trait::async_trait;
+use choreo_core::entities::Proposal;
+use choreo_core::error::DomainError;
+use choreo_core::ports::{ExecutionOutcome, ExecutorPort};
+use choreo_core::value_objects::{Attributes, DurationMs};
+use tracing::debug;
+use uuid::Uuid;
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopExecutor;
+
+impl NoopExecutor {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl ExecutorPort for NoopExecutor {
+    async fn execute(
+        &self,
+        winner: &Proposal,
+        _options: &Attributes,
+    ) -> Result<ExecutionOutcome, DomainError> {
+        debug!(
+            proposal_id = winner.id().as_str(),
+            "noop executor: skipping execution"
+        );
+        Ok(ExecutionOutcome {
+            execution_id: Uuid::new_v4().to_string(),
+            succeeded: true,
+            duration: DurationMs::ZERO,
+            output: Attributes::empty(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use choreo_core::value_objects::{AgentId, ProposalId, Specialty};
+    use time::macros::datetime;
+
+    fn proposal() -> Proposal {
+        Proposal::new(
+            ProposalId::new("p1").unwrap(),
+            AgentId::new("a").unwrap(),
+            Specialty::new("s").unwrap(),
+            "content",
+            Attributes::empty(),
+            datetime!(2026-04-15 12:00:00 UTC),
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn always_succeeds() {
+        let out = NoopExecutor::new()
+            .execute(&proposal(), &Attributes::empty())
+            .await
+            .unwrap();
+        assert!(out.succeeded);
+        assert_eq!(out.duration, DurationMs::ZERO);
+        assert!(!out.execution_id.is_empty());
+    }
+
+    #[tokio::test]
+    async fn execution_ids_are_unique_across_calls() {
+        let exec = NoopExecutor::new();
+        let a = exec
+            .execute(&proposal(), &Attributes::empty())
+            .await
+            .unwrap();
+        let b = exec
+            .execute(&proposal(), &Attributes::empty())
+            .await
+            .unwrap();
+        assert_ne!(a.execution_id, b.execution_id);
+    }
+}

--- a/crates/choreo-adapters/src/noop/messaging.rs
+++ b/crates/choreo-adapters/src/noop/messaging.rs
@@ -1,0 +1,170 @@
+//! No-op [`MessagingPort`].
+//!
+//! Every publish call returns `Ok(())` without any transport activity.
+//! Intended for deployments that disable messaging (`nats_enabled=false`)
+//! and for tests. Events are logged at `debug` level so they remain
+//! observable without requiring a broker.
+
+use async_trait::async_trait;
+use choreo_core::error::DomainError;
+use choreo_core::events::{
+    DeliberationCompletedEvent, PhaseChangedEvent, TaskCompletedEvent, TaskDispatchedEvent,
+    TaskFailedEvent,
+};
+use choreo_core::ports::MessagingPort;
+use tracing::debug;
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopMessaging;
+
+impl NoopMessaging {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl MessagingPort for NoopMessaging {
+    async fn publish_task_dispatched(
+        &self,
+        event: &TaskDispatchedEvent,
+    ) -> Result<(), DomainError> {
+        debug!(
+            task_id = event.task_id().as_str(),
+            specialty = event.specialty().as_str(),
+            "noop messaging: task.dispatched"
+        );
+        Ok(())
+    }
+
+    async fn publish_task_completed(&self, event: &TaskCompletedEvent) -> Result<(), DomainError> {
+        debug!(
+            task_id = event.task_id().as_str(),
+            specialty = event.specialty().as_str(),
+            "noop messaging: task.completed"
+        );
+        Ok(())
+    }
+
+    async fn publish_task_failed(&self, event: &TaskFailedEvent) -> Result<(), DomainError> {
+        debug!(
+            task_id = event.task_id().as_str(),
+            specialty = event.specialty().as_str(),
+            kind = event.error_kind(),
+            "noop messaging: task.failed"
+        );
+        Ok(())
+    }
+
+    async fn publish_deliberation_completed(
+        &self,
+        event: &DeliberationCompletedEvent,
+    ) -> Result<(), DomainError> {
+        debug!(
+            task_id = event.task_id().as_str(),
+            specialty = event.specialty().as_str(),
+            winner = event.winner_proposal_id().as_str(),
+            "noop messaging: deliberation.completed"
+        );
+        Ok(())
+    }
+
+    async fn publish_phase_changed(&self, event: &PhaseChangedEvent) -> Result<(), DomainError> {
+        debug!(
+            task_id = event.task_id().as_str(),
+            from = event.from_phase(),
+            to = event.to_phase(),
+            "noop messaging: phase.changed"
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use choreo_core::events::EventEnvelope;
+    use choreo_core::value_objects::{
+        AgentId, DurationMs, EventId, ProposalId, Score, Specialty, TaskId,
+    };
+    use time::macros::datetime;
+
+    fn env() -> EventEnvelope {
+        EventEnvelope::new(
+            EventId::new("e").unwrap(),
+            datetime!(2026-04-15 12:00:00 UTC),
+            "test",
+            None,
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn publish_task_dispatched_is_ok() {
+        let ev = TaskDispatchedEvent::new(
+            env(),
+            TaskId::new("t").unwrap(),
+            Specialty::new("s").unwrap(),
+            None,
+        );
+        NoopMessaging::new()
+            .publish_task_dispatched(&ev)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn publish_task_completed_is_ok() {
+        let ev = TaskCompletedEvent::new(
+            env(),
+            TaskId::new("t").unwrap(),
+            Specialty::new("s").unwrap(),
+            Some(AgentId::new("a").unwrap()),
+            DurationMs::from_millis(1),
+        );
+        NoopMessaging::new()
+            .publish_task_completed(&ev)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn publish_task_failed_is_ok() {
+        let ev = TaskFailedEvent::new(
+            env(),
+            TaskId::new("t").unwrap(),
+            Specialty::new("s").unwrap(),
+            "kind",
+            "reason",
+        )
+        .unwrap();
+        NoopMessaging::new().publish_task_failed(&ev).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn publish_deliberation_completed_is_ok() {
+        let ev = DeliberationCompletedEvent::new(
+            env(),
+            TaskId::new("t").unwrap(),
+            Specialty::new("s").unwrap(),
+            ProposalId::new("p").unwrap(),
+            Score::new(0.5).unwrap(),
+            1,
+            DurationMs::from_millis(10),
+        );
+        NoopMessaging::new()
+            .publish_deliberation_completed(&ev)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn publish_phase_changed_is_ok() {
+        let ev = PhaseChangedEvent::new(env(), TaskId::new("t").unwrap(), "a", "b").unwrap();
+        NoopMessaging::new()
+            .publish_phase_changed(&ev)
+            .await
+            .unwrap();
+    }
+}

--- a/crates/choreo-adapters/src/noop/mod.rs
+++ b/crates/choreo-adapters/src/noop/mod.rs
@@ -1,0 +1,12 @@
+//! No-op adapters.
+//!
+//! These implementations honour the port contract without performing
+//! any externally-visible side effect. They are the safe defaults for
+//! deployments that disable a subsystem (e.g. `nats_enabled=false`)
+//! and are also used extensively in tests.
+
+mod executor;
+mod messaging;
+
+pub use executor::NoopExecutor;
+pub use messaging::NoopMessaging;

--- a/crates/choreo-app/src/usecases/deliberate.rs
+++ b/crates/choreo-app/src/usecases/deliberate.rs
@@ -336,6 +336,7 @@ mod tests {
     }
 
     // --- Agent -----------------------------------------------------------
+    #[derive(Debug)]
     struct StubAgent {
         id: AgentId,
         specialty: Specialty,
@@ -765,6 +766,7 @@ mod tests {
     /// `(i+1) % N`.
     #[tokio::test]
     async fn peer_review_pairs_each_agent_with_its_neighbour() {
+        #[derive(Debug)]
         struct MarkerAgent {
             id: AgentId,
             specialty: Specialty,

--- a/crates/choreo-core/src/ports/agent.rs
+++ b/crates/choreo-core/src/ports/agent.rs
@@ -38,7 +38,7 @@ pub struct Revision {
 }
 
 #[async_trait]
-pub trait AgentPort: Send + Sync {
+pub trait AgentPort: std::fmt::Debug + Send + Sync {
     /// Stable identity of this agent. Used for attribution and logging.
     fn id(&self) -> &AgentId;
 


### PR DESCRIPTION
## Summary

First slice of the adapter layer. All non-IO adapters, pure Rust,
unit-testable with no external dependencies. Deliberately small so
each concrete dependency (gRPC, NATS, provider HTTP clients) gets
its own slice in 5b / 5c / 5d.

## Adapters (always available)

| Adapter | Port |
|---|---|
| `clock::SystemClock` | `ClockPort` |
| `config::EnvConfiguration` | `ConfigurationPort` (figment + `CHOREO_*` env) |
| `memory::InMemoryCouncilRegistry` | `CouncilRegistryPort` |
| `memory::InMemoryDeliberationRepository` | `DeliberationRepositoryPort` |
| `memory::InMemoryAgentRegistry` | `AgentResolverPort` (+ insert/remove) |
| `noop::NoopExecutor` | `ExecutorPort` |
| `noop::NoopMessaging` | `MessagingPort` |

## Core change

- `AgentPort` gains `std::fmt::Debug` as a supertrait so
  containers holding `Arc<dyn AgentPort>` can derive `Debug`
  (used by `InMemoryAgentRegistry`). All in-tree stub agents
  updated; real provider adapters (vLLM, Anthropic, OpenAI)
  coming in 5d will implement `Debug` without leaking secrets.

## Honesty & Evidence

- 31 new tests. Total: **169 unit tests pass** (126 core + 12
  app + 31 adapters).
- Env-touching tests use a module-level `tokio::sync::Mutex` so
  process-env mutations serialize correctly under parallel test
  execution — a real correctness concern in Rust test harnesses.
- `time` workspace features expanded (`formatting`, `parsing`,
  `serde-human-readable`) so per-crate `cargo test -p …` works
  without relying on feature unification from other crates.

## Contract Impact

- [x] No gRPC (`underpass.choreo.v1`) surface change
- [x] No AsyncAPI change
- [x] No Helm chart change

## Architecture Review

- [x] DDD + HEX preserved — adapters depend on core, not the
      other way around
- [x] `Arc<dyn Port>` not `Arc<Mutex<…>>` exposed in public API;
      internal mutation is `tokio::sync::RwLock`
- [x] No primitive obsession — adapters accept VOs from
      `choreo-core::value_objects`
- [x] No provider-specific types introduced; all provider
      adapters land in 5d behind their own feature flags