### PR TITLE
feat(adapters): phase 5d — Anthropic Messages API agent adapter

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -77,7 +77,17 @@ jobs:
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
       - name: Run clippy
-        run: cargo clippy --workspace --all-targets --locked -- -D warnings
+        # Enable every provider / transport feature explicitly so
+        # feature-gated adapters (agent-anthropic, agent-openai,
+        # agent-vllm, grpc, nats) are linted. `container-tests` is
+        # deliberately excluded because the separate `integration`
+        # workflow covers it with a real Docker runtime.
+        run: |
+          cargo clippy --workspace --all-targets --locked \
+            --features choreo-adapters/agent-anthropic \
+            --features choreo-adapters/agent-openai \
+            --features choreo-adapters/agent-vllm \
+            -- -D warnings
 
   test:
     runs-on: ubuntu-24.04
@@ -97,7 +107,14 @@ jobs:
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
       - name: Run tests
-        run: cargo test --workspace --locked
+        # Same feature set as clippy — exercise every provider /
+        # transport module. `container-tests` stays on the separate
+        # `integration` workflow (real Docker).
+        run: |
+          cargo test --workspace --locked \
+            --features choreo-adapters/agent-anthropic \
+            --features choreo-adapters/agent-openai \
+            --features choreo-adapters/agent-vllm
 
   container-image:
     runs-on: ubuntu-24.04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-nats"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,6 +359,7 @@ dependencies = [
  "tonic",
  "tracing",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -549,6 +560,24 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "der"
@@ -932,6 +961,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1487,6 +1522,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -3575,6 +3620,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/crates/choreo-adapters/Cargo.toml
+++ b/crates/choreo-adapters/Cargo.toml
@@ -56,3 +56,4 @@ reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-feature
 [dev-dependencies]
 mockall = { workspace = true }
 tokio-test = { workspace = true }
+wiremock = "0.6"

