### PR TITLE
fix(api): align proto and AsyncAPI with the domain model

### DIFF
--- a/crates/choreo-proto/proto/underpass/choreo/v1/choreo.proto
+++ b/crates/choreo-proto/proto/underpass/choreo/v1/choreo.proto
@@ -35,6 +35,20 @@ import "google/protobuf/timestamp.proto";
 // Service
 // ============================================================================
 
+// Implementation status (server side) at v0.1:
+//
+//   Deliberate, Orchestrate, GetDeliberationResult,
+//   CreateCouncil, ListCouncils, DeleteCouncil,
+//   ProcessTriggerEvent
+//     -> backed by a use case in `choreo-app/src/usecases/` (or
+//        `services/auto_dispatch.rs` for ProcessTriggerEvent).
+//
+//   StreamDeliberation, RegisterAgent, UnregisterAgent,
+//   GetStatus, GetMetrics
+//     -> declared here because they belong to the contract, but the
+//        server returns `UNIMPLEMENTED` until their backing use cases
+//        land. Enumerate what is real (not what is planned) per the
+//        project's honesty principles.
 service ChoreographerService {
   // ---- Deliberation ----------------------------------------------------
 
@@ -111,14 +125,20 @@ message Proposal {
 }
 
 // Outcome of validating and scoring a proposal.
+//
+// `passed` is NOT stored: it is a pure projection of `reports` and
+// MUST be computed by serializers as `reports.all(|r| r.passed)` if
+// their wire format needs it. Having two sources of truth for pass /
+// fail is a denormalization bug waiting to happen and is refused here.
 message ValidationOutcome {
   double score = 1;
-  bool passed = 2;
-  repeated ValidatorReport reports = 3;
+  repeated ValidatorReport reports = 2;
 }
 
 message ValidatorReport {
-  string validator = 1; // free-form validator id
+  // Free-form, adapter-defined kind (e.g. `"lint"`, `"policy"`,
+  // `"dry-run"`, `"clinical-safety"`, `"fact-check"`).
+  string kind = 1;
   bool passed = 2;
   string summary = 3;
   google.protobuf.Struct details = 4;
@@ -145,14 +165,17 @@ message DeliberationUpdate {
   google.protobuf.Timestamp emitted_at = 20;
 }
 
+// Lifecycle phases of a deliberation. Matches the domain aggregate's
+// 5-state FSM: Proposing → Revising → Validating → Scoring → Completed.
+// There is no separate `CRITIQUING` phase — critique/revise rounds
+// happen internally within `REVISING`.
 enum DeliberationPhase {
   DELIBERATION_PHASE_UNSPECIFIED = 0;
   DELIBERATION_PHASE_PROPOSING = 1;
-  DELIBERATION_PHASE_CRITIQUING = 2;
-  DELIBERATION_PHASE_REVISING = 3;
-  DELIBERATION_PHASE_VALIDATING = 4;
-  DELIBERATION_PHASE_SCORING = 5;
-  DELIBERATION_PHASE_COMPLETED = 6;
+  DELIBERATION_PHASE_REVISING = 2;
+  DELIBERATION_PHASE_VALIDATING = 3;
+  DELIBERATION_PHASE_SCORING = 4;
+  DELIBERATION_PHASE_COMPLETED = 5;
 }
 
 message Critique {

--- a/specs/asyncapi/choreographer.asyncapi.yaml
+++ b/specs/asyncapi/choreographer.asyncapi.yaml
@@ -216,12 +216,16 @@ components:
       allOf:
         - $ref: '#/components/schemas/EventEnvelope'
         - type: object
-          required: [task_id, specialty, error]
+          required: [task_id, specialty, error_kind]
           properties:
             task_id: { type: string }
             specialty: { type: string }
-            error: { type: string }
-            error_type: { type: string }
+            # Adapter-defined category of the failure
+            # (e.g. `"validator.timeout"`, `"executor.error"`).
+            error_kind: { type: string }
+            # Free-form human-readable description. Bounded length
+            # (see Rust domain invariant) to avoid unbounded payloads.
+            error_reason: { type: string }
 
     PhaseChanged:
       allOf:


### PR DESCRIPTION
## Summary

API-first discipline: before writing the gRPC server adapter (Phase
5b) I audited the two specs against the Rust domain that landed in
phases 3 and 4. Fixed the real drifts, documented the design
differences. No Rust code changes.

## Audit findings

Cross-referenced:
- `crates/choreo-proto/proto/underpass/choreo/v1/choreo.proto`
- `specs/asyncapi/choreographer.asyncapi.yaml`
- `crates/choreo-core/src/{entities,events,ports}/`

**Actual drifts (fixed in this PR):**

| Drift | Fix |
|---|---|
| Proto lists `DELIBERATION_PHASE_CRITIQUING` (6 states) | Removed; proto now matches the 5-state FSM (Phase 4 collapse) |
| Proto `ValidatorReport.validator` vs Rust `kind` | Renamed to `kind` in proto |
| Proto `ValidationOutcome.passed` stored vs Rust computed | Removed from proto; adapters compute via `reports.all(\|r\| r.passed)` |
| AsyncAPI `TaskFailed.error` + `error_type` vs Rust `error_reason` + `error_kind` | Renamed in AsyncAPI to match Rust (clearer semantics) |

**Design-level differences (documented, not bugs):**

- `DeliberateResponse.results[]` / `OrchestrateResponse.candidates[]`
  are flat ranked lists while Rust returns the full `Deliberation`
  aggregate. The gRPC mapper will project the flat wire shape from
  `deliberation.proposals()` + `outcomes()` + `ranking()` when 5b
  lands. Correct separation of concerns.
- Some RPCs (`StreamDeliberation`, `RegisterAgent`, `UnregisterAgent`,
  `GetStatus`, `GetMetrics`) are declared in the service but have
  no backing use case today. Added a docblock to the service
  enumerating implementation status so readers are not misled —
  project honesty principle.

**Clean, no action needed:**

- 6 NATS subjects in AsyncAPI ↔ 5 `publish_*` methods + 1 inbound
  trigger channel: exact 1:1 match
- 5 of 6 event schemas (TriggerEvent, TaskDispatched, TaskCompleted,
  DeliberationCompleted, PhaseChanged) were already field-by-field
  aligned with the Rust structs

## Honesty & Evidence

- 169 unit tests continue to pass (126 core + 12 app + 31 adapters).
- `cargo fmt` + `cargo clippy -D warnings` clean.
- `buf format` + `buf lint` clean locally.
- Pre-1.0, no downstream proto consumers — breaking wire changes
  (enum renumber, field rename, field removal) are safe to do now.

## Contract Impact

- [x] Breaking: `DeliberationPhase` enum members renumbered
- [x] Breaking: `ValidatorReport.validator` → `kind`
- [x] Breaking: `ValidationOutcome.passed` removed
- [x] Breaking: `TaskFailed.error` / `error_type` renamed to
      `error_reason` / `error_kind` in AsyncAPI

## Architecture Review

- [x] Specs are the source of truth; Rust code already matches the
      fixed spec (no code migration needed)
- [x] No domain-specific or provider-specific vocabulary added
- [x] Service-level implementation status now honestly documented