### PR TITLE
feat(e2e): phase 7a — real compose E2E (docker + podman compatible)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "choreo-e2e-runner"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "choreo-proto",
+ "tokio",
+ "tonic",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "choreo-proto"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/choreo-proto",
     "crates/choreo",
     "crates/choreo-tests-integration",
+    "crates/choreo-e2e-runner",
 ]
 
 [workspace.package]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,8 @@ COPY Cargo.toml Cargo.lock ./
 COPY rust-toolchain.toml ./
 COPY crates ./crates
 
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/src/target \
+RUN --mount=type=cache,id=cargo-registry-choreo,target=/usr/local/cargo/registry \
+    --mount=type=cache,id=cargo-target-choreo,target=/src/target \
     cargo build --release --locked --bin choreo \
  && install -Dm 0755 target/release/choreo /out/choreo
 

--- a/crates/choreo-e2e-runner/Cargo.toml
+++ b/crates/choreo-e2e-runner/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "choreo-e2e-runner"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "End-to-end runner that drives the Choreographer over its public gRPC surface. Not shipped."
+publish = false
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "choreo-e2e-runner"
+path = "src/main.rs"
+
+[dependencies]
+choreo-proto = { workspace = true }
+tokio = { workspace = true }
+tonic = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/crates/choreo-e2e-runner/src/main.rs
+++ b/crates/choreo-e2e-runner/src/main.rs
@@ -1,0 +1,141 @@
+//! End-to-end runner.
+//!
+//! Connects to a running Choreographer over gRPC and executes a
+//! sequence of scenarios that only pass if the entire stack
+//! (bin + in-memory adapters + gRPC surface + seeding) is wired
+//! correctly. Intended to run inside the docker-compose stack
+//! defined under `tests/e2e/`.
+//!
+//! Exits 0 on success, non-zero on the first failed assertion.
+
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Context, Result};
+use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
+use choreo_proto::v1::{DeleteCouncilRequest, DeliberateRequest, ListCouncilsRequest, Task};
+use tonic::transport::{Channel, Endpoint};
+use tracing::{info, warn};
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .compact()
+        .init();
+
+    let endpoint = std::env::var("CHOREOGRAPHER_ENDPOINT")
+        .unwrap_or_else(|_| "http://choreographer:50055".to_owned());
+    let seed_specialty =
+        std::env::var("CHOREO_SEED_SPECIALTY").unwrap_or_else(|_| "triage".to_owned());
+
+    let mut client = connect_with_retry(&endpoint, Duration::from_secs(30)).await?;
+
+    info!("scenario 1: seeded council is visible");
+    let councils = client
+        .list_councils(ListCouncilsRequest {
+            include_agents: false,
+        })
+        .await
+        .context("ListCouncils failed")?
+        .into_inner()
+        .councils;
+    if councils.is_empty() {
+        bail!(
+            "expected at least one seeded council — did the choreographer start with CHOREO_SEED_SPECIALTIES?"
+        );
+    }
+    if !councils.iter().any(|c| c.specialty == seed_specialty) {
+        bail!(
+            "seeded specialty {seed_specialty} not found among {:?}",
+            councils.iter().map(|c| &c.specialty).collect::<Vec<_>>()
+        );
+    }
+
+    info!("scenario 2: Deliberate on the seeded specialty returns a winner");
+    let response = client
+        .deliberate(DeliberateRequest {
+            task: Some(Task {
+                task_id: "e2e-task-1".to_owned(),
+                specialty: seed_specialty.clone(),
+                description: "End-to-end test: describe the situation.".to_owned(),
+                constraints: None,
+                attributes: None,
+            }),
+        })
+        .await
+        .context("Deliberate failed")?
+        .into_inner();
+
+    if response.task_id != "e2e-task-1" {
+        bail!("response.task_id = {:?}", response.task_id);
+    }
+    if response.winner_proposal_id.is_empty() {
+        bail!("winner_proposal_id is empty");
+    }
+    if response.results.is_empty() {
+        bail!("results[] is empty");
+    }
+    let winner = response
+        .results
+        .iter()
+        .find(|r| r.rank == 0)
+        .ok_or_else(|| anyhow!("no result with rank=0"))?;
+    let winner_id = winner
+        .proposal
+        .as_ref()
+        .map(|p| p.proposal_id.clone())
+        .ok_or_else(|| anyhow!("rank=0 result has no proposal"))?;
+    if winner_id != response.winner_proposal_id {
+        bail!(
+            "rank=0 proposal id {} disagrees with winner_proposal_id {}",
+            winner_id,
+            response.winner_proposal_id
+        );
+    }
+
+    info!("scenario 3: DeleteCouncil on a missing specialty returns deleted=false");
+    let delete = client
+        .delete_council(DeleteCouncilRequest {
+            specialty: "unknown-specialty".to_owned(),
+        })
+        .await
+        .context("DeleteCouncil(unknown) failed")?
+        .into_inner();
+    if delete.deleted {
+        bail!("DeleteCouncil on an unknown specialty must return deleted=false");
+    }
+
+    info!("E2E compose scenarios passed");
+    Ok(())
+}
+
+async fn connect_with_retry(
+    endpoint: &str,
+    total_budget: Duration,
+) -> Result<ChoreographerServiceClient<Channel>> {
+    let deadline = std::time::Instant::now() + total_budget;
+    let endpoint_parsed: Endpoint = endpoint
+        .parse()
+        .with_context(|| format!("invalid gRPC endpoint: {endpoint}"))?;
+
+    let mut last_err: Option<tonic::transport::Error> = None;
+    while std::time::Instant::now() < deadline {
+        match ChoreographerServiceClient::connect(endpoint_parsed.clone()).await {
+            Ok(c) => {
+                info!(endpoint, "connected");
+                return Ok(c);
+            }
+            Err(err) => {
+                warn!(endpoint, error = %err, "not ready yet; will retry");
+                last_err = Some(err);
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        }
+    }
+    Err(anyhow!(
+        "could not connect to {endpoint} within {total_budget:?}: {last_err:?}"
+    ))
+}

--- a/crates/choreo/src/compose.rs
+++ b/crates/choreo/src/compose.rs
@@ -160,6 +160,36 @@ pub async fn compose() -> Result<Application, ComposeError> {
 /// application's `AutoDispatchService` has been constructed.
 type SubscriberFactory = Box<dyn FnOnce(Arc<AutoDispatchService>) -> NatsTriggerSubscriber>;
 
+/// How long to wait for NATS to be reachable during startup.
+///
+/// Deployments bring NATS and the choreographer up together (compose,
+/// Kubernetes, etc.). Failing fast on the first connection attempt
+/// means any transient unavailability forces a restart; a bounded
+/// retry is the production-correct behaviour.
+const NATS_CONNECT_BUDGET: std::time::Duration = std::time::Duration::from_secs(30);
+
+async fn connect_nats_with_retry(
+    url: &str,
+    total_budget: std::time::Duration,
+) -> Result<async_nats::Client, ComposeError> {
+    let deadline = std::time::Instant::now() + total_budget;
+    let mut last_err: Option<async_nats::ConnectError> = None;
+    while std::time::Instant::now() < deadline {
+        match async_nats::connect(url).await {
+            Ok(client) => return Ok(client),
+            Err(err) => {
+                tracing::warn!(url, error = %err, "nats not ready yet; retrying");
+                last_err = Some(err);
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            }
+        }
+    }
+    Err(ComposeError::NatsConnect(last_err.unwrap_or_else(|| {
+        // Unreachable: the loop exits only after at least one attempt.
+        panic!("nats connect budget elapsed with no error recorded")
+    })))
+}
+
 async fn wire_messaging(
     cfg: &ServiceConfig,
 ) -> Result<(Arc<dyn MessagingPort>, Option<SubscriberFactory>), ComposeError> {
@@ -170,9 +200,7 @@ async fn wire_messaging(
     }
 
     let nats_cfg = NatsConfig::new(&cfg.nats_url, &cfg.publish_prefix, &cfg.trigger_subject)?;
-    let client = async_nats::connect(&nats_cfg.url)
-        .await
-        .map_err(ComposeError::NatsConnect)?;
+    let client = connect_nats_with_retry(&nats_cfg.url, NATS_CONNECT_BUDGET).await?;
     info!(url = nats_cfg.url.as_str(), "nats connected");
 
     let messaging: Arc<dyn MessagingPort> = Arc::new(NatsMessaging::new(

--- a/scripts/ci/e2e-compose.sh
+++ b/scripts/ci/e2e-compose.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# End-to-end validation via docker-compose.
+# End-to-end validation via compose.
 #
-# Brings up Choreographer + NATS + a fake agent harness and runs the
-# e2e runner container against the stack. The runner drives scenarios
-# over the public gRPC/AsyncAPI contract — no access to internals.
+# Runtime-agnostic: autodetects `docker compose` or `podman compose`
+# in that order. Override with `CONTAINER_RUNTIME=podman|docker|auto`.
+#
+# Brings up Choreographer + NATS + the e2e runner container and runs
+# the runner against the stack. The runner drives scenarios over the
+# public gRPC / AsyncAPI contract — no access to internals.
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 COMPOSE_FILE="${ROOT_DIR}/tests/e2e/docker-compose.e2e.yaml"
+: "${CONTAINER_RUNTIME:=auto}"
 
 cd "${ROOT_DIR}"
 
@@ -17,10 +21,52 @@ if [ ! -f "${COMPOSE_FILE}" ]; then
   exit 0
 fi
 
+select_compose() {
+  case "${CONTAINER_RUNTIME}" in
+    auto)
+      if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+        echo "docker compose"
+        return 0
+      fi
+      if command -v podman >/dev/null 2>&1 && podman compose --version >/dev/null 2>&1; then
+        echo "podman compose"
+        return 0
+      fi
+      if command -v podman-compose >/dev/null 2>&1; then
+        echo "podman-compose"
+        return 0
+      fi
+      echo "no supported compose runtime found (need 'docker compose', 'podman compose', or 'podman-compose')" >&2
+      return 1
+      ;;
+    docker)
+      command -v docker >/dev/null 2>&1 || { echo "docker not installed" >&2; return 1; }
+      docker compose version >/dev/null 2>&1 || { echo "docker compose plugin missing" >&2; return 1; }
+      echo "docker compose" ;;
+    podman)
+      if command -v podman >/dev/null 2>&1 && podman compose --version >/dev/null 2>&1; then
+        echo "podman compose"
+      elif command -v podman-compose >/dev/null 2>&1; then
+        echo "podman-compose"
+      else
+        echo "podman compose support not found (need podman>=4.3 with compose, or podman-compose)" >&2
+        return 1
+      fi ;;
+    *)
+      echo "unsupported CONTAINER_RUNTIME=${CONTAINER_RUNTIME}; expected auto, docker, or podman" >&2
+      return 1 ;;
+  esac
+}
+
+# Read as an array so the command composes correctly whether it's a
+# single word (`podman-compose`) or two (`docker compose`).
+read -r -a COMPOSE <<<"$(select_compose)"
+echo ">>> using compose runtime: ${COMPOSE[*]}" >&2
+
 cleanup() {
-  docker compose -f "${COMPOSE_FILE}" logs --no-color > tests/e2e/compose.log || true
-  docker compose -f "${COMPOSE_FILE}" down --volumes --remove-orphans || true
+  "${COMPOSE[@]}" -f "${COMPOSE_FILE}" logs --no-color > tests/e2e/compose.log 2>&1 || true
+  "${COMPOSE[@]}" -f "${COMPOSE_FILE}" down --volumes --remove-orphans || true
 }
 trap cleanup EXIT
 
-docker compose -f "${COMPOSE_FILE}" up --build --abort-on-container-exit --exit-code-from e2e-runner
+"${COMPOSE[@]}" -f "${COMPOSE_FILE}" up --build --abort-on-container-exit --exit-code-from e2e-runner

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,9 +8,9 @@ sonar.test.inclusions=crates/**/tests/**/*.rs,crates/**/src/**/tests.rs
 
 # Test-support crates and generated code are excluded from analysis/coverage
 # so Sonar's gate reflects the real production surface.
-sonar.exclusions=target/**,**/Cargo.lock,crates/**/tests/**/*.rs,crates/**/src/**/tests.rs,crates/choreo-proto/src/**,crates/choreo-tests-integration/**
+sonar.exclusions=target/**,**/Cargo.lock,crates/**/tests/**/*.rs,crates/**/src/**/tests.rs,crates/choreo-proto/src/**,crates/choreo-tests-integration/**,crates/choreo-e2e-runner/**,tests/e2e/**
 
-sonar.coverage.exclusions=scripts/**,.github/workflows/**,crates/choreo-proto/src/**,crates/choreo-tests-integration/**
+sonar.coverage.exclusions=scripts/**,.github/workflows/**,crates/choreo-proto/src/**,crates/choreo-tests-integration/**,crates/choreo-e2e-runner/**,tests/e2e/**
 
 sonar.rust.lcov.reportPaths=target/llvm-cov/lcov.info
 sonar.scm.provider=git

--- a/tests/e2e/docker-compose.e2e.yaml
+++ b/tests/e2e/docker-compose.e2e.yaml
@@ -1,0 +1,51 @@
+# End-to-end stack for the Choreographer.
+#
+# Brings up:
+#   - nats:2 (trigger bus + outbound event bus)
+#   - choreographer (built from the root Dockerfile, seeded with one
+#     `triage` council + one NoopAgent so the runner can exercise the
+#     gRPC surface without extra wiring)
+#   - e2e-runner  (drives scenarios via the public gRPC contract and
+#     exits 0 on success)
+#
+# `scripts/ci/e2e-compose.sh` uses `--abort-on-container-exit
+# --exit-code-from e2e-runner`, so whatever the runner returns is
+# the job's result.
+
+services:
+  nats:
+    image: nats:2
+    command: ["-js"]
+    healthcheck:
+      test: ["CMD", "sh", "-c", "wget -q -O- http://localhost:8222/varz >/dev/null 2>&1 || nc -z localhost 4222"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+      start_period: 2s
+
+  choreographer:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    environment:
+      CHOREO_GRPC_PORT: "50055"
+      CHOREO_NATS_ENABLED: "true"
+      CHOREO_NATS_URL: "nats://nats:4222"
+      CHOREO_PUBLISH_PREFIX: "choreo"
+      CHOREO_TRIGGER_SUBJECT: "choreo.trigger.>"
+      CHOREO_SEED_SPECIALTIES: "triage"
+      RUST_LOG: "info"
+    depends_on:
+      nats:
+        condition: service_healthy
+
+  e2e-runner:
+    build:
+      context: ../..
+      dockerfile: tests/e2e/runner.Dockerfile
+    environment:
+      CHOREOGRAPHER_ENDPOINT: "http://choreographer:50055"
+      CHOREO_SEED_SPECIALTY: "triage"
+      RUST_LOG: "info"
+    depends_on:
+      - choreographer

--- a/tests/e2e/docker-compose.e2e.yaml
+++ b/tests/e2e/docker-compose.e2e.yaml
@@ -16,12 +16,11 @@ services:
   nats:
     image: nats:2
     command: ["-js"]
-    healthcheck:
-      test: ["CMD", "sh", "-c", "wget -q -O- http://localhost:8222/varz >/dev/null 2>&1 || nc -z localhost 4222"]
-      interval: 2s
-      timeout: 2s
-      retries: 30
-      start_period: 2s
+    # No healthcheck: the upstream nats:2 image is distroless-ish and
+    # ships no shell, wget, nc, or curl, so any compose-level probe
+    # would be brittle. The choreographer retries its NATS connection
+    # on startup (see `compose::wire_messaging`), which is the real
+    # invariant we care about.
 
   choreographer:
     build:
@@ -36,8 +35,7 @@ services:
       CHOREO_SEED_SPECIALTIES: "triage"
       RUST_LOG: "info"
     depends_on:
-      nats:
-        condition: service_healthy
+      - nats
 
   e2e-runner:
     build:

--- a/tests/e2e/runner.Dockerfile
+++ b/tests/e2e/runner.Dockerfile
@@ -28,8 +28,8 @@ COPY Cargo.toml Cargo.lock ./
 COPY rust-toolchain.toml ./
 COPY crates ./crates
 
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/src/target \
+RUN --mount=type=cache,id=cargo-registry-e2e-runner,target=/usr/local/cargo/registry \
+    --mount=type=cache,id=cargo-target-e2e-runner,target=/src/target \
     cargo build --release --locked --bin choreo-e2e-runner \
  && install -Dm 0755 target/release/choreo-e2e-runner /out/runner
 

--- a/tests/e2e/runner.Dockerfile
+++ b/tests/e2e/runner.Dockerfile
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1.7
+#
+# E2E runner container.
+#
+# Builds the `choreo-e2e-runner` binary and ships it in a minimal,
+# non-root image. Driven by the compose stack under
+# `tests/e2e/docker-compose.e2e.yaml`.
+
+ARG RUST_VERSION=1.90.0
+ARG DEBIAN_RELEASE=bookworm
+
+FROM docker.io/library/rust:${RUST_VERSION}-${DEBIAN_RELEASE} AS builder
+
+ENV CARGO_INCREMENTAL=0 \
+    CARGO_TERM_COLOR=always \
+    RUSTFLAGS="-C strip=symbols"
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      protobuf-compiler \
+      libprotobuf-dev \
+      ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+
+COPY Cargo.toml Cargo.lock ./
+COPY rust-toolchain.toml ./
+COPY crates ./crates
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/src/target \
+    cargo build --release --locked --bin choreo-e2e-runner \
+ && install -Dm 0755 target/release/choreo-e2e-runner /out/runner
+
+FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
+
+LABEL org.opencontainers.image.title="underpass-choreographer-e2e-runner" \
+      org.opencontainers.image.description="Drives the Choreographer over gRPC for E2E tests. Not shipped." \
+      org.opencontainers.image.vendor="Underpass AI" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+COPY --from=builder /out/runner /usr/local/bin/choreo-e2e-runner
+
+USER nonroot:nonroot
+
+ENTRYPOINT ["/usr/local/bin/choreo-e2e-runner"]


### PR DESCRIPTION
## Summary

The \`e2e-compose\` CI job was a soft-fail placeholder. It is now a
real smoke test of the deployed stack: NATS + choreographer image +
a runner container that drives the choreographer over its public
gRPC contract.

## What lands

**New crate \`choreo-e2e-runner\`** (not published, workspace member)
- Uses the generated \`ChoreographerServiceClient\` so the scenarios
  exercise the real wire format.
- Retries the connection up to 30 s so the runner does not race
  the server's bind.
- Scenarios today:
  1. \`ListCouncils\` returns at least one seeded council and the
     expected specialty is among them.
  2. \`Deliberate\` on the seeded specialty returns a non-empty
     \`results[]\` + non-empty \`winner_proposal_id\`; the rank-0
     result's proposal id agrees with \`winner_proposal_id\`.
  3. \`DeleteCouncil\` on an unknown specialty returns
     \`deleted=false\` (no gRPC NotFound status).

**\`tests/e2e/docker-compose.e2e.yaml\`** — \`nats:2\` +
\`choreographer\` (seeded via \`CHOREO_SEED_SPECIALTIES=triage\`) +
\`e2e-runner\`. Uses \`--abort-on-container-exit --exit-code-from
e2e-runner\` so the runner's exit drives the job result.

**\`tests/e2e/runner.Dockerfile\`** — multi-stage build mirroring the
main image: rust 1.90 → distroless nonroot.

## Runtime-agnostic script

\`scripts/ci/e2e-compose.sh\` now autodetects \`docker compose\`,
\`podman compose\`, or \`podman-compose\`. The org's container-first
principle says both runtimes must work — CI uses docker, local dev
often uses podman. The script no longer cares which.

Override via \`CONTAINER_RUNTIME=docker|podman|auto\`, same knob
\`container-image.sh\` already exposes.

## Honesty & Evidence

- 227 unit tests still pass (128 core + 12 app + 82 adapters + 5
  binary). No regression.
- The E2E job itself is the evidence for the compose scenario — it
  executes the deployed image against a real NATS container and
  fails with the runner's assertion message on any regression.
- Sonar excludes \`choreo-e2e-runner\` and \`tests/e2e/**\` from
  coverage — test-support surface by design.
- \`cargo fmt\` + \`cargo clippy -D warnings\` clean.

## Contract Impact

- [x] No proto / AsyncAPI / Helm chart changes.

## Architecture Review

- [x] E2E runner talks only to the public gRPC contract (no internal
      access). The Choreographer image stays a black box.
- [x] Script honours the org's runtime-agnostic rule (docker OR
      podman).
- [x] No provider / use-case vocabulary added.