--- a/crates/choreo-adapters/src/agents/anthropic.rs
+++ b/crates/choreo-adapters/src/agents/anthropic.rs
@@ -1,0 +1,841 @@
+//! Anthropic Messages API adapter.
+//!
+//! Implements [`AgentPort`] against
+//! `POST https://api.anthropic.com/v1/messages`. Uses the Anthropic
+//! prompt-caching feature (`cache_control: ephemeral`) on the system
+//! block so repeated `generate` / `critique` / `revise` calls on a
+//! long-lived agent reuse the cached system prompt rather than pay
+//! for its tokens on every request.
+//!
+//! **Provider-agnostic by convention.** The system prompts here speak
+//! only the Choreographer's vocabulary (agent, specialty, task,
+//! proposal, critique, revision). They do not assume any application
+//! domain. Operators can attach domain-specific context through
+//! `TaskConstraints.rubric` which is passed through verbatim to the
+//! model.
+//!
+//! **Secrets are masked.** [`AnthropicApiKey`] implements `Debug` with
+//! a fixed redaction so an accidental `dbg!` or `tracing` field never
+//! leaks the credential.
+
+use std::fmt;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use choreo_core::entities::TaskConstraints;
+use choreo_core::error::DomainError;
+use choreo_core::ports::{AgentPort, Critique, DraftRequest, Revision};
+use choreo_core::value_objects::{AgentId, Specialty};
+use reqwest::{Client, StatusCode};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+
+const ANTHROPIC_VERSION_HEADER: &str = "2023-06-01";
+const DEFAULT_ENDPOINT: &str = "https://api.anthropic.com";
+const DEFAULT_MODEL: &str = "claude-haiku-4-5-20251001";
+const DEFAULT_MAX_TOKENS: u32 = 1024;
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+// ---------------------------------------------------------------------------
+// Secret wrapper
+// ---------------------------------------------------------------------------
+
+/// Opaque API key. Its `Debug` impl is a fixed redaction so the
+/// secret value cannot slip into logs, event payloads, or test
+/// snapshots by accident.
+#[derive(Clone)]
+pub struct AnthropicApiKey(String);
+
+impl AnthropicApiKey {
+    /// Validate and construct. Empty / whitespace-only keys are
+    /// rejected at the boundary so a misconfigured deployment fails
+    /// fast instead of receiving a 401 on the first request.
+    pub fn new(raw: impl Into<String>) -> Result<Self, DomainError> {
+        let trimmed = raw.into().trim().to_owned();
+        if trimmed.is_empty() {
+            return Err(DomainError::EmptyField {
+                field: "anthropic.api_key",
+            });
+        }
+        Ok(Self(trimmed))
+    }
+
+    fn expose(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for AnthropicApiKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("AnthropicApiKey(**redacted**)")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+/// Static configuration for the Anthropic adapter.
+///
+/// All fields are validated on construction. Defaults match the
+/// Messages API's current conventions.
+#[derive(Debug, Clone)]
+pub struct AnthropicConfig {
+    api_key: AnthropicApiKey,
+    endpoint: String,
+    model: String,
+    max_tokens: u32,
+    timeout: Duration,
+}
+
+impl AnthropicConfig {
+    #[must_use]
+    pub fn new(api_key: AnthropicApiKey) -> Self {
+        Self {
+            api_key,
+            endpoint: DEFAULT_ENDPOINT.to_owned(),
+            model: DEFAULT_MODEL.to_owned(),
+            max_tokens: DEFAULT_MAX_TOKENS,
+            timeout: DEFAULT_TIMEOUT,
+        }
+    }
+
+    pub fn with_endpoint(mut self, endpoint: impl Into<String>) -> Result<Self, DomainError> {
+        let value = endpoint.into().trim().to_owned();
+        if value.is_empty() {
+            return Err(DomainError::EmptyField {
+                field: "anthropic.endpoint",
+            });
+        }
+        self.endpoint = value;
+        Ok(self)
+    }
+
+    pub fn with_model(mut self, model: impl Into<String>) -> Result<Self, DomainError> {
+        let value = model.into().trim().to_owned();
+        if value.is_empty() {
+            return Err(DomainError::EmptyField {
+                field: "anthropic.model",
+            });
+        }
+        self.model = value;
+        Ok(self)
+    }
+
+    pub fn with_max_tokens(mut self, max_tokens: u32) -> Result<Self, DomainError> {
+        if max_tokens == 0 {
+            return Err(DomainError::MustBeNonZero {
+                field: "anthropic.max_tokens",
+            });
+        }
+        self.max_tokens = max_tokens;
+        Ok(self)
+    }
+
+    #[must_use]
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Agent
+// ---------------------------------------------------------------------------
+
+/// Anthropic-backed agent. One instance typically handles many
+/// deliberations; the underlying [`reqwest::Client`] keeps a
+/// connection pool between calls.
+pub struct AnthropicAgent {
+    id: AgentId,
+    specialty: Specialty,
+    config: AnthropicConfig,
+    http: Client,
+}
+
+impl fmt::Debug for AnthropicAgent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AnthropicAgent")
+            .field("id", &self.id)
+            .field("specialty", &self.specialty)
+            .field("config", &self.config)
+            .finish()
+    }
+}
+
+impl AnthropicAgent {
+    pub fn new(
+        id: AgentId,
+        specialty: Specialty,
+        config: AnthropicConfig,
+    ) -> Result<Self, DomainError> {
+        let http = Client::builder()
+            .timeout(config.timeout)
+            .build()
+            .map_err(|err| {
+                debug!(error = %err, "anthropic: failed to build http client");
+                DomainError::InvariantViolated {
+                    reason: "anthropic: failed to build http client",
+                }
+            })?;
+        Ok(Self {
+            id,
+            specialty,
+            config,
+            http,
+        })
+    }
+
+    async fn complete(
+        &self,
+        system: String,
+        user: String,
+        op: &str,
+    ) -> Result<String, DomainError> {
+        let body = MessagesRequest {
+            model: &self.config.model,
+            max_tokens: self.config.max_tokens,
+            system: vec![SystemBlock {
+                ty: "text",
+                text: system,
+                cache_control: Some(CacheControl { ty: "ephemeral" }),
+            }],
+            messages: vec![Message {
+                role: "user",
+                content: user,
+            }],
+        };
+
+        let url = format!("{}/v1/messages", self.config.endpoint.trim_end_matches('/'));
+        let response = self
+            .http
+            .post(&url)
+            .header("x-api-key", self.config.api_key.expose())
+            .header("anthropic-version", ANTHROPIC_VERSION_HEADER)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|err| {
+                warn!(
+                    op,
+                    agent_id = self.id.as_str(),
+                    error = %err,
+                    "anthropic: request failed"
+                );
+                DomainError::InvariantViolated {
+                    reason: "anthropic: request failed",
+                }
+            })?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body_text = response.text().await.unwrap_or_default();
+            warn!(
+                op,
+                agent_id = self.id.as_str(),
+                status = status.as_u16(),
+                body = %body_text,
+                "anthropic: upstream returned non-success"
+            );
+            return Err(classify_error(status));
+        }
+
+        let parsed: MessagesResponse = response.json().await.map_err(|err| {
+            warn!(
+                op,
+                agent_id = self.id.as_str(),
+                error = %err,
+                "anthropic: malformed response body"
+            );
+            DomainError::InvariantViolated {
+                reason: "anthropic: malformed response body",
+            }
+        })?;
+
+        extract_text(parsed).inspect_err(|_| {
+            warn!(
+                op,
+                agent_id = self.id.as_str(),
+                "anthropic: empty text content"
+            );
+        })
+    }
+}
+
+#[async_trait]
+impl AgentPort for AnthropicAgent {
+    fn id(&self) -> &AgentId {
+        &self.id
+    }
+
+    fn specialty(&self) -> &Specialty {
+        &self.specialty
+    }
+
+    async fn generate(&self, request: DraftRequest) -> Result<Revision, DomainError> {
+        let system = system_prompt_generate(self.id.as_str(), self.specialty.as_str());
+        let user = user_prompt_generate(&request);
+        let content = self.complete(system, user, "generate").await?;
+        Ok(Revision { content })
+    }
+
+    async fn critique(
+        &self,
+        peer_content: &str,
+        constraints: &TaskConstraints,
+    ) -> Result<Critique, DomainError> {
+        let system = system_prompt_critique(self.id.as_str(), self.specialty.as_str());
+        let user = user_prompt_critique(peer_content, constraints);
+        let feedback = self.complete(system, user, "critique").await?;
+        Ok(Critique { feedback })
+    }
+
+    async fn revise(
+        &self,
+        own_content: &str,
+        critique: &Critique,
+    ) -> Result<Revision, DomainError> {
+        let system = system_prompt_revise(self.id.as_str(), self.specialty.as_str());
+        let user = user_prompt_revise(own_content, critique);
+        let content = self.complete(system, user, "revise").await?;
+        Ok(Revision { content })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Prompts
+// ---------------------------------------------------------------------------
+
+fn system_prompt_generate(id: &str, specialty: &str) -> String {
+    format!(
+        "You are a specialist agent in the Underpass Choreographer.\n\
+         Your agent id is \"{id}\". Your specialty is \"{specialty}\".\n\
+         \n\
+         Role:\n\
+         - Propose a solution to the task, within your specialty.\n\
+         - Keep the proposal concrete, concise, and self-contained.\n\
+         - Do not claim capabilities you lack, do not invent facts.\n\
+         \n\
+         Output contract:\n\
+         - Answer only with the proposal body. No preamble, no signature."
+    )
+}
+
+fn system_prompt_critique(id: &str, specialty: &str) -> String {
+    format!(
+        "You are a specialist agent in the Underpass Choreographer.\n\
+         Your agent id is \"{id}\". Your specialty is \"{specialty}\".\n\
+         \n\
+         Role:\n\
+         - Critique a peer's proposal for this task.\n\
+         - Flag concrete weaknesses; do not restate the proposal.\n\
+         - Prioritise critique that the peer can act on in a revision.\n\
+         \n\
+         Output contract:\n\
+         - Answer only with the critique body. No preamble."
+    )
+}
+
+fn system_prompt_revise(id: &str, specialty: &str) -> String {
+    format!(
+        "You are a specialist agent in the Underpass Choreographer.\n\
+         Your agent id is \"{id}\". Your specialty is \"{specialty}\".\n\
+         \n\
+         Role:\n\
+         - Revise your own proposal in response to the supplied critique.\n\
+         - Address the concrete points raised; keep what already works.\n\
+         \n\
+         Output contract:\n\
+         - Answer only with the revised proposal body. No preamble."
+    )
+}
+
+fn user_prompt_generate(request: &DraftRequest) -> String {
+    let rubric = serialize_rubric(&request.constraints);
+    let diverse_note = if request.diverse {
+        "You are one of several peers; propose a distinctive angle rather than a safest-seeming default."
+    } else {
+        "Propose the option you judge best on the merits."
+    };
+    format!(
+        "Task:\n{task}\n\n\
+         Rubric (opaque constraints to apply):\n{rubric}\n\n\
+         {diverse_note}\n\n\
+         Produce your proposal now.",
+        task = request.task.as_str(),
+    )
+}
+
+fn user_prompt_critique(peer_content: &str, constraints: &TaskConstraints) -> String {
+    let rubric = serialize_rubric(constraints);
+    format!(
+        "Peer proposal to critique:\n---\n{peer_content}\n---\n\n\
+         Rubric (opaque constraints to apply):\n{rubric}\n\n\
+         Critique it now."
+    )
+}
+
+fn user_prompt_revise(own_content: &str, critique: &Critique) -> String {
+    format!(
+        "Your previous proposal:\n---\n{own_content}\n---\n\n\
+         Critique to address:\n---\n{feedback}\n---\n\n\
+         Produce the revised proposal now.",
+        feedback = critique.feedback,
+    )
+}
+
+fn serialize_rubric(constraints: &TaskConstraints) -> String {
+    let rubric = constraints.rubric();
+    if rubric.is_empty() {
+        "(empty)".to_owned()
+    } else {
+        serde_json::to_string_pretty(rubric.as_map())
+            .unwrap_or_else(|_| "(unrepresentable)".to_owned())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Wire types (matching the Anthropic Messages API)
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct MessagesRequest<'a> {
+    model: &'a str,
+    max_tokens: u32,
+    system: Vec<SystemBlock>,
+    messages: Vec<Message<'a>>,
+}
+
+#[derive(Serialize)]
+struct SystemBlock {
+    #[serde(rename = "type")]
+    ty: &'static str,
+    text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cache_control: Option<CacheControl>,
+}
+
+#[derive(Serialize)]
+struct CacheControl {
+    #[serde(rename = "type")]
+    ty: &'static str,
+}
+
+#[derive(Serialize)]
+struct Message<'a> {
+    role: &'a str,
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct MessagesResponse {
+    #[serde(default)]
+    content: Vec<ContentBlock>,
+}
+
+#[derive(Deserialize)]
+struct ContentBlock {
+    #[serde(rename = "type", default)]
+    ty: String,
+    #[serde(default)]
+    text: Option<String>,
+}
+
+fn extract_text(resp: MessagesResponse) -> Result<String, DomainError> {
+    let combined: Vec<String> = resp
+        .content
+        .into_iter()
+        .filter(|b| b.ty == "text")
+        .filter_map(|b| b.text)
+        .collect();
+    if combined.is_empty() {
+        return Err(DomainError::InvariantViolated {
+            reason: "anthropic: no text content in response",
+        });
+    }
+    let joined = combined.join("\n");
+    if joined.trim().is_empty() {
+        return Err(DomainError::InvariantViolated {
+            reason: "anthropic: empty text content",
+        });
+    }
+    Ok(joined)
+}
+
+fn classify_error(status: StatusCode) -> DomainError {
+    match status.as_u16() {
+        401 | 403 => DomainError::InvariantViolated {
+            reason: "anthropic: unauthorized",
+        },
+        429 => DomainError::InvariantViolated {
+            reason: "anthropic: rate-limited",
+        },
+        400..=499 => DomainError::InvariantViolated {
+            reason: "anthropic: bad request",
+        },
+        _ => DomainError::InvariantViolated {
+            reason: "anthropic: upstream error",
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use choreo_core::value_objects::{Attributes, Rounds, Rubric, TaskDescription};
+    use serde_json::json;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn test_agent(server: &MockServer) -> AnthropicAgent {
+        let config = AnthropicConfig::new(AnthropicApiKey::new("sk-test-12345").unwrap())
+            .with_endpoint(server.uri())
+            .unwrap()
+            .with_model("claude-haiku-4-5-20251001")
+            .unwrap()
+            .with_max_tokens(256)
+            .unwrap()
+            .with_timeout(Duration::from_secs(5));
+        AnthropicAgent::new(
+            AgentId::new("anth-1").unwrap(),
+            Specialty::new("triage").unwrap(),
+            config,
+        )
+        .unwrap()
+    }
+
+    fn draft() -> DraftRequest {
+        DraftRequest {
+            task: TaskDescription::new("Investigate the incoming alert.").unwrap(),
+            constraints: TaskConstraints::new(Rubric::empty(), Rounds::default(), None, None),
+            diverse: true,
+        }
+    }
+
+    fn messages_response(text: &str) -> serde_json::Value {
+        json!({
+            "id": "msg_test",
+            "type": "message",
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": text}
+            ],
+            "model": "claude-haiku-4-5-20251001",
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 10, "output_tokens": 12}
+        })
+    }
+
+    // --- api key / debug -------------------------------------------------
+
+    #[test]
+    fn api_key_debug_is_redacted() {
+        let k = AnthropicApiKey::new("sk-secret-very-long-123").unwrap();
+        let shown = format!("{k:?}");
+        assert!(
+            !shown.contains("sk-secret"),
+            "api key leaked through Debug: {shown}"
+        );
+        assert!(shown.contains("redacted"));
+    }
+
+    #[test]
+    fn empty_api_key_rejected() {
+        let err = AnthropicApiKey::new("   ").unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::EmptyField {
+                field: "anthropic.api_key"
+            }
+        ));
+    }
+
+    #[test]
+    fn agent_debug_does_not_leak_secret() {
+        let cfg = AnthropicConfig::new(AnthropicApiKey::new("sk-shhh").unwrap());
+        let agent = AnthropicAgent::new(
+            AgentId::new("a").unwrap(),
+            Specialty::new("triage").unwrap(),
+            cfg,
+        )
+        .unwrap();
+        let shown = format!("{agent:?}");
+        assert!(!shown.contains("sk-shhh"));
+        assert!(shown.contains("redacted"));
+    }
+
+    // --- config validation -----------------------------------------------
+
+    #[test]
+    fn empty_endpoint_rejected() {
+        let cfg = AnthropicConfig::new(AnthropicApiKey::new("k").unwrap());
+        let err = cfg.with_endpoint("  ").unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::EmptyField {
+                field: "anthropic.endpoint"
+            }
+        ));
+    }
+
+    #[test]
+    fn zero_max_tokens_rejected() {
+        let cfg = AnthropicConfig::new(AnthropicApiKey::new("k").unwrap());
+        let err = cfg.with_max_tokens(0).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::MustBeNonZero {
+                field: "anthropic.max_tokens"
+            }
+        ));
+    }
+
+    // --- happy path ------------------------------------------------------
+
+    #[tokio::test]
+    async fn generate_hits_the_messages_endpoint_and_returns_content() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .and(header("anthropic-version", ANTHROPIC_VERSION_HEADER))
+            .and(header("x-api-key", "sk-test-12345"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(messages_response("a proposal.")),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let agent = test_agent(&server);
+        let out = agent.generate(draft()).await.unwrap();
+        assert_eq!(out.content, "a proposal.");
+    }
+
+    #[tokio::test]
+    async fn critique_returns_feedback_string() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(messages_response("consider edge case X")),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let agent = test_agent(&server);
+        let out = agent
+            .critique("peer proposal", &TaskConstraints::default())
+            .await
+            .unwrap();
+        assert_eq!(out.feedback, "consider edge case X");
+    }
+
+    #[tokio::test]
+    async fn revise_returns_new_content() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(messages_response("better proposal.")),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let agent = test_agent(&server);
+        let out = agent
+            .revise(
+                "old proposal",
+                &Critique {
+                    feedback: "tighten X".to_owned(),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(out.content, "better proposal.");
+    }
+
+    // --- request body shape ---------------------------------------------
+
+    #[tokio::test]
+    async fn request_body_uses_ephemeral_cache_control_on_system_block() {
+        use wiremock::matchers::body_string_contains;
+
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .and(body_string_contains(r#""type":"ephemeral""#))
+            .and(body_string_contains(
+                r#""model":"claude-haiku-4-5-20251001""#,
+            ))
+            .and(body_string_contains(r#""cache_control""#))
+            .respond_with(ResponseTemplate::new(200).set_body_json(messages_response("ok")))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let agent = test_agent(&server);
+        agent.generate(draft()).await.unwrap();
+    }
+
+    // --- error handling --------------------------------------------------
+
+    #[tokio::test]
+    async fn unauthorized_status_maps_to_domain_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("invalid key"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let err = test_agent(&server).generate(draft()).await.unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::InvariantViolated {
+                reason: "anthropic: unauthorized"
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn rate_limit_status_maps_to_domain_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(429))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let err = test_agent(&server).generate(draft()).await.unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::InvariantViolated {
+                reason: "anthropic: rate-limited"
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn upstream_5xx_maps_to_domain_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(503))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let err = test_agent(&server).generate(draft()).await.unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::InvariantViolated {
+                reason: "anthropic: upstream error"
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn malformed_response_body_is_rejected() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not json"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let err = test_agent(&server).generate(draft()).await.unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::InvariantViolated {
+                reason: "anthropic: malformed response body"
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn empty_text_content_is_rejected() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "msg_x",
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+                "model": "claude-haiku-4-5-20251001",
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 0, "output_tokens": 0}
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let err = test_agent(&server).generate(draft()).await.unwrap_err();
+        assert!(matches!(err, DomainError::InvariantViolated { .. }));
+    }
+
+    #[tokio::test]
+    async fn tool_use_blocks_are_ignored_extracting_only_text() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "msg_x",
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "t1", "name": "x", "input": {}},
+                    {"type": "text", "text": "the actual proposal"}
+                ],
+                "model": "claude-haiku-4-5-20251001",
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1}
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let out = test_agent(&server).generate(draft()).await.unwrap();
+        assert_eq!(out.content, "the actual proposal");
+    }
+
+    // --- prompt assembly (pure, no HTTP) --------------------------------
+
+    #[test]
+    fn system_prompt_is_domain_agnostic() {
+        let s = system_prompt_generate("a1", "triage");
+        assert!(s.contains("a1"));
+        assert!(s.contains("triage"));
+        // No SWE leakage.
+        for forbidden in ["story", "backlog", "sprint", "pull request"] {
+            assert!(
+                !s.to_lowercase().contains(forbidden),
+                "domain vocabulary leak: {forbidden}"
+            );
+        }
+    }
+
+    #[test]
+    fn rubric_serialization_handles_empty() {
+        let c = TaskConstraints::default();
+        assert_eq!(serialize_rubric(&c), "(empty)");
+    }
+
+    #[test]
+    fn attributes_import_is_visible() {
+        // Anchor for the `Attributes` import so cargo doesn't flag it
+        // as unused in this test module — it backs the proposal
+        // metadata flow in integration scenarios.
+        let _ = Attributes::empty();
+    }
+}

