### PR TITLE
feat(e2e): phase 7b — real Kubernetes Job E2E + chart env-var fix

### DIFF
--- a/charts/choreographer/templates/deployment.yaml
+++ b/charts/choreographer/templates/deployment.yaml
@@ -39,22 +39,26 @@ spec:
               containerPort: {{ .Values.config.grpcPort }}
               protocol: TCP
           env:
-            - name: GRPC_PORT
+            - name: CHOREO_GRPC_PORT
               value: {{ .Values.config.grpcPort | quote }}
             - name: RUST_LOG
               value: {{ .Values.config.logLevel | quote }}
             {{- if .Values.messaging.nats.enabled }}
-            - name: ENABLE_NATS
+            - name: CHOREO_NATS_ENABLED
               value: "true"
-            - name: NATS_URL
+            - name: CHOREO_NATS_URL
               value: {{ .Values.messaging.nats.url | quote }}
             - name: CHOREO_TRIGGER_SUBJECT
               value: {{ .Values.messaging.nats.triggerSubject | quote }}
             - name: CHOREO_PUBLISH_PREFIX
               value: {{ .Values.messaging.nats.publishPrefix | quote }}
             {{- else }}
-            - name: ENABLE_NATS
+            - name: CHOREO_NATS_ENABLED
               value: "false"
+            {{- end }}
+            {{- if .Values.config.seedSpecialties }}
+            - name: CHOREO_SEED_SPECIALTIES
+              value: {{ .Values.config.seedSpecialties | quote }}
             {{- end }}
           {{- if .Values.probes.liveness.enabled }}
           livenessProbe:

--- a/charts/choreographer/values.yaml
+++ b/charts/choreographer/values.yaml
@@ -74,6 +74,12 @@ affinity: {}
 config:
   grpcPort: 50055
   logLevel: info
+  # Optional startup seeding. Comma-separated list of specialty
+  # labels: for each one the binary registers a deterministic
+  # `NoopAgent` and a single-agent council, so the service is
+  # immediately exercisable end-to-end. Off by default — real
+  # deployments register agents through other channels.
+  seedSpecialties: ""
 
 messaging:
   nats:

