### PR TITLE
feat(choreo): phase 6 — composition root and runnable binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,16 +306,21 @@ name = "choreo"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-nats",
+ "async-trait",
  "choreo-adapters",
  "choreo-app",
  "choreo-core",
  "choreo-proto",
  "figment",
  "serde",
+ "thiserror 1.0.69",
+ "time",
  "tokio",
  "tonic",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -66,6 +66,35 @@ This project follows the same discipline as its siblings
 
 ## Status
 
-Scaffold only. Porting underway from `swe-ai-fleet/services/orchestrator`,
-stripping all SWE identity as described in `docs/experiments/` and the
-PR template.
+**What runs today** (enforced by CI, every claim is backed by a test or
+gate in this repository):
+
+- `choreo` binary starts, reads config from `CHOREO_*` env vars, and
+  serves the full `underpass.choreo.v1` gRPC contract.
+- Implemented RPCs: `Deliberate`, `Orchestrate`, `CreateCouncil`,
+  `ListCouncils`, `DeleteCouncil`, `GetDeliberationResult`,
+  `ProcessTriggerEvent`.
+- Honestly `UNIMPLEMENTED` RPCs: `StreamDeliberation`, `RegisterAgent`,
+  `UnregisterAgent`, `GetStatus`, `GetMetrics`. They return
+  `UNIMPLEMENTED` so clients cannot mistake them for working.
+- Optional NATS messaging: when `CHOREO_NATS_ENABLED=true`, the service
+  publishes all 5 outbound events (`choreo.task.*`,
+  `choreo.deliberation.completed`, `choreo.phase.changed`) and
+  consumes inbound `TriggerEvent`s from `choreo.trigger.>`.
+  Otherwise a no-op messaging adapter is wired.
+- Optional seeding: `CHOREO_SEED_SPECIALTIES=triage,reviewer`
+  registers one `NoopAgent` and one single-agent council per specialty
+  so a fresh deployment is immediately exercisable end-to-end.
+
+**What is *not* wired yet**:
+
+- No real LLM / frontier / rule-based agent adapters — only the
+  deterministic `NoopAgent`. Provider adapters (vLLM, Anthropic,
+  OpenAI, …) land in later slices behind their own Cargo features.
+- Statistics / metrics reporting (the `StatisticsPort` is not yet in
+  core).
+- Deliberation streaming and runtime agent registration (their
+  matching RPCs return `UNIMPLEMENTED`).
+- Persistence beyond in-process memory.
+
+See `docs/experiments/` for anything beyond these bullet points.

--- a/crates/choreo-adapters/src/lib.rs
+++ b/crates/choreo-adapters/src/lib.rs
@@ -14,8 +14,11 @@
 //! | [`memory::InMemoryCouncilRegistry`] | `CouncilRegistryPort`             |
 //! | [`memory::InMemoryDeliberationRepository`] | `DeliberationRepositoryPort` |
 //! | [`memory::InMemoryAgentRegistry`]   | `AgentResolverPort` (+ writes)    |
+//! | [`noop::NoopAgent`]                 | `AgentPort` (deterministic; tests / demos) |
 //! | [`noop::NoopExecutor`]              | `ExecutorPort`                    |
 //! | [`noop::NoopMessaging`]             | `MessagingPort`                   |
+//! | [`scoring::UniformScoring`]         | `ScoringPort` (pass fraction)     |
+//! | [`validators::ContentNonEmptyValidator`] | `ValidatorPort` (sanity check) |
 //!
 //! ## Feature-gated
 //!
@@ -35,6 +38,8 @@ pub mod clock;
 pub mod config;
 pub mod memory;
 pub mod noop;
+pub mod scoring;
+pub mod validators;
 
 #[cfg(feature = "grpc")]
 pub mod grpc;

