### PR TITLE
feat(adapters): phase 5c — NATS messaging, trigger subscriber, testcontainers integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -29,7 +38,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76433c4de73442daedb3a59e991d94e85c14ebfc33db53dfcd347a21cd6ef4f8"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures",
  "memchr",
@@ -162,6 +171,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -171,6 +186,12 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -185,6 +206,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bollard"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ccca1260af6a459d75994ad5acc1651bcabcbdbc41467cc9786519ab854c30"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "home",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-named-pipe",
+ "hyper-rustls",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs 0.8.3",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.47.1-rc.27.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f179cfbddb6e77a5472703d4b30436bff32929c0aa8a9008ecf23d1d3cdd0da"
+dependencies = [
+ "serde",
+ "serde_repr",
+ "serde_with",
 ]
 
 [[package]]
@@ -317,6 +388,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "choreo-tests-integration"
+version = "0.1.0"
+dependencies = [
+ "async-nats",
+ "async-trait",
+ "choreo-adapters",
+ "choreo-app",
+ "choreo-core",
+ "futures",
+ "serde_json",
+ "testcontainers",
+ "time",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,6 +494,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,10 +576,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "docker_credential"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d89dfcba45b4afad7450a99b39e751590463e45c04728cf555d36bb66940de8"
+dependencies = [
+ "base64 0.21.7",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ed25519"
@@ -492,6 +643,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +677,17 @@ dependencies = [
  "toml",
  "uncased",
  "version_check",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -744,6 +917,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,6 +999,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,7 +1048,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -860,6 +1063,45 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -951,6 +1193,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,6 +1227,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -1059,6 +1308,18 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.4",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1203,6 +1464,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,9 +1508,34 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "parse-display"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
+dependencies = [
+ "parse-display-derive",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax",
+ "structmeta",
+ "syn",
 ]
 
 [[package]]
@@ -1326,6 +1621,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -1604,11 +1905,49 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1646,7 +1985,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http",
@@ -1713,7 +2052,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1822,6 +2161,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1833,7 +2196,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -1846,7 +2209,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -1951,6 +2314,37 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2060,6 +2454,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2114,6 +2537,35 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "testcontainers"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a4f01f39bb10fc2a5ab23eb0d888b1e2bb168c157f61a1b98e6c501c639c74"
+dependencies = [
+ "async-trait",
+ "bollard",
+ "bollard-stubs",
+ "bytes",
+ "docker_credential",
+ "either",
+ "etcetera",
+ "futures",
+ "log",
+ "memchr",
+ "parse-display",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-tar",
+ "tokio-util",
+ "url",
+]
 
 [[package]]
 name = "thiserror"
@@ -2270,6 +2722,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tar"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "redox_syscall 0.3.5",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
 name = "tokio-test"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2299,7 +2766,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -2364,7 +2831,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2",
  "http",
@@ -2440,7 +2907,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -2597,6 +3064,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -2745,7 +3213,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -2781,10 +3249,94 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2811,6 +3363,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2848,6 +3415,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2860,6 +3433,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2869,6 +3448,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2896,6 +3481,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2905,6 +3496,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2920,6 +3517,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2929,6 +3532,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3009,7 +3618,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -3044,6 +3653,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/choreo-adapters",
     "crates/choreo-proto",
     "crates/choreo",
+    "crates/choreo-tests-integration",
 ]
 
 [workspace.package]

--- a/crates/choreo-adapters/Cargo.toml
+++ b/crates/choreo-adapters/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 # particular LLM vendor, transport, or message bus; concrete integrations
 # live behind features so that consumers pick what they need.
 [features]
-default = ["grpc"]
+default = ["grpc", "nats"]
 
 # Transports / infra
 grpc = ["dep:prost-types"]

--- a/crates/choreo-adapters/src/lib.rs
+++ b/crates/choreo-adapters/src/lib.rs
@@ -40,7 +40,7 @@ pub mod noop;
 pub mod grpc;
 
 #[cfg(feature = "nats")]
-pub mod nats {}
+pub mod nats;
 
 pub mod agents {
     #[cfg(feature = "agent-vllm")]

--- a/crates/choreo-adapters/src/nats/config.rs
+++ b/crates/choreo-adapters/src/nats/config.rs
@@ -1,0 +1,144 @@
+//! NATS adapter configuration.
+//!
+//! Honest defaults matching the Helm chart's `values.yaml`:
+//! - publish prefix: `choreo`
+//! - inbound trigger subject wildcard: `choreo.trigger.>`
+//! - outbound subjects rooted at `<prefix>.<event>`.
+
+use choreo_core::error::DomainError;
+
+const MAX_SUBJECT_LEN: usize = 256;
+
+/// NATS connection and subject configuration.
+///
+/// Built from the service configuration (`ServiceConfig`) at wiring
+/// time. Kept as a value object so the adapter can validate invariants
+/// up-front without a dependency on the broker.
+#[derive(Debug, Clone)]
+pub struct NatsConfig {
+    pub url: String,
+    pub subjects: NatsSubjects,
+}
+
+impl NatsConfig {
+    pub fn new(
+        url: impl Into<String>,
+        publish_prefix: impl Into<String>,
+        trigger_subject: impl Into<String>,
+    ) -> Result<Self, DomainError> {
+        let url = url.into();
+        let url_trimmed = url.trim();
+        if url_trimmed.is_empty() {
+            return Err(DomainError::EmptyField { field: "nats.url" });
+        }
+
+        let subjects = NatsSubjects::new(publish_prefix, trigger_subject)?;
+        Ok(Self {
+            url: url_trimmed.to_owned(),
+            subjects,
+        })
+    }
+}
+
+/// Derived subjects for every inbound and outbound channel declared
+/// by the AsyncAPI spec.
+#[derive(Debug, Clone)]
+pub struct NatsSubjects {
+    pub trigger: String,
+    pub task_dispatched: String,
+    pub task_completed: String,
+    pub task_failed: String,
+    pub deliberation_completed: String,
+    pub phase_changed: String,
+}
+
+impl NatsSubjects {
+    pub fn new(
+        publish_prefix: impl Into<String>,
+        trigger_subject: impl Into<String>,
+    ) -> Result<Self, DomainError> {
+        let prefix_raw: String = publish_prefix.into();
+        let trigger_raw: String = trigger_subject.into();
+        let prefix = Self::validate_subject(&prefix_raw, "nats.publish_prefix")?;
+        let trigger = Self::validate_subject(&trigger_raw, "nats.trigger_subject")?;
+        Ok(Self {
+            trigger,
+            task_dispatched: format!("{prefix}.task.dispatched"),
+            task_completed: format!("{prefix}.task.completed"),
+            task_failed: format!("{prefix}.task.failed"),
+            deliberation_completed: format!("{prefix}.deliberation.completed"),
+            phase_changed: format!("{prefix}.phase.changed"),
+        })
+    }
+
+    fn validate_subject(raw: &str, field: &'static str) -> Result<String, DomainError> {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return Err(DomainError::EmptyField { field });
+        }
+        if trimmed.len() > MAX_SUBJECT_LEN {
+            return Err(DomainError::FieldTooLong {
+                field,
+                actual: trimmed.len(),
+                max: MAX_SUBJECT_LEN,
+            });
+        }
+        if trimmed.chars().any(char::is_control) {
+            return Err(DomainError::InvalidCharacters { field });
+        }
+        Ok(trimmed.to_owned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subjects_derive_from_prefix() {
+        let s = NatsSubjects::new("choreo", "choreo.trigger.>").unwrap();
+        assert_eq!(s.trigger, "choreo.trigger.>");
+        assert_eq!(s.task_dispatched, "choreo.task.dispatched");
+        assert_eq!(s.task_completed, "choreo.task.completed");
+        assert_eq!(s.task_failed, "choreo.task.failed");
+        assert_eq!(s.deliberation_completed, "choreo.deliberation.completed");
+        assert_eq!(s.phase_changed, "choreo.phase.changed");
+    }
+
+    #[test]
+    fn different_prefixes_produce_different_subjects() {
+        let prod = NatsSubjects::new("choreo.prod", "choreo.prod.trigger.>").unwrap();
+        assert_eq!(prod.task_dispatched, "choreo.prod.task.dispatched");
+    }
+
+    #[test]
+    fn empty_url_is_rejected() {
+        let err = NatsConfig::new("   ", "choreo", "choreo.trigger.>").unwrap_err();
+        assert!(matches!(err, DomainError::EmptyField { field: "nats.url" }));
+    }
+
+    #[test]
+    fn empty_prefix_is_rejected() {
+        let err = NatsSubjects::new("  ", "choreo.trigger.>").unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::EmptyField {
+                field: "nats.publish_prefix"
+            }
+        ));
+    }
+
+    #[test]
+    fn control_characters_in_subject_are_rejected() {
+        // Embedded (non-trimmable) control character must fail.
+        let err = NatsSubjects::new("cho\x00reo", "choreo.trigger.>").unwrap_err();
+        assert!(matches!(err, DomainError::InvalidCharacters { .. }));
+    }
+
+    #[test]
+    fn config_builds_from_defaults() {
+        let cfg = NatsConfig::new("nats://nats:4222", "choreo", "choreo.trigger.>").unwrap();
+        assert_eq!(cfg.url, "nats://nats:4222");
+        assert_eq!(cfg.subjects.trigger, "choreo.trigger.>");
+    }
+}

--- a/crates/choreo-adapters/src/nats/messaging.rs
+++ b/crates/choreo-adapters/src/nats/messaging.rs
@@ -1,0 +1,102 @@
+//! NATS [`MessagingPort`] implementation.
+//!
+//! Publishes every outbound domain event as a JSON message on its
+//! canonical subject. The payload is whatever `serde_json` produces
+//! for the event type; thanks to `#[serde(flatten)]` on the envelope
+//! field the shape matches the AsyncAPI contract (envelope at the
+//! root next to event-specific fields).
+
+use async_nats::Client;
+use async_trait::async_trait;
+use choreo_core::error::DomainError;
+use choreo_core::events::{
+    DeliberationCompletedEvent, PhaseChangedEvent, TaskCompletedEvent, TaskDispatchedEvent,
+    TaskFailedEvent,
+};
+use choreo_core::ports::MessagingPort;
+use serde::Serialize;
+use tracing::debug;
+
+use super::config::NatsSubjects;
+
+/// Publishes domain events to NATS.
+///
+/// Constructed from an already-connected [`Client`]; the composition
+/// root owns connection lifecycle so the adapter stays focused.
+#[derive(Clone)]
+pub struct NatsMessaging {
+    client: Client,
+    subjects: NatsSubjects,
+}
+
+impl std::fmt::Debug for NatsMessaging {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NatsMessaging")
+            .field("subjects", &self.subjects)
+            .finish()
+    }
+}
+
+impl NatsMessaging {
+    #[must_use]
+    pub fn new(client: Client, subjects: NatsSubjects) -> Self {
+        Self { client, subjects }
+    }
+
+    async fn publish_event<E: Serialize>(
+        &self,
+        subject: &str,
+        event: &E,
+    ) -> Result<(), DomainError> {
+        let payload = serde_json::to_vec(event).map_err(|err| {
+            debug!(error = %err, "nats payload encoding failed");
+            DomainError::InvariantViolated {
+                reason: "nats: failed to serialize outbound event",
+            }
+        })?;
+        self.client
+            .publish(subject.to_owned(), payload.into())
+            .await
+            .map_err(|err| {
+                debug!(error = %err, subject, "nats publish failed");
+                DomainError::InvariantViolated {
+                    reason: "nats: publish failed",
+                }
+            })?;
+        debug!(subject, "nats event published");
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl MessagingPort for NatsMessaging {
+    async fn publish_task_dispatched(
+        &self,
+        event: &TaskDispatchedEvent,
+    ) -> Result<(), DomainError> {
+        self.publish_event(&self.subjects.task_dispatched, event)
+            .await
+    }
+
+    async fn publish_task_completed(&self, event: &TaskCompletedEvent) -> Result<(), DomainError> {
+        self.publish_event(&self.subjects.task_completed, event)
+            .await
+    }
+
+    async fn publish_task_failed(&self, event: &TaskFailedEvent) -> Result<(), DomainError> {
+        self.publish_event(&self.subjects.task_failed, event).await
+    }
+
+    async fn publish_deliberation_completed(
+        &self,
+        event: &DeliberationCompletedEvent,
+    ) -> Result<(), DomainError> {
+        self.publish_event(&self.subjects.deliberation_completed, event)
+            .await
+    }
+
+    async fn publish_phase_changed(&self, event: &PhaseChangedEvent) -> Result<(), DomainError> {
+        self.publish_event(&self.subjects.phase_changed, event)
+            .await
+    }
+}

--- a/crates/choreo-adapters/src/nats/mod.rs
+++ b/crates/choreo-adapters/src/nats/mod.rs
@@ -1,0 +1,20 @@
+//! NATS adapter.
+//!
+//! Two adapters live here: [`NatsMessaging`] publishes outbound
+//! domain events, and [`NatsTriggerSubscriber`] consumes inbound
+//! [`TriggerEvent`]s and hands them to the `AutoDispatchService`.
+//!
+//! Both honour the AsyncAPI contract in
+//! `specs/asyncapi/choreographer.asyncapi.yaml`: subjects under a
+//! configurable prefix (default `choreo.*`), JSON payloads with the
+//! envelope fields flattened at the root of each message.
+//!
+//! [`TriggerEvent`]: choreo_core::events::TriggerEvent
+
+mod config;
+mod messaging;
+mod subscriber;
+
+pub use config::{NatsConfig, NatsSubjects};
+pub use messaging::NatsMessaging;
+pub use subscriber::NatsTriggerSubscriber;

--- a/crates/choreo-adapters/src/nats/subscriber.rs
+++ b/crates/choreo-adapters/src/nats/subscriber.rs
@@ -1,0 +1,111 @@
+//! NATS subscriber for inbound [`TriggerEvent`]s.
+//!
+//! Wire format: JSON on the configured trigger subject wildcard
+//! (default `choreo.trigger.>`), with envelope fields at the top
+//! level next to `kind`, `requested_specialties`, etc. The exact
+//! shape matches AsyncAPI's allOf composition.
+
+use std::sync::Arc;
+
+use async_nats::Client;
+use choreo_app::services::AutoDispatchService;
+use choreo_core::error::DomainError;
+use choreo_core::events::TriggerEvent;
+use futures::StreamExt;
+use tokio::task::JoinHandle;
+use tracing::{error, info, warn};
+
+use super::config::NatsSubjects;
+
+/// Spawns a background task that consumes trigger events from NATS
+/// and forwards them to the application's `AutoDispatchService`.
+#[derive(Clone)]
+pub struct NatsTriggerSubscriber {
+    client: Client,
+    subjects: NatsSubjects,
+    dispatch: Arc<AutoDispatchService>,
+}
+
+impl std::fmt::Debug for NatsTriggerSubscriber {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NatsTriggerSubscriber")
+            .field("subjects", &self.subjects)
+            .finish()
+    }
+}
+
+impl NatsTriggerSubscriber {
+    #[must_use]
+    pub fn new(client: Client, subjects: NatsSubjects, dispatch: Arc<AutoDispatchService>) -> Self {
+        Self {
+            client,
+            subjects,
+            dispatch,
+        }
+    }
+
+    /// Start the subscription loop in a Tokio task.
+    ///
+    /// Returns the task handle so the composition root can await it
+    /// on shutdown. The task runs until the subscription stream ends
+    /// (e.g. on connection close).
+    pub async fn spawn(self) -> Result<JoinHandle<()>, DomainError> {
+        let mut subscription = self
+            .client
+            .subscribe(self.subjects.trigger.clone())
+            .await
+            .map_err(|err| {
+                error!(
+                    error = %err,
+                    subject = self.subjects.trigger.as_str(),
+                    "nats subscribe failed"
+                );
+                DomainError::InvariantViolated {
+                    reason: "nats: subscribe failed",
+                }
+            })?;
+
+        info!(
+            subject = self.subjects.trigger.as_str(),
+            "nats trigger subscriber started"
+        );
+
+        let dispatch = self.dispatch.clone();
+
+        let handle = tokio::spawn(async move {
+            while let Some(message) = subscription.next().await {
+                handle_message(&dispatch, &message.payload).await;
+            }
+            info!("nats trigger subscriber stream ended");
+        });
+
+        Ok(handle)
+    }
+}
+
+async fn handle_message(dispatch: &AutoDispatchService, payload: &[u8]) {
+    let trigger: TriggerEvent = match serde_json::from_slice(payload) {
+        Ok(t) => t,
+        Err(err) => {
+            warn!(error = %err, "nats trigger: malformed payload, dropping");
+            return;
+        }
+    };
+    match dispatch.dispatch(&trigger).await {
+        Ok(outcome) => {
+            info!(
+                event_id = trigger.envelope().event_id().as_str(),
+                successes = outcome.successes.len(),
+                failures = outcome.failures.len(),
+                "nats trigger dispatched"
+            );
+        }
+        Err(err) => {
+            error!(
+                event_id = trigger.envelope().event_id().as_str(),
+                error = %err,
+                "nats trigger auto-dispatch failed"
+            );
+        }
+    }
+}

--- a/crates/choreo-core/src/events/deliberation_completed.rs
+++ b/crates/choreo-core/src/events/deliberation_completed.rs
@@ -7,6 +7,7 @@ use crate::value_objects::{DurationMs, ProposalId, Score, Specialty, TaskId};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DeliberationCompletedEvent {
+    #[serde(flatten)]
     envelope: EventEnvelope,
     task_id: TaskId,
     specialty: Specialty,

--- a/crates/choreo-core/src/events/envelope.rs
+++ b/crates/choreo-core/src/events/envelope.rs
@@ -121,4 +121,27 @@ mod tests {
         assert_eq!(env.emitted_at(), at());
         assert_eq!(env.correlation_id(), Some(&corr));
     }
+
+    #[test]
+    fn json_shape_matches_asyncapi_allof() {
+        // AsyncAPI composes EventEnvelope into each event via `allOf`,
+        // which produces a flat JSON object. Events use
+        // `#[serde(flatten)]` on their `envelope` field so the wire
+        // shape matches this expectation. This test locks in the
+        // EventEnvelope keys at the JSON root; breaking it is a
+        // breaking change on the event bus contract.
+        let env = EventEnvelope::new(
+            EventId::new("e").unwrap(),
+            at(),
+            "src",
+            Some(EventId::new("c").unwrap()),
+        )
+        .unwrap();
+        let json = serde_json::to_value(&env).unwrap();
+        let obj = json.as_object().unwrap();
+        assert!(obj.contains_key("event_id"));
+        assert!(obj.contains_key("emitted_at"));
+        assert!(obj.contains_key("source"));
+        assert!(obj.contains_key("correlation_id"));
+    }
 }

--- a/crates/choreo-core/src/events/phase_changed.rs
+++ b/crates/choreo-core/src/events/phase_changed.rs
@@ -14,6 +14,7 @@ const MAX_PHASE_LEN: usize = 64;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PhaseChangedEvent {
+    #[serde(flatten)]
     envelope: EventEnvelope,
     task_id: TaskId,
     from_phase: String,

--- a/crates/choreo-core/src/events/task_completed.rs
+++ b/crates/choreo-core/src/events/task_completed.rs
@@ -7,6 +7,7 @@ use crate::value_objects::{AgentId, DurationMs, Specialty, TaskId};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TaskCompletedEvent {
+    #[serde(flatten)]
     envelope: EventEnvelope,
     task_id: TaskId,
     specialty: Specialty,

--- a/crates/choreo-core/src/events/task_dispatched.rs
+++ b/crates/choreo-core/src/events/task_dispatched.rs
@@ -8,6 +8,7 @@ use crate::value_objects::{EventId, Specialty, TaskId};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TaskDispatchedEvent {
+    #[serde(flatten)]
     envelope: EventEnvelope,
     task_id: TaskId,
     specialty: Specialty,

--- a/crates/choreo-core/src/events/task_failed.rs
+++ b/crates/choreo-core/src/events/task_failed.rs
@@ -10,6 +10,7 @@ const MAX_REASON_LEN: usize = 4096;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TaskFailedEvent {
+    #[serde(flatten)]
     envelope: EventEnvelope,
     task_id: TaskId,
     specialty: Specialty,

--- a/crates/choreo-core/src/events/trigger.rs
+++ b/crates/choreo-core/src/events/trigger.rs
@@ -18,6 +18,7 @@ const MAX_KIND_LEN: usize = 128;
 /// An inbound event that fans out into deliberations.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TriggerEvent {
+    #[serde(flatten)]
     envelope: EventEnvelope,
     kind: String,
     requested_specialties: Vec<Specialty>,
@@ -190,6 +191,35 @@ mod tests {
         )
         .unwrap();
         assert_eq!(ev.requested_specialties().len(), 2);
+    }
+
+    #[test]
+    fn json_shape_is_flat_per_asyncapi() {
+        // Regression test: AsyncAPI declares TriggerEvent via allOf
+        // composition with EventEnvelope, so the JSON on the wire has
+        // envelope fields at the top level next to `kind`,
+        // `requested_specialties`, etc. This test would fail if the
+        // `#[serde(flatten)]` attribute on `envelope` regressed.
+        let ev = TriggerEvent::new(
+            env(),
+            "alert.fired",
+            vec![sp("triage")],
+            None,
+            TaskConstraints::default(),
+            Attributes::empty(),
+        )
+        .unwrap();
+        let json = serde_json::to_value(&ev).unwrap();
+        let obj = json.as_object().unwrap();
+        assert!(obj.contains_key("event_id"));
+        assert!(obj.contains_key("source"));
+        assert!(obj.contains_key("emitted_at"));
+        assert!(obj.contains_key("kind"));
+        assert!(obj.contains_key("requested_specialties"));
+        assert!(
+            !obj.contains_key("envelope"),
+            "envelope must flatten into the root"
+        );
     }
 
     #[test]

--- a/crates/choreo-tests-integration/Cargo.toml
+++ b/crates/choreo-tests-integration/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "choreo-tests-integration"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Integration tests for Choreographer adapters, backed by testcontainers-managed services. Not shipped."
+publish = false
+
+[lints]
+workspace = true
+
+[features]
+# Opt-in: CI enables this feature to actually run the tests. Without
+# the feature the crate compiles but exercises nothing, so `cargo
+# test --workspace` stays fast and network-free.
+container-tests = []
+
+[dependencies]
+choreo-core = { workspace = true }
+choreo-app = { workspace = true }
+choreo-adapters = { workspace = true, features = ["nats"] }
+
+[dev-dependencies]
+async-nats = { workspace = true }
+tokio = { workspace = true }
+time = { workspace = true }
+uuid = { workspace = true }
+serde_json = { workspace = true }
+async-trait = { workspace = true }
+futures = { workspace = true }
+testcontainers = "0.23"

--- a/crates/choreo-tests-integration/src/lib.rs
+++ b/crates/choreo-tests-integration/src/lib.rs
@@ -1,0 +1,6 @@
+//! Integration tests for the Choreographer's adapters.
+//!
+//! The library itself is empty; the actual scenarios live under
+//! `tests/` and are gated by the `container-tests` feature so
+//! running `cargo test --workspace` in isolation does not require a
+//! container runtime.

--- a/crates/choreo-tests-integration/tests/nats_messaging_roundtrip.rs
+++ b/crates/choreo-tests-integration/tests/nats_messaging_roundtrip.rs
@@ -1,0 +1,231 @@
+//! Integration test: NATS messaging roundtrip over a real broker.
+//!
+//! Spins up a `nats:2` testcontainer, publishes every outbound event
+//! type via [`NatsMessaging`], subscribes with a raw client, and
+//! verifies the payloads land on the canonical subjects with an
+//! AsyncAPI-shaped JSON (envelope fields flat at the root).
+//!
+//! Runs only when the `container-tests` feature is enabled (CI).
+
+#![cfg(feature = "container-tests")]
+
+use std::time::Duration;
+
+use choreo_adapters::nats::{NatsMessaging, NatsSubjects};
+use choreo_core::events::{
+    DeliberationCompletedEvent, EventEnvelope, PhaseChangedEvent, TaskCompletedEvent,
+    TaskDispatchedEvent, TaskFailedEvent,
+};
+use choreo_core::ports::MessagingPort;
+use choreo_core::value_objects::{
+    AgentId, DurationMs, EventId, ProposalId, Score, Specialty, TaskId,
+};
+use futures::StreamExt;
+use testcontainers::{
+    core::{IntoContainerPort, WaitFor},
+    runners::AsyncRunner,
+    GenericImage, ImageExt,
+};
+use time::OffsetDateTime;
+
+const NATS_IMAGE: &str = "nats";
+const NATS_TAG: &str = "2";
+
+async fn start_nats() -> (
+    async_nats::Client,
+    testcontainers::ContainerAsync<GenericImage>,
+    String,
+) {
+    let container = GenericImage::new(NATS_IMAGE, NATS_TAG)
+        .with_exposed_port(4222_u16.tcp())
+        .with_wait_for(WaitFor::message_on_stderr("Server is ready"))
+        .with_cmd(["-js"])
+        .start()
+        .await
+        .expect("nats container should start");
+    let port = container
+        .get_host_port_ipv4(4222_u16.tcp())
+        .await
+        .expect("host port");
+    let url = format!("nats://127.0.0.1:{port}");
+
+    // Retry the connection briefly — testcontainers' wait-for only
+    // guarantees stderr progress, the accept loop may still be
+    // stabilising.
+    let mut last_err = None;
+    for _ in 0..20 {
+        match async_nats::connect(&url).await {
+            Ok(client) => return (client, container, url),
+            Err(err) => {
+                last_err = Some(err);
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        }
+    }
+    panic!("could not connect to nats after warmup: {last_err:?}");
+}
+
+fn envelope() -> EventEnvelope {
+    EventEnvelope::new(
+        EventId::new(uuid::Uuid::new_v4().to_string()).unwrap(),
+        OffsetDateTime::now_utc(),
+        "integration-test",
+        None,
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+#[allow(clippy::too_many_lines)] // a single integration scenario covers all 5 publish methods
+async fn all_outbound_events_land_on_their_canonical_subjects() {
+    let (client, _container, _url) = start_nats().await;
+    let subjects = NatsSubjects::new("choreo", "choreo.trigger.>").unwrap();
+    let messaging = NatsMessaging::new(client.clone(), subjects.clone());
+
+    let mut sub_dispatched = client
+        .subscribe(subjects.task_dispatched.clone())
+        .await
+        .unwrap();
+    let mut sub_completed = client
+        .subscribe(subjects.task_completed.clone())
+        .await
+        .unwrap();
+    let mut sub_failed = client
+        .subscribe(subjects.task_failed.clone())
+        .await
+        .unwrap();
+    let mut sub_deliberation = client
+        .subscribe(subjects.deliberation_completed.clone())
+        .await
+        .unwrap();
+    let mut sub_phase = client
+        .subscribe(subjects.phase_changed.clone())
+        .await
+        .unwrap();
+
+    // Flush subscribes — NATS is fire-and-forget; wait until the
+    // server acknowledges the SUB.
+    client.flush().await.unwrap();
+
+    // Publish every event.
+    messaging
+        .publish_task_dispatched(&TaskDispatchedEvent::new(
+            envelope(),
+            TaskId::new("t1").unwrap(),
+            Specialty::new("triage").unwrap(),
+            None,
+        ))
+        .await
+        .unwrap();
+    messaging
+        .publish_task_completed(&TaskCompletedEvent::new(
+            envelope(),
+            TaskId::new("t1").unwrap(),
+            Specialty::new("triage").unwrap(),
+            Some(AgentId::new("a1").unwrap()),
+            DurationMs::from_millis(250),
+        ))
+        .await
+        .unwrap();
+    messaging
+        .publish_task_failed(
+            &TaskFailedEvent::new(
+                envelope(),
+                TaskId::new("t1").unwrap(),
+                Specialty::new("triage").unwrap(),
+                "validator.timeout",
+                "deadline exceeded",
+            )
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    messaging
+        .publish_deliberation_completed(&DeliberationCompletedEvent::new(
+            envelope(),
+            TaskId::new("t1").unwrap(),
+            Specialty::new("triage").unwrap(),
+            ProposalId::new("p1").unwrap(),
+            Score::new(0.75).unwrap(),
+            3,
+            DurationMs::from_millis(900),
+        ))
+        .await
+        .unwrap();
+    messaging
+        .publish_phase_changed(
+            &PhaseChangedEvent::new(
+                envelope(),
+                TaskId::new("t1").unwrap(),
+                "proposing",
+                "revising",
+            )
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Collect — each subject must yield exactly one message.
+    let got_dispatched = tokio::time::timeout(Duration::from_secs(5), sub_dispatched.next())
+        .await
+        .expect("timed out waiting for task.dispatched")
+        .expect("subscription closed early");
+    let got_completed = tokio::time::timeout(Duration::from_secs(5), sub_completed.next())
+        .await
+        .unwrap()
+        .unwrap();
+    let got_failed = tokio::time::timeout(Duration::from_secs(5), sub_failed.next())
+        .await
+        .unwrap()
+        .unwrap();
+    let got_deliberation = tokio::time::timeout(Duration::from_secs(5), sub_deliberation.next())
+        .await
+        .unwrap()
+        .unwrap();
+    let got_phase = tokio::time::timeout(Duration::from_secs(5), sub_phase.next())
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Verify each payload parses as JSON with flat envelope fields
+    // (AsyncAPI shape) and the correct event-specific fields.
+    for (subject, payload) in [
+        (&subjects.task_dispatched, got_dispatched.payload.clone()),
+        (&subjects.task_completed, got_completed.payload.clone()),
+        (&subjects.task_failed, got_failed.payload.clone()),
+        (
+            &subjects.deliberation_completed,
+            got_deliberation.payload.clone(),
+        ),
+        (&subjects.phase_changed, got_phase.payload.clone()),
+    ] {
+        let v: serde_json::Value =
+            serde_json::from_slice(&payload).unwrap_or_else(|e| panic!("{subject}: {e}"));
+        let obj = v.as_object().unwrap();
+        assert!(
+            obj.contains_key("event_id"),
+            "{subject}: missing event_id at root"
+        );
+        assert!(
+            obj.contains_key("emitted_at"),
+            "{subject}: missing emitted_at at root"
+        );
+        assert!(
+            obj.contains_key("source"),
+            "{subject}: missing source at root"
+        );
+        assert!(
+            !obj.contains_key("envelope"),
+            "{subject}: envelope must be flattened, not nested"
+        );
+    }
+
+    // Sanity checks on event-specific fields.
+    let completed: serde_json::Value = serde_json::from_slice(&got_completed.payload).unwrap();
+    assert_eq!(completed["task_id"], "t1");
+    assert_eq!(completed["specialty"], "triage");
+
+    let failed: serde_json::Value = serde_json::from_slice(&got_failed.payload).unwrap();
+    assert_eq!(failed["error_kind"], "validator.timeout");
+    assert_eq!(failed["error_reason"], "deadline exceeded");
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,9 +8,9 @@ sonar.test.inclusions=crates/**/tests/**/*.rs,crates/**/src/**/tests.rs
 
 # Test-support crates and generated code are excluded from analysis/coverage
 # so Sonar's gate reflects the real production surface.
-sonar.exclusions=target/**,**/Cargo.lock,crates/**/tests/**/*.rs,crates/**/src/**/tests.rs,crates/choreo-proto/src/**
+sonar.exclusions=target/**,**/Cargo.lock,crates/**/tests/**/*.rs,crates/**/src/**/tests.rs,crates/choreo-proto/src/**,crates/choreo-tests-integration/**
 
-sonar.coverage.exclusions=scripts/**,.github/workflows/**,crates/choreo-proto/src/**
+sonar.coverage.exclusions=scripts/**,.github/workflows/**,crates/choreo-proto/src/**,crates/choreo-tests-integration/**
 
 sonar.rust.lcov.reportPaths=target/llvm-cov/lcov.info
 sonar.scm.provider=git


### PR DESCRIPTION
## Summary

Port the event bus to a real transport. The choreographer can now
publish outbound domain events to NATS on the subject tree declared
in the AsyncAPI spec, and consume inbound \`TriggerEvent\`s from
\`choreo.trigger.>\` to drive the application's \`AutoDispatchService\`.

## Core

- \`EventEnvelope\` on the 6 event structs carries \`#[serde(flatten)]\`.
  The wire JSON matches the AsyncAPI \`allOf\` composition (envelope
  fields flat at the root) which is what any consumer expects. Two
  new unit tests lock the shape in.

## NATS adapter (\`choreo-adapters/src/nats/\`)

- **\`NatsConfig\` / \`NatsSubjects\`** — validated config. Subjects
  derived from a single \`publish_prefix\`:
  \`<prefix>.task.dispatched\`, \`.task.completed\`, \`.task.failed\`,
  \`.deliberation.completed\`, \`.phase.changed\`. Control chars,
  over-long prefixes, blank inputs are rejected as \`DomainError\`.
- **\`NatsMessaging\`** implements \`MessagingPort\`; one publish
  method per canonical subject.
- **\`NatsTriggerSubscriber\`** subscribes on the configured
  wildcard, decodes each message as \`TriggerEvent\`, and forwards to
  the injected \`AutoDispatchService\`. Malformed payloads logged and
  dropped (no poison-pill). Runs in a \`tokio::spawn\`ed task whose
  handle the composition root keeps for shutdown.
- \`nats\` is now in the default feature set; the binary picks it up
  out of the box, opt-out for consumers who only want in-memory.

## Integration crate (\`choreo-tests-integration/\`)

Test-only workspace member, not published. Every test is gated by
the \`container-tests\` feature, so \`cargo test --workspace\` stays
network-free.

\`tests/nats_messaging_roundtrip.rs\` spins up a \`nats:2\` container
via testcontainers-rs, publishes every outbound event through
\`NatsMessaging\`, and asserts on a parallel subscriber that:
- the payload lands on the canonical subject,
- the JSON has \`event_id\`/\`emitted_at\`/\`source\` at the root (not
  nested under \`envelope\`),
- event-specific fields (\`error_kind\`, \`task_id\`, \`specialty\`, …)
  are populated per the AsyncAPI contract.

## Honesty & Evidence

- **211 unit tests pass** (128 core + 12 app + 71 adapters).
- \`cargo fmt\` + \`cargo clippy -D warnings\` clean across the
  workspace, including the integration crate with
  \`--features container-tests\`.
- \`scripts/ci/integration-nats.sh\` was soft-failing before (placeholder
  crate). It now executes the real NATS roundtrip against a real
  broker in the \`integration\` CI job.
- \`sonar-project.properties\` excludes the integration crate from
  coverage analysis — it is test-support code by design, not a
  production surface.

## Contract Impact

- [x] AsyncAPI unchanged — Rust structs are what matched the
      contract; the \`serde(flatten)\` brings the JSON shape in line.
- [x] No proto changes.
- [x] No Helm chart changes (chart already exposed \`CHOREO_NATS_*\`
      env vars).

## Architecture Review

- [x] DDD + HEX preserved — adapter consumes \`MessagingPort\` /
      \`AutoDispatchService\`; no core coupling to async-nats.
- [x] Port surface narrow (no \`publish_any\`, one typed method per
      event).
- [x] Errors funneled through \`DomainError\` — no transport-shaped
      leakage upward.
- [x] No provider-specific vocabulary introduced.