--- a/scripts/ci/container-image.sh
+++ b/scripts/ci/container-image.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 IMAGE_TAG="${1:-underpass-choreographer:ci}"
+DOCKERFILE="${2:-Dockerfile}"
 : "${CONTAINER_RUNTIME:=auto}"
 
 select_container_cli() {
@@ -36,9 +37,9 @@ if [[ "${CONTAINER_CLI}" == "podman" ]]; then
   mkdir -p "${XDG_RUNTIME_DIR}"
 fi
 
-echo "building container image with ${CONTAINER_CLI}" >&2
+echo "building ${IMAGE_TAG} with ${CONTAINER_CLI} from ${DOCKERFILE}" >&2
 
 "${CONTAINER_CLI}" build \
-  --file Dockerfile \
+  --file "${DOCKERFILE}" \
   --tag "${IMAGE_TAG}" \
   "${ROOT_DIR}"

--- a/scripts/ci/e2e-kubernetes.sh
+++ b/scripts/ci/e2e-kubernetes.sh
@@ -1,47 +1,96 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# End-to-end validation on Kubernetes.
+# End-to-end validation against a real Kubernetes cluster (kind).
 #
-# 1. Builds the Choreographer container image and loads it into kind.
-# 2. Installs the Helm chart with dev values.
-# 3. Submits an E2E runner Kubernetes Job that drives the scenarios
-#    over the public gRPC/AsyncAPI contract and writes a report.
-# 4. Streams Job logs and fails the script if the Job does not succeed.
+# Flow:
+#   1. Build the Choreographer image and the E2E runner image, and
+#      load both into the kind node.
+#   2. Deploy a tiny NATS (Deployment + Service).
+#   3. `helm install` the Choreographer chart pointed at the local
+#      images, with seeding enabled so `ListCouncils` returns a
+#      non-empty set.
+#   4. Submit the E2E runner as a Kubernetes Job; its exit code
+#      decides the CI result.
+#
+# Any step that fails dumps diagnostics (pod logs, kubectl describe)
+# before bailing so CI is debuggable without re-running.
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CHART_PATH="${ROOT_DIR}/charts/choreographer"
+NATS_MANIFEST="${ROOT_DIR}/tests/e2e/kubernetes/nats.yaml"
 JOB_MANIFEST="${ROOT_DIR}/tests/e2e/kubernetes/runner-job.yaml"
-IMAGE="underpass-choreographer:e2e"
+CHOREO_IMAGE="underpass-choreographer:e2e"
+RUNNER_IMAGE="underpass-choreographer-e2e-runner:e2e"
+CLUSTER_NAME="${KIND_CLUSTER_NAME:-choreographer-e2e}"
 
 cd "${ROOT_DIR}"
 
-if [ ! -f "${JOB_MANIFEST}" ]; then
-  echo "::warning::${JOB_MANIFEST} not present yet; E2E placeholder"
+if [ ! -f "${JOB_MANIFEST}" ] || [ ! -f "${NATS_MANIFEST}" ]; then
+  echo "::warning::${JOB_MANIFEST} or ${NATS_MANIFEST} not present yet; E2E placeholder"
   exit 0
 fi
 
-echo ">>> building image"
-bash scripts/ci/container-image.sh "${IMAGE}"
+on_error() {
+  echo "::group::kubectl get all"
+  kubectl get all -A || true
+  echo "::endgroup::"
+  echo "::group::kubectl describe job"
+  kubectl describe job choreographer-e2e-runner || true
+  echo "::endgroup::"
+  echo "::group::runner logs"
+  kubectl logs job/choreographer-e2e-runner --tail=500 || true
+  echo "::endgroup::"
+  echo "::group::choreographer logs"
+  kubectl logs -l app.kubernetes.io/name=choreographer --tail=500 || true
+  echo "::endgroup::"
+  echo "::group::nats logs"
+  kubectl logs -l app=nats --tail=200 || true
+  echo "::endgroup::"
+}
+trap on_error ERR
 
-echo ">>> loading image into kind"
-kind load docker-image "${IMAGE}" --name choreographer-e2e
+echo ">>> building choreographer image"
+bash scripts/ci/container-image.sh "${CHOREO_IMAGE}" Dockerfile
 
-echo ">>> installing chart"
+echo ">>> building e2e runner image"
+bash scripts/ci/container-image.sh "${RUNNER_IMAGE}" tests/e2e/runner.Dockerfile
+
+echo ">>> loading images into kind cluster '${CLUSTER_NAME}'"
+kind load docker-image "${CHOREO_IMAGE}" --name "${CLUSTER_NAME}"
+kind load docker-image "${RUNNER_IMAGE}" --name "${CLUSTER_NAME}"
+
+echo ">>> deploying NATS"
+kubectl apply -f "${NATS_MANIFEST}"
+kubectl wait --for=condition=available --timeout=2m deployment/nats
+
+echo ">>> installing Choreographer chart"
 helm upgrade --install choreographer "${CHART_PATH}" \
   --values "${CHART_PATH}/values.dev.yaml" \
   --set "image.repository=underpass-choreographer" \
   --set "image.tag=e2e" \
   --set "image.pullPolicy=Never" \
+  --set "config.seedSpecialties=triage" \
   --wait --timeout 3m
 
-echo ">>> submitting e2e runner job"
+echo ">>> submitting E2E runner Job"
 kubectl apply -f "${JOB_MANIFEST}"
 
-echo ">>> waiting for job completion"
-kubectl wait --for=condition=complete --timeout=10m job/choreographer-e2e-runner || {
-  kubectl logs job/choreographer-e2e-runner || true
+echo ">>> waiting for Job to complete"
+# Use `kubectl wait` with both conditions so we fail fast on a
+# runner that bailed out (condition=failed) instead of sleeping
+# through the full timeout.
+if ! kubectl wait --for=condition=complete --timeout=5m job/choreographer-e2e-runner; then
+  if kubectl wait --for=condition=failed --timeout=10s job/choreographer-e2e-runner 2>/dev/null; then
+    echo "::error::e2e runner Job failed"
+  else
+    echo "::error::e2e runner Job did not complete within 5m"
+  fi
+  on_error
   exit 1
-}
+fi
 
+echo ">>> runner logs"
 kubectl logs job/choreographer-e2e-runner
+
+echo ">>> E2E kubernetes scenarios passed"

--- a/tests/e2e/kubernetes/nats.yaml
+++ b/tests/e2e/kubernetes/nats.yaml
@@ -1,0 +1,63 @@
+---
+# Minimal NATS deployment for the Kubernetes E2E.
+#
+# Not a production chart — intentionally tiny so the E2E path is
+# exact and debuggable. The Service name `nats` matches the default
+# `messaging.nats.url` the Choreographer chart ships with.
+apiVersion: v1
+kind: Service
+metadata:
+  name: nats
+  labels:
+    app: nats
+    app.kubernetes.io/part-of: choreographer-e2e
+spec:
+  selector:
+    app: nats
+  ports:
+    - name: client
+      port: 4222
+      targetPort: 4222
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nats
+  labels:
+    app: nats
+    app.kubernetes.io/part-of: choreographer-e2e
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nats
+  template:
+    metadata:
+      labels:
+        app: nats
+    spec:
+      containers:
+        - name: nats
+          image: nats:2
+          args: ["-js"]
+          ports:
+            - name: client
+              containerPort: 4222
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: client
+            periodSeconds: 2
+            failureThreshold: 30
+          livenessProbe:
+            tcpSocket:
+              port: client
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi

--- a/tests/e2e/kubernetes/runner-job.yaml
+++ b/tests/e2e/kubernetes/runner-job.yaml
@@ -1,0 +1,44 @@
+---
+# End-to-end runner as a Kubernetes Job.
+#
+# Launched after the Choreographer chart is `helm install`-ed in the
+# kind cluster. The Job drives the Choreographer over its public
+# gRPC contract and exits 0 on success; `kubectl wait
+# --for=condition=complete` in the CI script turns that exit code
+# into the job's result.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: choreographer-e2e-runner
+  labels:
+    app.kubernetes.io/name: choreographer-e2e-runner
+    app.kubernetes.io/part-of: choreographer-e2e
+spec:
+  # The runner is intended to run exactly once; a restart on failure
+  # would mask the real error from the CI logs.
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: choreographer-e2e-runner
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: runner
+          image: underpass-choreographer-e2e-runner:e2e
+          imagePullPolicy: Never
+          env:
+            - name: CHOREOGRAPHER_ENDPOINT
+              value: http://choreographer:50055
+            - name: CHOREO_SEED_SPECIALTY
+              value: triage
+            - name: RUST_LOG
+              value: info
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              cpu: 500m
+              memory: 128Mi


### PR DESCRIPTION
## Summary

Close the last soft-fail CI job. \`e2e-kubernetes\` now runs the
Choreographer against a real Kubernetes cluster (kind) with the
published Helm chart driving the deployment. The runner Job's exit
code is the CI result. Every CI gate in this repo now exercises
something real.

## Chart fix (caught by this slice — real deployment bug)

The chart was emitting \`GRPC_PORT\`, \`ENABLE_NATS\`, \`NATS_URL\` as
env vars. But \`EnvConfiguration\` in the binary only reads the
\`CHOREO_*\` prefix. **Every deployment was silently ignoring chart
values and falling back to in-code defaults**. Fixed:
\`CHOREO_GRPC_PORT\` / \`CHOREO_NATS_ENABLED\` / \`CHOREO_NATS_URL\`.
Plus: new \`config.seedSpecialties\` field emits
\`CHOREO_SEED_SPECIALTIES\` when non-empty so the chart can bring up
a deployment that is immediately exercisable.

## E2E manifests (\`tests/e2e/kubernetes/\`)

- **\`nats.yaml\`** — tiny Deployment + Service named \`nats\`. TCP
  readiness / liveness probes (no shell / curl needed in the
  minimal nats:2 image; same lesson as 7a).
- **\`runner-job.yaml\`** — single-shot Job (\`backoffLimit: 0\`) that
  runs the \`choreo-e2e-runner\` image against
  \`http://choreographer:50055\`. \`kubectl wait\` turns the exit code
  into the job result.

## CI glue

- \`scripts/ci/container-image.sh\` now takes an optional Dockerfile
  path as second arg so the same script builds both images.
- \`scripts/ci/e2e-kubernetes.sh\`:
  - builds Choreographer + runner images and loads both into kind;
  - applies \`nats.yaml\` and waits for the Deployment to be ready;
  - \`helm upgrade --install\` with \`config.seedSpecialties=triage\`
    so the runner sees a council on \`ListCouncils\`;
  - applies the runner Job and waits up to 5m for completion;
  - on error, dumps \`kubectl get all\`, Job description, runner
    logs, Choreographer logs, NATS logs — **debuggable without a
    re-run**.

## Honesty & Evidence

- **227 unit tests still pass** (128 core + 12 app + 82 adapters +
  5 binary). No regression.
- The Kubernetes E2E itself is the evidence that the chart, the
  image, the seeding, and the gRPC surface agree end-to-end.
- Every CI job in this repo now executes something real: unit
  tests, contract lint (buf + asyncapi), testcontainers NATS
  roundtrip (integration-nats), compose stack smoke
  (e2e-compose), and full kind + Helm + Job (this PR).
- \`cargo fmt\` + \`cargo clippy -D warnings\` clean.
- \`helm lint\` + \`helm template --set config.seedSpecialties=triage\`
  verified locally to emit the correct \`CHOREO_*\` env vars.

## Contract Impact

- [x] No proto / AsyncAPI changes
- [x] Breaking chart env-var names fixed — any existing
      deployment on a previous chart version was already broken, so
      this aligns chart with the binary's real contract

## Architecture Review

- [x] E2E runner talks only to the public gRPC surface
- [x] Deploy path exercises the published chart, not ad-hoc YAML
- [x] No provider-specific or use-case-specific identity added