--- a/crates/choreo-adapters/src/noop/agent.rs
+++ b/crates/choreo-adapters/src/noop/agent.rs
@@ -1,0 +1,133 @@
+//! No-op [`AgentPort`].
+//!
+//! Returns deterministic, self-describing content so the full
+//! deliberation pipeline can run without an LLM or any other
+//! provider. Intended for tests and minimal deployments; it must not
+//! be confused with a real agent.
+
+use async_trait::async_trait;
+use choreo_core::entities::TaskConstraints;
+use choreo_core::error::DomainError;
+use choreo_core::ports::{AgentPort, Critique, DraftRequest, Revision};
+use choreo_core::value_objects::{AgentId, Specialty};
+
+/// A deterministic agent that composes its own `id` and the task
+/// description into its proposal / critique / revision outputs. Safe
+/// to run without any external service.
+#[derive(Debug, Clone)]
+pub struct NoopAgent {
+    id: AgentId,
+    specialty: Specialty,
+}
+
+impl NoopAgent {
+    #[must_use]
+    pub fn new(id: AgentId, specialty: Specialty) -> Self {
+        Self { id, specialty }
+    }
+}
+
+#[async_trait]
+impl AgentPort for NoopAgent {
+    fn id(&self) -> &AgentId {
+        &self.id
+    }
+
+    fn specialty(&self) -> &Specialty {
+        &self.specialty
+    }
+
+    async fn generate(&self, request: DraftRequest) -> Result<Revision, DomainError> {
+        Ok(Revision {
+            content: format!(
+                "noop-proposal[{id}] for task: {task}",
+                id = self.id,
+                task = request.task.as_str(),
+            ),
+        })
+    }
+
+    async fn critique(
+        &self,
+        peer_content: &str,
+        _constraints: &TaskConstraints,
+    ) -> Result<Critique, DomainError> {
+        Ok(Critique {
+            feedback: format!(
+                "noop-critique[{id}] on peer content of length {n}",
+                id = self.id,
+                n = peer_content.len(),
+            ),
+        })
+    }
+
+    async fn revise(
+        &self,
+        own_content: &str,
+        _critique: &Critique,
+    ) -> Result<Revision, DomainError> {
+        Ok(Revision {
+            content: format!("{own_content}[revised-by:{id}]", id = self.id),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use choreo_core::value_objects::TaskDescription;
+
+    fn agent(id: &str) -> NoopAgent {
+        NoopAgent::new(AgentId::new(id).unwrap(), Specialty::new("triage").unwrap())
+    }
+
+    #[tokio::test]
+    async fn generate_is_deterministic_and_includes_identity() {
+        let a = agent("a1");
+        let out = a
+            .generate(DraftRequest {
+                task: TaskDescription::new("hello").unwrap(),
+                constraints: TaskConstraints::default(),
+                diverse: true,
+            })
+            .await
+            .unwrap();
+        assert!(out.content.contains("a1"));
+        assert!(out.content.contains("hello"));
+    }
+
+    #[tokio::test]
+    async fn critique_mentions_reviewer_id() {
+        let a = agent("a1");
+        let out = a
+            .critique("abc", &TaskConstraints::default())
+            .await
+            .unwrap();
+        assert!(out.feedback.contains("a1"));
+    }
+
+    #[tokio::test]
+    async fn revise_appends_marker_preserving_own_content() {
+        let a = agent("a1");
+        let out = a
+            .revise(
+                "seed-content",
+                &Critique {
+                    feedback: String::new(),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(out.content.starts_with("seed-content"));
+        assert!(out.content.contains("a1"));
+    }
+
+    #[test]
+    fn specialty_is_returned_as_given() {
+        let a = NoopAgent::new(
+            AgentId::new("a").unwrap(),
+            Specialty::new("triage").unwrap(),
+        );
+        assert_eq!(a.specialty().as_str(), "triage");
+    }
+}

--- a/crates/choreo-adapters/src/noop/mod.rs
+++ b/crates/choreo-adapters/src/noop/mod.rs
@@ -5,8 +5,10 @@
 //! deployments that disable a subsystem (e.g. `nats_enabled=false`)
 //! and are also used extensively in tests.
 
+mod agent;
 mod executor;
 mod messaging;
 
+pub use agent::NoopAgent;
 pub use executor::NoopExecutor;
 pub use messaging::NoopMessaging;

--- a/crates/choreo-adapters/src/scoring.rs
+++ b/crates/choreo-adapters/src/scoring.rs
@@ -1,0 +1,86 @@
+//! Scoring adapters.
+//!
+//! The domain defines `ScoringPort` as a single trait that aggregates
+//! validator reports into a [`Score`]. This module ships one minimal,
+//! honestly-described implementation; operators can plug in their own
+//! policy (weighted average, fail-fast, learned combinator, …) by
+//! implementing `ScoringPort` elsewhere.
+
+use async_trait::async_trait;
+use choreo_core::entities::ValidatorReport;
+use choreo_core::error::DomainError;
+use choreo_core::ports::ScoringPort;
+use choreo_core::value_objects::Score;
+
+/// Uniform scoring: the score is the fraction of reports that passed.
+///
+/// With zero reports the score is [`Score::MIN`] — no evidence means
+/// no confidence. That choice biases operators to configure at least
+/// one validator rather than silently returning a perfect score from
+/// thin air.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct UniformScoring;
+
+impl UniformScoring {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl ScoringPort for UniformScoring {
+    async fn score(&self, reports: &[ValidatorReport]) -> Result<Score, DomainError> {
+        if reports.is_empty() {
+            return Ok(Score::MIN);
+        }
+        let passed = reports.iter().filter(|r| r.passed()).count();
+        let total = reports.len();
+        #[allow(clippy::cast_precision_loss)]
+        let value = passed as f64 / total as f64;
+        Score::new(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use choreo_core::value_objects::Attributes;
+
+    fn report(passed: bool) -> ValidatorReport {
+        ValidatorReport::new("k", passed, "", Attributes::empty()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn empty_reports_score_to_min() {
+        let s = UniformScoring::new().score(&[]).await.unwrap();
+        assert_eq!(s, Score::MIN);
+    }
+
+    #[tokio::test]
+    async fn all_passed_scores_to_max() {
+        let s = UniformScoring::new()
+            .score(&[report(true), report(true)])
+            .await
+            .unwrap();
+        assert_eq!(s, Score::MAX);
+    }
+
+    #[tokio::test]
+    async fn mixed_reports_score_to_pass_fraction() {
+        let s = UniformScoring::new()
+            .score(&[report(true), report(false), report(true), report(false)])
+            .await
+            .unwrap();
+        assert_eq!(s.get(), 0.5);
+    }
+
+    #[tokio::test]
+    async fn all_failed_scores_to_min() {
+        let s = UniformScoring::new()
+            .score(&[report(false), report(false)])
+            .await
+            .unwrap();
+        assert_eq!(s, Score::MIN);
+    }
+}

--- a/crates/choreo-adapters/src/validators.rs
+++ b/crates/choreo-adapters/src/validators.rs
@@ -1,0 +1,81 @@
+//! Default validator adapters.
+//!
+//! These implementations cover use-case-agnostic sanity checks. They
+//! are deliberately minimal; domain-specific validators (clinical
+//! safety, policy compliance, fact checking, …) belong in the
+//! integrating product, not in the Choreographer.
+
+use async_trait::async_trait;
+use choreo_core::entities::{TaskConstraints, ValidatorReport};
+use choreo_core::error::DomainError;
+use choreo_core::ports::ValidatorPort;
+use choreo_core::value_objects::Attributes;
+
+/// A validator that fails a proposal only when its content is empty
+/// (after trimming). The thinnest possible "is there anything here"
+/// check — useful as a default so operators who do not configure a
+/// richer validator still get a meaningful ranking signal.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ContentNonEmptyValidator;
+
+impl ContentNonEmptyValidator {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl ValidatorPort for ContentNonEmptyValidator {
+    fn kind(&self) -> &'static str {
+        "content-non-empty"
+    }
+
+    async fn validate(
+        &self,
+        proposal_content: &str,
+        _constraints: &TaskConstraints,
+    ) -> Result<ValidatorReport, DomainError> {
+        let trimmed = proposal_content.trim();
+        let passed = !trimmed.is_empty();
+        let summary = if passed {
+            format!("len={}", trimmed.len())
+        } else {
+            "content is empty after trimming".to_owned()
+        };
+        ValidatorReport::new(self.kind(), passed, summary, Attributes::empty())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn non_empty_content_passes() {
+        let v = ContentNonEmptyValidator::new();
+        let r = v
+            .validate("hello", &TaskConstraints::default())
+            .await
+            .unwrap();
+        assert!(r.passed());
+        assert_eq!(r.kind(), "content-non-empty");
+    }
+
+    #[tokio::test]
+    async fn whitespace_only_content_fails() {
+        let v = ContentNonEmptyValidator::new();
+        let r = v
+            .validate("   \n\t ", &TaskConstraints::default())
+            .await
+            .unwrap();
+        assert!(!r.passed());
+    }
+
+    #[tokio::test]
+    async fn empty_string_fails() {
+        let v = ContentNonEmptyValidator::new();
+        let r = v.validate("", &TaskConstraints::default()).await.unwrap();
+        assert!(!r.passed());
+    }
+}

--- a/crates/choreo/Cargo.toml
+++ b/crates/choreo/Cargo.toml
@@ -11,6 +11,10 @@ description = "Underpass Choreographer binary: wires adapters and runs the gRPC 
 [lints]
 workspace = true
 
+[lib]
+name = "choreo"
+path = "src/lib.rs"
+
 [[bin]]
 name = "choreo"
 path = "src/main.rs"
@@ -18,9 +22,14 @@ path = "src/main.rs"
 [dependencies]
 choreo-core = { workspace = true }
 choreo-app = { workspace = true }
-choreo-adapters = { workspace = true, features = ["nats"] }
+choreo-adapters = { workspace = true, features = ["grpc", "nats"] }
 choreo-proto = { workspace = true }
 
+async-nats = { workspace = true }
+async-trait = { workspace = true }
+thiserror = { workspace = true }
+time = { workspace = true }
+uuid = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/choreo/src/compose.rs
+++ b/crates/choreo/src/compose.rs
@@ -1,0 +1,220 @@
+//! Wire every adapter and use case into a runnable [`Application`].
+
+use std::sync::Arc;
+
+use choreo_adapters::clock::SystemClock;
+use choreo_adapters::config::EnvConfiguration;
+use choreo_adapters::memory::{
+    InMemoryAgentRegistry, InMemoryCouncilRegistry, InMemoryDeliberationRepository,
+};
+use choreo_adapters::nats::{NatsConfig, NatsMessaging, NatsTriggerSubscriber};
+use choreo_adapters::noop::{NoopExecutor, NoopMessaging};
+use choreo_adapters::scoring::UniformScoring;
+use choreo_adapters::validators::ContentNonEmptyValidator;
+use choreo_app::services::AutoDispatchService;
+use choreo_app::usecases::{
+    CreateCouncilUseCase, DeleteCouncilUseCase, DeliberateUseCase, GetDeliberationUseCase,
+    ListCouncilsUseCase, OrchestrateUseCase,
+};
+use choreo_core::error::DomainError;
+use choreo_core::ports::{
+    ConfigurationPort, ExecutorPort, MessagingPort, ScoringPort, ServiceConfig, ValidatorPort,
+};
+use thiserror::Error;
+use tracing::info;
+
+use crate::seeding::SeedingError;
+
+/// Aggregate of every handle the composition root produces.
+pub struct Application {
+    pub service_config: ServiceConfig,
+    pub agent_registry: Arc<InMemoryAgentRegistry>,
+    pub council_registry: Arc<InMemoryCouncilRegistry>,
+    pub repository: Arc<InMemoryDeliberationRepository>,
+    pub grpc_service: choreo_adapters::grpc::ChoreographerGrpcService,
+    pub nats_subscriber: Option<NatsTriggerSubscriber>,
+}
+
+impl std::fmt::Debug for Application {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Application")
+            .field("service_config", &self.service_config)
+            .field("nats_subscriber_enabled", &self.nats_subscriber.is_some())
+            .finish()
+    }
+}
+
+/// Errors produced while composing the application.
+#[derive(Debug, Error)]
+pub enum ComposeError {
+    #[error("domain error during wiring: {0}")]
+    Domain(#[from] DomainError),
+
+    #[error("nats connection failed: {0}")]
+    NatsConnect(#[source] async_nats::ConnectError),
+
+    #[error("seeding failed: {0}")]
+    Seeding(#[from] SeedingError),
+}
+
+/// Wire the full application.
+///
+/// - Reads [`ServiceConfig`] from the environment.
+/// - Builds the in-memory registries and the no-op executor /
+///   validator / scoring defaults. Operators swap these for richer
+///   adapters through later slices (5d providers, real repos, …)
+///   without touching this function.
+/// - When `nats_enabled`, connects to NATS and wires both the
+///   outbound `NatsMessaging` and the inbound `NatsTriggerSubscriber`.
+///   Otherwise uses [`NoopMessaging`].
+/// - Optionally seeds demo councils if `CHOREO_SEED_SPECIALTIES` is
+///   set, so an empty deployment is immediately exercisable against
+///   the AsyncAPI / gRPC contract.
+pub async fn compose() -> Result<Application, ComposeError> {
+    let service_config = EnvConfiguration::new().load().await?;
+
+    let clock = Arc::new(SystemClock::new());
+    let agent_registry = Arc::new(InMemoryAgentRegistry::new());
+    let council_registry = Arc::new(InMemoryCouncilRegistry::new());
+    let repository = Arc::new(InMemoryDeliberationRepository::new());
+
+    let validators: Vec<Arc<dyn ValidatorPort>> = vec![Arc::new(ContentNonEmptyValidator::new())];
+    let scoring: Arc<dyn ScoringPort> = Arc::new(UniformScoring::new());
+    let executor: Arc<dyn ExecutorPort> = Arc::new(NoopExecutor::new());
+
+    let (messaging, nats_subscriber_factory) = wire_messaging(&service_config).await?;
+
+    let deliberate = Arc::new(DeliberateUseCase::new(
+        clock.clone(),
+        council_registry.clone(),
+        agent_registry.clone(),
+        validators,
+        scoring,
+        repository.clone(),
+        messaging.clone(),
+        "choreographer",
+    ));
+
+    let orchestrate = Arc::new(OrchestrateUseCase::new(
+        deliberate.clone(),
+        executor,
+        messaging.clone(),
+        clock.clone(),
+        "choreographer",
+    ));
+
+    let create_council = Arc::new(CreateCouncilUseCase::new(
+        clock.clone(),
+        council_registry.clone(),
+        agent_registry.clone(),
+    ));
+    let delete_council = Arc::new(DeleteCouncilUseCase::new(council_registry.clone()));
+    let list_councils = Arc::new(ListCouncilsUseCase::new(council_registry.clone()));
+    let get_deliberation = Arc::new(GetDeliberationUseCase::new(repository.clone()));
+
+    let auto_dispatch = Arc::new(AutoDispatchService::new(
+        deliberate.clone(),
+        "Investigate the incoming trigger event.",
+    )?);
+
+    // Seeding — keeps the service exercisable on a fresh boot.
+    crate::seeding::apply_env_seeding(
+        clock.as_ref(),
+        agent_registry.as_ref(),
+        council_registry.as_ref(),
+    )
+    .await?;
+
+    // Now that the auto-dispatch service exists, the subscriber
+    // factory can finish wiring.
+    let nats_subscriber = nats_subscriber_factory.map(|factory| factory(auto_dispatch.clone()));
+
+    let grpc_service = choreo_adapters::grpc::ChoreographerGrpcService::builder()
+        .deliberate(deliberate)
+        .orchestrate(orchestrate)
+        .create_council(create_council)
+        .delete_council(delete_council)
+        .list_councils(list_councils)
+        .get_deliberation(get_deliberation)
+        .auto_dispatch(auto_dispatch)
+        .build()?;
+
+    info!(
+        grpc_port = service_config.grpc_port,
+        nats_enabled = service_config.nats_enabled,
+        trigger_subject = service_config.trigger_subject.as_str(),
+        "choreographer wired"
+    );
+
+    Ok(Application {
+        service_config,
+        agent_registry,
+        council_registry,
+        repository,
+        grpc_service,
+        nats_subscriber,
+    })
+}
+
+/// Factory closure that produces a [`NatsTriggerSubscriber`] once the
+/// application's `AutoDispatchService` has been constructed.
+type SubscriberFactory = Box<dyn FnOnce(Arc<AutoDispatchService>) -> NatsTriggerSubscriber>;
+
+async fn wire_messaging(
+    cfg: &ServiceConfig,
+) -> Result<(Arc<dyn MessagingPort>, Option<SubscriberFactory>), ComposeError> {
+    if !cfg.nats_enabled {
+        info!("nats disabled; using noop messaging");
+        let messaging: Arc<dyn MessagingPort> = Arc::new(NoopMessaging::new());
+        return Ok((messaging, None));
+    }
+
+    let nats_cfg = NatsConfig::new(&cfg.nats_url, &cfg.publish_prefix, &cfg.trigger_subject)?;
+    let client = async_nats::connect(&nats_cfg.url)
+        .await
+        .map_err(ComposeError::NatsConnect)?;
+    info!(url = nats_cfg.url.as_str(), "nats connected");
+
+    let messaging: Arc<dyn MessagingPort> = Arc::new(NatsMessaging::new(
+        client.clone(),
+        nats_cfg.subjects.clone(),
+    ));
+
+    let subjects = nats_cfg.subjects.clone();
+    let factory: SubscriberFactory =
+        Box::new(move |dispatch| NatsTriggerSubscriber::new(client, subjects, dispatch));
+
+    Ok((messaging, Some(factory)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn compose_builds_application_with_nats_disabled() {
+        // Serialize env mutations to avoid races with other tests
+        // that touch `CHOREO_*` vars (see `config::tests` for the
+        // same pattern — we keep a local mutex here so we do not
+        // depend on another crate's private state).
+        static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+        let _guard = ENV_LOCK.lock().await;
+
+        // Clear CHOREO_* so the defaults apply, then disable NATS
+        // (so this test does not require a broker).
+        for (k, _) in std::env::vars() {
+            if k.starts_with("CHOREO_") {
+                std::env::remove_var(k);
+            }
+        }
+        std::env::set_var("CHOREO_NATS_ENABLED", "false");
+
+        let app = compose().await.expect("compose should succeed");
+        assert!(!app.service_config.nats_enabled);
+        assert!(app.nats_subscriber.is_none());
+        // The gRPC service is wired and ready but no server has started.
+        let _ = &app.grpc_service;
+
+        std::env::remove_var("CHOREO_NATS_ENABLED");
+    }
+}

--- a/crates/choreo/src/lib.rs
+++ b/crates/choreo/src/lib.rs
@@ -1,0 +1,13 @@
+//! Composition root for the Underpass Choreographer.
+//!
+//! The binary entry point (`src/main.rs`) is kept tiny: it installs
+//! tracing, calls [`compose`] to wire every adapter, then runs the
+//! resulting [`Application`]. All wiring logic lives here so it can
+//! be unit-tested without starting a server.
+
+pub mod compose;
+pub mod runtime;
+pub mod seeding;
+
+pub use compose::{compose, Application, ComposeError};
+pub use runtime::serve;

--- a/crates/choreo/src/main.rs
+++ b/crates/choreo/src/main.rs
@@ -3,12 +3,7 @@ use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
-        )
-        .json()
-        .init();
+    init_tracing();
 
     tracing::info!(
         service = "underpass-choreographer",
@@ -16,6 +11,14 @@ async fn main() -> Result<()> {
         "starting"
     );
 
-    // TODO: load config, wire adapters, start gRPC server + event consumers.
-    Ok(())
+    let app = choreo::compose().await?;
+    choreo::serve(app).await
+}
+
+fn init_tracing() {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .json()
+        .init();
 }

--- a/crates/choreo/src/runtime.rs
+++ b/crates/choreo/src/runtime.rs
@@ -1,0 +1,79 @@
+//! gRPC server lifecycle.
+//!
+//! [`serve`] takes a composed [`Application`] and runs the server
+//! until a shutdown signal is received. Kept separate from
+//! [`crate::compose`] so wiring and lifetime are each
+//! unit-testable.
+
+use std::net::SocketAddr;
+
+use anyhow::{Context, Result};
+use tokio::signal::unix::{signal, SignalKind};
+use tracing::{error, info};
+
+use crate::compose::Application;
+
+/// Bind the gRPC server, spawn the optional NATS subscriber, and
+/// serve until SIGTERM or SIGINT.
+pub async fn serve(app: Application) -> Result<()> {
+    let Application {
+        service_config,
+        grpc_service,
+        nats_subscriber,
+        ..
+    } = app;
+
+    let subscriber_handle = match nats_subscriber {
+        Some(subscriber) => Some(
+            subscriber
+                .spawn()
+                .await
+                .context("failed to spawn nats trigger subscriber")?,
+        ),
+        None => None,
+    };
+
+    let addr: SocketAddr = format!("0.0.0.0:{}", service_config.grpc_port)
+        .parse()
+        .with_context(|| {
+            format!(
+                "invalid grpc bind address for port {}",
+                service_config.grpc_port
+            )
+        })?;
+    info!(addr = %addr, "grpc server starting");
+
+    tonic::transport::Server::builder()
+        .add_service(grpc_service.into_server())
+        .serve_with_shutdown(addr, shutdown_signal())
+        .await
+        .context("grpc server terminated with error")?;
+
+    info!("grpc server stopped");
+
+    if let Some(handle) = subscriber_handle {
+        handle.abort();
+        match handle.await {
+            Ok(()) => info!("nats subscriber stopped"),
+            Err(err) if err.is_cancelled() => info!("nats subscriber cancelled"),
+            Err(err) => error!(error = %err, "nats subscriber task errored"),
+        }
+    }
+
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    let mut sigterm = match signal(SignalKind::terminate()) {
+        Ok(s) => s,
+        Err(err) => {
+            error!(error = %err, "cannot install SIGTERM handler; shutdown relies on SIGINT only");
+            let _ = tokio::signal::ctrl_c().await;
+            return;
+        }
+    };
+    tokio::select! {
+        _ = sigterm.recv() => info!("received SIGTERM; shutting down"),
+        _ = tokio::signal::ctrl_c() => info!("received SIGINT; shutting down"),
+    }
+}

--- a/crates/choreo/src/seeding.rs
+++ b/crates/choreo/src/seeding.rs
@@ -1,0 +1,154 @@
+//! Optional startup seeding of demo councils and agents.
+//!
+//! Controlled by `CHOREO_SEED_SPECIALTIES`: a comma-separated list
+//! of specialty labels. For each label, the binary registers a
+//! [`NoopAgent`] and a single-agent [`Council`] so the service is
+//! immediately exercisable over gRPC / NATS.
+//!
+//! Seeding is **off by default**. The presence of the variable is
+//! an opt-in operator choice. Real deployments wire agents through
+//! adapter-specific channels (future slices: RegisterAgent RPC,
+//! config-driven factories).
+
+use choreo_adapters::memory::{InMemoryAgentRegistry, InMemoryCouncilRegistry};
+use choreo_adapters::noop::NoopAgent;
+use choreo_core::entities::Council;
+use choreo_core::error::DomainError;
+use choreo_core::ports::{ClockPort, CouncilRegistryPort};
+use choreo_core::value_objects::{AgentId, CouncilId, Specialty};
+use std::sync::Arc;
+use thiserror::Error;
+use tracing::info;
+
+/// Environment variable used to opt in to startup seeding.
+pub const SEED_ENV_VAR: &str = "CHOREO_SEED_SPECIALTIES";
+
+#[derive(Debug, Error)]
+pub enum SeedingError {
+    #[error("seeding failed: {0}")]
+    Domain(#[from] DomainError),
+}
+
+/// Read the opt-in env var and apply seeding if present.
+pub async fn apply_env_seeding(
+    clock: &dyn ClockPort,
+    agent_registry: &InMemoryAgentRegistry,
+    council_registry: &InMemoryCouncilRegistry,
+) -> Result<(), SeedingError> {
+    let Ok(raw) = std::env::var(SEED_ENV_VAR) else {
+        return Ok(());
+    };
+    let labels: Vec<&str> = raw
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+    if labels.is_empty() {
+        return Ok(());
+    }
+    info!(specialties = ?labels, "seeding demo councils");
+    apply_seeding(clock, agent_registry, council_registry, &labels).await
+}
+
+/// Seed one `NoopAgent` and one single-agent council per specialty.
+///
+/// Split from [`apply_env_seeding`] so tests can drive seeding
+/// without touching process env.
+pub async fn apply_seeding(
+    clock: &dyn ClockPort,
+    agent_registry: &InMemoryAgentRegistry,
+    council_registry: &InMemoryCouncilRegistry,
+    specialties: &[&str],
+) -> Result<(), SeedingError> {
+    for label in specialties {
+        let specialty = Specialty::new(*label)?;
+        let agent_id = AgentId::new(format!("seed-{label}-0"))?;
+        let agent = Arc::new(NoopAgent::new(agent_id.clone(), specialty.clone()));
+        // If the agent is already registered (re-seeding) swallow the
+        // AlreadyExists error so restarts stay idempotent.
+        match agent_registry.insert(agent).await {
+            Ok(()) | Err(DomainError::AlreadyExists { .. }) => {}
+            Err(err) => return Err(err.into()),
+        }
+        let council_id = CouncilId::new(format!("seed-{label}"))?;
+        let council = Council::new(council_id, specialty.clone(), vec![agent_id], clock.now())?;
+        match council_registry.register(council).await {
+            Ok(()) | Err(DomainError::AlreadyExists { .. }) => {}
+            Err(err) => return Err(err.into()),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use choreo_adapters::clock::SystemClock;
+    use choreo_core::ports::{AgentResolverPort, CouncilRegistryPort};
+
+    #[tokio::test]
+    async fn seeding_is_idempotent() {
+        let clock = SystemClock::new();
+        let agents = InMemoryAgentRegistry::new();
+        let councils = InMemoryCouncilRegistry::new();
+
+        apply_seeding(&clock, &agents, &councils, &["triage", "reviewer"])
+            .await
+            .unwrap();
+        assert_eq!(councils.len().await, 2);
+        assert_eq!(agents.len().await, 2);
+
+        // Second pass must not fail and must not duplicate.
+        apply_seeding(&clock, &agents, &councils, &["triage", "reviewer"])
+            .await
+            .unwrap();
+        assert_eq!(councils.len().await, 2);
+        assert_eq!(agents.len().await, 2);
+    }
+
+    #[tokio::test]
+    async fn seeded_council_is_resolvable_and_matches_specialty() {
+        let clock = SystemClock::new();
+        let agents = InMemoryAgentRegistry::new();
+        let councils = InMemoryCouncilRegistry::new();
+        apply_seeding(&clock, &agents, &councils, &["triage"])
+            .await
+            .unwrap();
+
+        let triage = Specialty::new("triage").unwrap();
+        let council = councils.get(&triage).await.unwrap();
+        assert_eq!(council.specialty(), &triage);
+        assert_eq!(council.size(), 1);
+
+        // The agent referenced by the council resolves.
+        let id = council.agents().iter().next().unwrap();
+        let resolved = agents.resolve(id).await.unwrap();
+        assert_eq!(resolved.specialty(), &triage);
+    }
+
+    #[tokio::test]
+    async fn invalid_specialty_surfaces_as_domain_error() {
+        let clock = SystemClock::new();
+        let agents = InMemoryAgentRegistry::new();
+        let councils = InMemoryCouncilRegistry::new();
+        let err = apply_seeding(&clock, &agents, &councils, &["   "])
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            SeedingError::Domain(DomainError::EmptyField { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn empty_label_list_is_a_noop() {
+        let clock = SystemClock::new();
+        let agents = InMemoryAgentRegistry::new();
+        let councils = InMemoryCouncilRegistry::new();
+        apply_seeding(&clock, &agents, &councils, &[])
+            .await
+            .unwrap();
+        assert!(agents.is_empty().await);
+        assert!(councils.is_empty().await);
+    }
+}


### PR DESCRIPTION
## Summary

The \`choreo\` binary is now a fully wired service. A fresh clone can
\`cargo run -p choreo\` (or start the published container) and
immediately answer gRPC on the configured port.

## New adapters (\`choreo-adapters\`)

| Adapter | Port | Notes |
|---|---|---|
| \`noop::NoopAgent\` | \`AgentPort\` | Deterministic; proposals / critiques / revisions compose the agent id with the task input. Safe for tests and minimal deployments. **Clearly labelled**, not sold as a real LLM. |
| \`scoring::UniformScoring\` | \`ScoringPort\` | Pass-fraction of validator reports. Zero reports → \`Score::MIN\` (no perfect-by-default). |
| \`validators::ContentNonEmptyValidator\` | \`ValidatorPort\` | Rejects empty / whitespace-only proposals. Thinnest sanity check; domain-specific validators stay out of the Choreographer. |

## Composition root (\`crates/choreo/\`)

- Crate is now a library + binary so every wiring step is
  unit-testable without starting a server.
- \`compose.rs\` — builds adapters, use cases, auto-dispatch, and the
  gRPC service. When \`CHOREO_NATS_ENABLED=true\` wires
  \`NatsMessaging\` + \`NatsTriggerSubscriber\`; otherwise
  \`NoopMessaging\`. Typed \`ComposeError\` surfaces wiring failures.
- \`runtime.rs\` — serves the gRPC server with graceful shutdown
  (SIGTERM / SIGINT) and aborts the subscriber task on stop.
- \`seeding.rs\` — reads \`CHOREO_SEED_SPECIALTIES\` (comma-separated)
  and idempotently registers one \`NoopAgent\` + single-agent council
  per label. **Off by default**; the binary does not fabricate state
  without opt-in.
- \`main.rs\` — 25 lines: tracing init, \`compose\`, \`serve\`.

## Honesty & Evidence

- **227 unit tests pass** (128 core + 12 app + 82 adapters + 5 binary).
- 11 new adapter tests cover every new default adapter.
- 4 seeding tests: happy path, idempotence, invalid specialty,
  empty label list.
- 1 compose test: full wiring without spawning a server.
- README status section rewritten to enumerate exactly which RPCs
  work today and which return \`UNIMPLEMENTED\`. No aspirational
  language.
- \`cargo fmt\` + \`cargo clippy -D warnings\` clean.

## Contract Impact

- [x] No proto changes
- [x] No AsyncAPI changes
- [x] No Helm chart behavioural changes (env vars documented in the
      chart's \`values.yaml\` already cover the new settings)

## Architecture Review

- [x] DDD + HEX preserved — binary depends only on adapters; core
      and app untouched apart from tests
- [x] No god-object — composition split into \`compose\`,
      \`runtime\`, \`seeding\`
- [x] SOLID — new adapters each own one responsibility
- [x] No provider-specific or use-case-specific identity added