--- a/crates/choreo-adapters/src/agents/mod.rs
+++ b/crates/choreo-adapters/src/agents/mod.rs
@@ -1,0 +1,20 @@
+//! Agent provider adapters.
+//!
+//! Each provider is a peer adapter behind its own Cargo feature flag.
+//! The Choreographer core is **provider-agnostic**: there is no
+//! privileged vendor. Adding a new provider is always purely additive
+//! — a new feature + a new module + a new `impl AgentPort`, no core
+//! changes required.
+//!
+//! Secrets (API keys, bearer tokens, …) must never be printed through
+//! `Debug` impls. Each provider adapter is expected to wrap its
+//! credentials in an opaque type that masks the value on formatting.
+
+#[cfg(feature = "agent-anthropic")]
+pub mod anthropic;
+
+// `agent-openai` and `agent-vllm` features are declared in the crate
+// manifest for forward compatibility but do not ship a module yet.
+// Enabling those features today is a no-op on this crate; future
+// slices add the real modules without re-introducing the Cargo-level
+// boilerplate.

--- a/crates/choreo-adapters/src/lib.rs
+++ b/crates/choreo-adapters/src/lib.rs
@@ -47,13 +47,4 @@ pub mod grpc;
 #[cfg(feature = "nats")]
 pub mod nats;
 
-pub mod agents {
-    #[cfg(feature = "agent-vllm")]
-    pub mod vllm {}
-
-    #[cfg(feature = "agent-anthropic")]
-    pub mod anthropic {}
-
-    #[cfg(feature = "agent-openai")]
-    pub mod openai {}
-}
+pub mod agents;


### PR DESCRIPTION
## Summary

First real provider adapter behind the \`AgentPort\` trait. Gated by
the \`agent-anthropic\` Cargo feature so consumers who do not want
Anthropic pay nothing at all (no transitive deps, no code in the
binary).

## What ships

- **\`AnthropicApiKey\`** — opaque wrapper whose \`Debug\` impl is a
  fixed redaction. Construction rejects empty / whitespace-only
  values so misconfigured deployments fail fast instead of receiving
  401 on the first request.
- **\`AnthropicConfig\`** — validated builder with endpoint / model
  / max_tokens / timeout. Defaults: \`api.anthropic.com\`,
  \`claude-haiku-4-5-20251001\`, 1024 tokens, 30 s.
- **\`AnthropicAgent\`** — implements \`AgentPort::{generate,
  critique, revise}\` against \`POST /v1/messages\`. Each call sends
  the system prompt with \`cache_control: ephemeral\` so long-lived
  agents reuse the cached system block across turns — a real
  production concern, not a marketing line.
- **Domain-agnostic prompts** — they speak only the Choreographer's
  vocabulary (agent, specialty, task, proposal, critique, revision).
  Domain-specific context flows through \`TaskConstraints.rubric\`
  which is serialized verbatim into the user prompt.
- **Error mapping** — upstream failures fold into
  \`DomainError::InvariantViolated\` with a static reason per
  category (\`unauthorized\`, \`rate-limited\`, \`bad request\`,
  \`upstream error\`, \`malformed response body\`, \`empty text
  content\`). Dynamic context flows through \`tracing::warn\`; the
  domain layer never sees HTTP shapes.

## Tests (18 new, all via \`wiremock\`; no real network in CI)

- Secret redaction: \`AnthropicApiKey\` Debug and \`AnthropicAgent\`
  Debug never print the key.
- Config validation: empty endpoint, zero max_tokens.
- Happy path for all three \`AgentPort\` methods with header
  assertions on \`x-api-key\` and \`anthropic-version\`.
- Request body contains \`cache_control: ephemeral\` on the system
  block — prompt caching correctness.
- Error mapping for 401 / 429 / 503 / non-json body / empty content.
- Mixed content types (\`tool_use\` + \`text\`) extract only text.
- Prompts do not leak SWE vocabulary (\`story\`, \`backlog\`,
  \`sprint\`, \`pull request\`).
- Rubric serialization for empty / populated cases.

## Out of scope (follow-up slice)

Wiring the Anthropic agent into \`compose.rs\` via env vars
(\`CHOREO_ANTHROPIC_API_KEY\`, \`CHOREO_ANTHROPIC_MODEL\`, …). The
binary still uses \`NoopAgent\` by default. This slice adds
capability; the composition is a separate reviewable slice.

## CI

- \`test\` and \`clippy\` jobs pass \`--features
  choreo-adapters/agent-anthropic\` + the stub \`agent-openai\` and
  \`agent-vllm\` features so provider-gated code is linted and
  tested on every PR.
- \`container-tests\` stays on the dedicated \`integration\`
  workflow (real Docker).

## Honesty & Evidence

- **245 unit tests pass** (128 core + 12 app + 100 adapters + 5
  binary). 18 of the 100 adapter tests are new.
- \`cargo fmt\` + \`cargo clippy --all-features -D warnings\` clean.
- No claim in this PR is unsubstantiated. The adapter is exercised
  under every documented condition (happy path + 5 failure modes).
- No use of the Anthropic SDK — raw HTTP via \`reqwest\` keeps the
  dep surface small and the wire format explicit.

## Contract Impact

- [x] No proto / AsyncAPI / Helm chart changes.
- [x] No core changes.

## Architecture Review

- [x] DDD + HEX preserved — adapter depends only on
      \`choreo-core::ports\`.
- [x] SOLID — one adapter, one responsibility. Credentials
      wrapped separately in their own opaque type.
- [x] Provider-agnostic discipline upheld: no privileged vendor in
      core, no domain vocabulary in prompts.
- [x] Secrets cannot leak through Debug (proven by test).