### PR TITLE
refactor(adapters): extract shared prompts and OpenAI-compat wire

### DIFF
--- a/crates/choreo-adapters/src/agents/anthropic.rs
+++ b/crates/choreo-adapters/src/agents/anthropic.rs
@@ -30,6 +30,8 @@ use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 
+use super::prompts;
+
 const ANTHROPIC_VERSION_HEADER: &str = "2023-06-01";
 const DEFAULT_ENDPOINT: &str = "https://api.anthropic.com";
 const DEFAULT_MODEL: &str = "claude-haiku-4-5-20251001";
@@ -273,8 +275,8 @@ impl AgentPort for AnthropicAgent {
     }
 
     async fn generate(&self, request: DraftRequest) -> Result<Revision, DomainError> {
-        let system = system_prompt_generate(self.id.as_str(), self.specialty.as_str());
-        let user = user_prompt_generate(&request);
+        let system = prompts::system_prompt_generate(self.id.as_str(), self.specialty.as_str());
+        let user = prompts::user_prompt_generate(&request);
         let content = self.complete(system, user, "generate").await?;
         Ok(Revision { content })
     }
@@ -284,8 +286,8 @@ impl AgentPort for AnthropicAgent {
         peer_content: &str,
         constraints: &TaskConstraints,
     ) -> Result<Critique, DomainError> {
-        let system = system_prompt_critique(self.id.as_str(), self.specialty.as_str());
-        let user = user_prompt_critique(peer_content, constraints);
+        let system = prompts::system_prompt_critique(self.id.as_str(), self.specialty.as_str());
+        let user = prompts::user_prompt_critique(peer_content, constraints);
         let feedback = self.complete(system, user, "critique").await?;
         Ok(Critique { feedback })
     }
@@ -295,102 +297,10 @@ impl AgentPort for AnthropicAgent {
         own_content: &str,
         critique: &Critique,
     ) -> Result<Revision, DomainError> {
-        let system = system_prompt_revise(self.id.as_str(), self.specialty.as_str());
-        let user = user_prompt_revise(own_content, critique);
+        let system = prompts::system_prompt_revise(self.id.as_str(), self.specialty.as_str());
+        let user = prompts::user_prompt_revise(own_content, critique);
         let content = self.complete(system, user, "revise").await?;
         Ok(Revision { content })
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Prompts
-// ---------------------------------------------------------------------------
-
-fn system_prompt_generate(id: &str, specialty: &str) -> String {
-    format!(
-        "You are a specialist agent in the Underpass Choreographer.\n\
-         Your agent id is \"{id}\". Your specialty is \"{specialty}\".\n\
-         \n\
-         Role:\n\
-         - Propose a solution to the task, within your specialty.\n\
-         - Keep the proposal concrete, concise, and self-contained.\n\
-         - Do not claim capabilities you lack, do not invent facts.\n\
-         \n\
-         Output contract:\n\
-         - Answer only with the proposal body. No preamble, no signature."
-    )
-}
-
-fn system_prompt_critique(id: &str, specialty: &str) -> String {
-    format!(
-        "You are a specialist agent in the Underpass Choreographer.\n\
-         Your agent id is \"{id}\". Your specialty is \"{specialty}\".\n\
-         \n\
-         Role:\n\
-         - Critique a peer's proposal for this task.\n\
-         - Flag concrete weaknesses; do not restate the proposal.\n\
-         - Prioritise critique that the peer can act on in a revision.\n\
-         \n\
-         Output contract:\n\
-         - Answer only with the critique body. No preamble."
-    )
-}
-
-fn system_prompt_revise(id: &str, specialty: &str) -> String {
-    format!(
-        "You are a specialist agent in the Underpass Choreographer.\n\
-         Your agent id is \"{id}\". Your specialty is \"{specialty}\".\n\
-         \n\
-         Role:\n\
-         - Revise your own proposal in response to the supplied critique.\n\
-         - Address the concrete points raised; keep what already works.\n\
-         \n\
-         Output contract:\n\
-         - Answer only with the revised proposal body. No preamble."
-    )
-}
-
-fn user_prompt_generate(request: &DraftRequest) -> String {
-    let rubric = serialize_rubric(&request.constraints);
-    let diverse_note = if request.diverse {
-        "You are one of several peers; propose a distinctive angle rather than a safest-seeming default."
-    } else {
-        "Propose the option you judge best on the merits."
-    };
-    format!(
-        "Task:\n{task}\n\n\
-         Rubric (opaque constraints to apply):\n{rubric}\n\n\
-         {diverse_note}\n\n\
-         Produce your proposal now.",
-        task = request.task.as_str(),
-    )
-}
-
-fn user_prompt_critique(peer_content: &str, constraints: &TaskConstraints) -> String {
-    let rubric = serialize_rubric(constraints);
-    format!(
-        "Peer proposal to critique:\n---\n{peer_content}\n---\n\n\
-         Rubric (opaque constraints to apply):\n{rubric}\n\n\
-         Critique it now."
-    )
-}
-
-fn user_prompt_revise(own_content: &str, critique: &Critique) -> String {
-    format!(
-        "Your previous proposal:\n---\n{own_content}\n---\n\n\
-         Critique to address:\n---\n{feedback}\n---\n\n\
-         Produce the revised proposal now.",
-        feedback = critique.feedback,
-    )
-}
-
-fn serialize_rubric(constraints: &TaskConstraints) -> String {
-    let rubric = constraints.rubric();
-    if rubric.is_empty() {
-        "(empty)".to_owned()
-    } else {
-        serde_json::to_string_pretty(rubric.as_map())
-            .unwrap_or_else(|_| "(unrepresentable)".to_owned())
     }
 }
 
@@ -486,7 +396,7 @@ fn classify_error(status: StatusCode) -> DomainError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use choreo_core::value_objects::{Attributes, Rounds, Rubric, TaskDescription};
+    use choreo_core::value_objects::{Rounds, Rubric, TaskDescription};
     use serde_json::json;
     use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -809,33 +719,6 @@ mod tests {
         assert_eq!(out.content, "the actual proposal");
     }
 
-    // --- prompt assembly (pure, no HTTP) --------------------------------
-
-    #[test]
-    fn system_prompt_is_domain_agnostic() {
-        let s = system_prompt_generate("a1", "triage");
-        assert!(s.contains("a1"));
-        assert!(s.contains("triage"));
-        // No SWE leakage.
-        for forbidden in ["story", "backlog", "sprint", "pull request"] {
-            assert!(
-                !s.to_lowercase().contains(forbidden),
-                "domain vocabulary leak: {forbidden}"
-            );
-        }
-    }
-
-    #[test]
-    fn rubric_serialization_handles_empty() {
-        let c = TaskConstraints::default();
-        assert_eq!(serialize_rubric(&c), "(empty)");
-    }
-
-    #[test]
-    fn attributes_import_is_visible() {
-        // Anchor for the `Attributes` import so cargo doesn't flag it
-        // as unused in this test module — it backs the proposal
-        // metadata flow in integration scenarios.
-        let _ = Attributes::empty();
-    }
+    // Prompt / rubric tests live in `super::prompts` — covered once,
+    // owned by the module that holds the shared helpers.
 }

--- a/crates/choreo-adapters/src/agents/mod.rs
+++ b/crates/choreo-adapters/src/agents/mod.rs
@@ -10,6 +10,23 @@
 //! `Debug` impls. Each provider adapter is expected to wrap its
 //! credentials in an opaque type that masks the value on formatting.
 
+// Shared infrastructure for provider adapters. `prompts` is reused
+// by every provider that speaks natural language (so all current
+// adapters); `openai_compat` is reused only by adapters that speak
+// the Chat Completions wire shape (OpenAI + vLLM, not Anthropic).
+//
+// Both are `pub(super)` (i.e. visible only within `agents::*`).
+
+#[cfg(any(
+    feature = "agent-anthropic",
+    feature = "agent-openai",
+    feature = "agent-vllm"
+))]
+mod prompts;
+
+#[cfg(any(feature = "agent-openai", feature = "agent-vllm"))]
+mod openai_compat;
+
 #[cfg(feature = "agent-anthropic")]
 pub mod anthropic;
 

--- a/crates/choreo-adapters/src/agents/openai.rs
+++ b/crates/choreo-adapters/src/agents/openai.rs
@@ -25,9 +25,23 @@ use choreo_core::entities::TaskConstraints;
 use choreo_core::error::DomainError;
 use choreo_core::ports::{AgentPort, Critique, DraftRequest, Revision};
 use choreo_core::value_objects::{AgentId, Specialty};
-use reqwest::{Client, StatusCode};
-use serde::{Deserialize, Serialize};
+use reqwest::Client;
 use tracing::{debug, warn};
+
+use super::openai_compat::{self as wire, ChatMessage, ChatRequest, ChatResponse, ErrorStrings};
+use super::prompts;
+
+/// Static error reasons for the OpenAI provider.
+const OPENAI_ERRORS: ErrorStrings = ErrorStrings {
+    unauthorized: "openai: unauthorized",
+    rate_limited: "openai: rate-limited",
+    bad_request: "openai: bad request",
+    upstream_error: "openai: upstream error",
+    malformed_body: "openai: malformed response body",
+    no_choices: "openai: no choices in response",
+    missing_content: "openai: choice has no message.content",
+    empty_content: "openai: empty text content",
+};
 
 const DEFAULT_ENDPOINT: &str = "https://api.openai.com";
 const DEFAULT_MODEL: &str = "gpt-4o-mini";
@@ -232,7 +246,7 @@ impl OpenAiAgent {
                 body = %body_text,
                 "openai: upstream returned non-success"
             );
-            return Err(classify_error(status));
+            return Err(wire::classify_error(status, &OPENAI_ERRORS));
         }
 
         let parsed: ChatResponse = response.json().await.map_err(|err| {
@@ -243,11 +257,11 @@ impl OpenAiAgent {
                 "openai: malformed response body"
             );
             DomainError::InvariantViolated {
-                reason: "openai: malformed response body",
+                reason: OPENAI_ERRORS.malformed_body,
             }
         })?;
 
-        extract_text(parsed).inspect_err(|_| {
+        wire::extract_text(parsed, &OPENAI_ERRORS).inspect_err(|_| {
             warn!(
                 op,
                 agent_id = self.id.as_str(),
@@ -268,8 +282,8 @@ impl AgentPort for OpenAiAgent {
     }
 
     async fn generate(&self, request: DraftRequest) -> Result<Revision, DomainError> {
-        let system = system_prompt_generate(self.id.as_str(), self.specialty.as_str());
-        let user = user_prompt_generate(&request);
+        let system = prompts::system_prompt_generate(self.id.as_str(), self.specialty.as_str());
+        let user = prompts::user_prompt_generate(&request);
         let content = self.complete(system, user, "generate").await?;
         Ok(Revision { content })
     }
@@ -279,8 +293,8 @@ impl AgentPort for OpenAiAgent {
         peer_content: &str,
         constraints: &TaskConstraints,
     ) -> Result<Critique, DomainError> {
-        let system = system_prompt_critique(self.id.as_str(), self.specialty.as_str());
-        let user = user_prompt_critique(peer_content, constraints);
+        let system = prompts::system_prompt_critique(self.id.as_str(), self.specialty.as_str());
+        let user = prompts::user_prompt_critique(peer_content, constraints);
         let feedback = self.complete(system, user, "critique").await?;
         Ok(Critique { feedback })
     }
@@ -290,179 +304,16 @@ impl AgentPort for OpenAiAgent {
         own_content: &str,
         critique: &Critique,
     ) -> Result<Revision, DomainError> {
-        let system = system_prompt_revise(self.id.as_str(), self.specialty.as_str());
-        let user = user_prompt_revise(own_content, critique);
+        let system = prompts::system_prompt_revise(self.id.as_str(), self.specialty.as_str());
+        let user = prompts::user_prompt_revise(own_content, critique);
         let content = self.complete(system, user, "revise").await?;
         Ok(Revision { content })
     }
 }
 
-// ---------------------------------------------------------------------------
-// Prompts (domain-agnostic; identical to the Anthropic adapter's set
-// on purpose — both providers see the same Choreographer voice)
-// ---------------------------------------------------------------------------
-
-fn system_prompt_generate(id: &str, specialty: &str) -> String {
-    format!(
-        "You are a specialist agent in the Underpass Choreographer.\n\
-         Your agent id is \"{id}\". Your specialty is \"{specialty}\".\n\
-         \n\
-         Role:\n\
-         - Propose a solution to the task, within your specialty.\n\
-         - Keep the proposal concrete, concise, and self-contained.\n\
-         - Do not claim capabilities you lack, do not invent facts.\n\
-         \n\
-         Output contract:\n\
-         - Answer only with the proposal body. No preamble, no signature."
-    )
-}
-
-fn system_prompt_critique(id: &str, specialty: &str) -> String {
-    format!(
-        "You are a specialist agent in the Underpass Choreographer.\n\
-         Your agent id is \"{id}\". Your specialty is \"{specialty}\".\n\
-         \n\
-         Role:\n\
-         - Critique a peer's proposal for this task.\n\
-         - Flag concrete weaknesses; do not restate the proposal.\n\
-         - Prioritise critique that the peer can act on in a revision.\n\
-         \n\
-         Output contract:\n\
-         - Answer only with the critique body. No preamble."
-    )
-}
-
-fn system_prompt_revise(id: &str, specialty: &str) -> String {
-    format!(
-        "You are a specialist agent in the Underpass Choreographer.\n\
-         Your agent id is \"{id}\". Your specialty is \"{specialty}\".\n\
-         \n\
-         Role:\n\
-         - Revise your own proposal in response to the supplied critique.\n\
-         - Address the concrete points raised; keep what already works.\n\
-         \n\
-         Output contract:\n\
-         - Answer only with the revised proposal body. No preamble."
-    )
-}
-
-fn user_prompt_generate(request: &DraftRequest) -> String {
-    let rubric = serialize_rubric(&request.constraints);
-    let diverse_note = if request.diverse {
-        "You are one of several peers; propose a distinctive angle rather than a safest-seeming default."
-    } else {
-        "Propose the option you judge best on the merits."
-    };
-    format!(
-        "Task:\n{task}\n\n\
-         Rubric (opaque constraints to apply):\n{rubric}\n\n\
-         {diverse_note}\n\n\
-         Produce your proposal now.",
-        task = request.task.as_str(),
-    )
-}
-
-fn user_prompt_critique(peer_content: &str, constraints: &TaskConstraints) -> String {
-    let rubric = serialize_rubric(constraints);
-    format!(
-        "Peer proposal to critique:\n---\n{peer_content}\n---\n\n\
-         Rubric (opaque constraints to apply):\n{rubric}\n\n\
-         Critique it now."
-    )
-}
-
-fn user_prompt_revise(own_content: &str, critique: &Critique) -> String {
-    format!(
-        "Your previous proposal:\n---\n{own_content}\n---\n\n\
-         Critique to address:\n---\n{feedback}\n---\n\n\
-         Produce the revised proposal now.",
-        feedback = critique.feedback,
-    )
-}
-
-fn serialize_rubric(constraints: &TaskConstraints) -> String {
-    let rubric = constraints.rubric();
-    if rubric.is_empty() {
-        "(empty)".to_owned()
-    } else {
-        serde_json::to_string_pretty(rubric.as_map())
-            .unwrap_or_else(|_| "(unrepresentable)".to_owned())
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Wire types
-// ---------------------------------------------------------------------------
-
-#[derive(Serialize)]
-struct ChatRequest<'a> {
-    model: &'a str,
-    max_tokens: u32,
-    messages: Vec<ChatMessage<'a>>,
-}
-
-#[derive(Serialize)]
-struct ChatMessage<'a> {
-    role: &'a str,
-    content: String,
-}
-
-#[derive(Deserialize)]
-struct ChatResponse {
-    #[serde(default)]
-    choices: Vec<ChatChoice>,
-}
-
-#[derive(Deserialize)]
-struct ChatChoice {
-    #[serde(default)]
-    message: Option<ChatResponseMessage>,
-}
-
-#[derive(Deserialize)]
-struct ChatResponseMessage {
-    #[serde(default)]
-    content: Option<String>,
-}
-
-fn extract_text(resp: ChatResponse) -> Result<String, DomainError> {
-    let first = resp
-        .choices
-        .into_iter()
-        .next()
-        .ok_or(DomainError::InvariantViolated {
-            reason: "openai: no choices in response",
-        })?;
-    let content = first
-        .message
-        .and_then(|m| m.content)
-        .ok_or(DomainError::InvariantViolated {
-            reason: "openai: choice has no message.content",
-        })?;
-    if content.trim().is_empty() {
-        return Err(DomainError::InvariantViolated {
-            reason: "openai: empty text content",
-        });
-    }
-    Ok(content)
-}
-
-fn classify_error(status: StatusCode) -> DomainError {
-    match status.as_u16() {
-        401 | 403 => DomainError::InvariantViolated {
-            reason: "openai: unauthorized",
-        },
-        429 => DomainError::InvariantViolated {
-            reason: "openai: rate-limited",
-        },
-        400..=499 => DomainError::InvariantViolated {
-            reason: "openai: bad request",
-        },
-        _ => DomainError::InvariantViolated {
-            reason: "openai: upstream error",
-        },
-    }
-}
+// Prompts live in `super::prompts`; wire types / extract_text /
+// classify_error live in `super::openai_compat`. This adapter only
+// carries its own config + auth + error labels.
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -780,24 +631,6 @@ mod tests {
         ));
     }
 
-    // --- prompt assembly -----------------------------------------------
-
-    #[test]
-    fn system_prompt_is_domain_agnostic() {
-        let s = system_prompt_generate("a1", "triage");
-        assert!(s.contains("a1"));
-        assert!(s.contains("triage"));
-        for forbidden in ["story", "backlog", "sprint", "pull request"] {
-            assert!(
-                !s.to_lowercase().contains(forbidden),
-                "domain vocabulary leak: {forbidden}"
-            );
-        }
-    }
-
-    #[test]
-    fn rubric_serialization_handles_empty() {
-        let c = TaskConstraints::default();
-        assert_eq!(serialize_rubric(&c), "(empty)");
-    }
+    // Prompt / rubric tests live in `super::prompts` — covered once,
+    // owned by the module that holds the shared helpers.
 }

--- a/crates/choreo-adapters/src/agents/openai_compat.rs
+++ b/crates/choreo-adapters/src/agents/openai_compat.rs
@@ -1,0 +1,275 @@
+//! Shared wire types and helpers for providers that speak the
+//! OpenAI Chat Completions shape (`POST /v1/chat/completions`).
+//!
+//! Two adapters live on top of this module today: `openai` (with
+//! mandatory bearer auth) and `vllm` (with optional bearer auth and
+//! different defaults). The wire format is identical for both; the
+//! difference is policy and configuration, which each adapter owns.
+//!
+//! Domain errors carry a `&'static str` reason, so the provider
+//! prefix cannot be formatted at runtime. Each adapter passes its
+//! own [`ErrorStrings`] table so the correct prefix lands in the
+//! error without requiring `String` allocations anywhere in the
+//! error path.
+
+use choreo_core::error::DomainError;
+use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
+
+/// Per-provider static error reasons.
+///
+/// Every adapter owns a `const` instance of this table and threads
+/// it through [`classify_error`] and [`extract_text`]. The constant
+/// makes it impossible to format a provider prefix at runtime —
+/// which is what keeps `DomainError::InvariantViolated { reason }`
+/// a `&'static str` across the board.
+pub(super) struct ErrorStrings {
+    pub unauthorized: &'static str,
+    pub rate_limited: &'static str,
+    pub bad_request: &'static str,
+    pub upstream_error: &'static str,
+    pub malformed_body: &'static str,
+    pub no_choices: &'static str,
+    pub missing_content: &'static str,
+    pub empty_content: &'static str,
+}
+
+// ---------------------------------------------------------------------------
+// Wire types
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+pub(super) struct ChatRequest<'a> {
+    pub model: &'a str,
+    pub max_tokens: u32,
+    pub messages: Vec<ChatMessage<'a>>,
+}
+
+#[derive(Serialize)]
+pub(super) struct ChatMessage<'a> {
+    pub role: &'a str,
+    pub content: String,
+}
+
+#[derive(Deserialize)]
+pub(super) struct ChatResponse {
+    #[serde(default)]
+    pub choices: Vec<ChatChoice>,
+}
+
+#[derive(Deserialize)]
+pub(super) struct ChatChoice {
+    #[serde(default)]
+    pub message: Option<ChatResponseMessage>,
+}
+
+#[derive(Deserialize)]
+pub(super) struct ChatResponseMessage {
+    #[serde(default)]
+    pub content: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Extract the first choice's text content. Rejects missing /
+/// empty / whitespace-only responses with provider-tagged errors.
+pub(super) fn extract_text(resp: ChatResponse, errs: &ErrorStrings) -> Result<String, DomainError> {
+    let first = resp
+        .choices
+        .into_iter()
+        .next()
+        .ok_or(DomainError::InvariantViolated {
+            reason: errs.no_choices,
+        })?;
+    let content = first
+        .message
+        .and_then(|m| m.content)
+        .ok_or(DomainError::InvariantViolated {
+            reason: errs.missing_content,
+        })?;
+    if content.trim().is_empty() {
+        return Err(DomainError::InvariantViolated {
+            reason: errs.empty_content,
+        });
+    }
+    Ok(content)
+}
+
+/// Classify an HTTP response status into a provider-tagged domain
+/// error. The status categories match both OpenAI and vLLM's
+/// observed behaviour.
+pub(super) fn classify_error(status: StatusCode, errs: &ErrorStrings) -> DomainError {
+    match status.as_u16() {
+        401 | 403 => DomainError::InvariantViolated {
+            reason: errs.unauthorized,
+        },
+        429 => DomainError::InvariantViolated {
+            reason: errs.rate_limited,
+        },
+        400..=499 => DomainError::InvariantViolated {
+            reason: errs.bad_request,
+        },
+        _ => DomainError::InvariantViolated {
+            reason: errs.upstream_error,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    const TEST_ERRS: ErrorStrings = ErrorStrings {
+        unauthorized: "test: unauthorized",
+        rate_limited: "test: rate-limited",
+        bad_request: "test: bad request",
+        upstream_error: "test: upstream error",
+        malformed_body: "test: malformed body",
+        no_choices: "test: no choices",
+        missing_content: "test: missing content",
+        empty_content: "test: empty content",
+    };
+
+    fn parse_response(value: serde_json::Value) -> ChatResponse {
+        serde_json::from_value(value).expect("valid ChatResponse json")
+    }
+
+    #[test]
+    fn extract_text_returns_content_on_happy_path() {
+        let resp = parse_response(json!({
+            "choices": [
+                {"message": {"role": "assistant", "content": "hello"}}
+            ]
+        }));
+        assert_eq!(extract_text(resp, &TEST_ERRS).unwrap(), "hello");
+    }
+
+    #[test]
+    fn extract_text_rejects_empty_choices() {
+        let resp = parse_response(json!({"choices": []}));
+        let err = extract_text(resp, &TEST_ERRS).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::InvariantViolated {
+                reason: "test: no choices"
+            }
+        ));
+    }
+
+    #[test]
+    fn extract_text_rejects_missing_message() {
+        let resp = parse_response(json!({
+            "choices": [{}]
+        }));
+        let err = extract_text(resp, &TEST_ERRS).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::InvariantViolated {
+                reason: "test: missing content"
+            }
+        ));
+    }
+
+    #[test]
+    fn extract_text_rejects_missing_content() {
+        let resp = parse_response(json!({
+            "choices": [{"message": {"role": "assistant"}}]
+        }));
+        let err = extract_text(resp, &TEST_ERRS).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::InvariantViolated {
+                reason: "test: missing content"
+            }
+        ));
+    }
+
+    #[test]
+    fn extract_text_rejects_whitespace_content() {
+        let resp = parse_response(json!({
+            "choices": [{"message": {"role": "assistant", "content": "   \n\t"}}]
+        }));
+        let err = extract_text(resp, &TEST_ERRS).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::InvariantViolated {
+                reason: "test: empty content"
+            }
+        ));
+    }
+
+    #[test]
+    fn classify_error_maps_401_to_unauthorized() {
+        assert!(matches!(
+            classify_error(StatusCode::from_u16(401).unwrap(), &TEST_ERRS),
+            DomainError::InvariantViolated {
+                reason: "test: unauthorized"
+            }
+        ));
+    }
+
+    #[test]
+    fn classify_error_maps_403_to_unauthorized() {
+        assert!(matches!(
+            classify_error(StatusCode::from_u16(403).unwrap(), &TEST_ERRS),
+            DomainError::InvariantViolated {
+                reason: "test: unauthorized"
+            }
+        ));
+    }
+
+    #[test]
+    fn classify_error_maps_429_to_rate_limited() {
+        assert!(matches!(
+            classify_error(StatusCode::TOO_MANY_REQUESTS, &TEST_ERRS),
+            DomainError::InvariantViolated {
+                reason: "test: rate-limited"
+            }
+        ));
+    }
+
+    #[test]
+    fn classify_error_maps_other_4xx_to_bad_request() {
+        for code in [400u16, 404, 422] {
+            let status = StatusCode::from_u16(code).unwrap();
+            assert!(
+                matches!(
+                    classify_error(status, &TEST_ERRS),
+                    DomainError::InvariantViolated {
+                        reason: "test: bad request"
+                    }
+                ),
+                "unexpected mapping for {code}",
+            );
+        }
+    }
+
+    #[test]
+    fn classify_error_maps_5xx_to_upstream() {
+        for code in [500u16, 502, 503] {
+            let status = StatusCode::from_u16(code).unwrap();
+            assert!(
+                matches!(
+                    classify_error(status, &TEST_ERRS),
+                    DomainError::InvariantViolated {
+                        reason: "test: upstream error"
+                    }
+                ),
+                "unexpected mapping for {code}",
+            );
+        }
+    }
+
+    /// `malformed_body` is carried by `ErrorStrings` but used by the
+    /// adapters when `response.json()` itself fails (before reaching
+    /// `extract_text`). Reference it here so the constant is not
+    /// flagged as unused under feature combinations that exclude
+    /// tests.
+    #[test]
+    fn error_strings_expose_malformed_body_label() {
+        assert_eq!(TEST_ERRS.malformed_body, "test: malformed body");
+    }
+}

--- a/crates/choreo-adapters/src/agents/prompts.rs
+++ b/crates/choreo-adapters/src/agents/prompts.rs
@@ -1,0 +1,191 @@
+//! Shared prompt builders for provider adapters.
+//!
+//! The Choreographer has a single voice across providers: every
+//! adapter speaks the same vocabulary of agent id, specialty, task,
+//! proposal, critique, revision. Keeping the prompts in one place
+//! ensures that divergence between providers is an explicit
+//! decision, not drift.
+//!
+//! Domain neutrality is enforced by a regression test below that
+//! scans the generated text for software-engineering vocabulary
+//! (story, backlog, sprint, pull request) — the kind of drift a
+//! copy-paste between providers would invite.
+//!
+//! All functions here are pure: given the same inputs they return
+//! the same `String`. No IO, no randomness.
+
+use choreo_core::entities::TaskConstraints;
+use choreo_core::ports::{Critique, DraftRequest};
+
+pub(super) fn system_prompt_generate(id: &str, specialty: &str) -> String {
+    format!(
+        "You are a specialist agent in the Underpass Choreographer.\n\
+         Your agent id is \"{id}\". Your specialty is \"{specialty}\".\n\
+         \n\
+         Role:\n\
+         - Propose a solution to the task, within your specialty.\n\
+         - Keep the proposal concrete, concise, and self-contained.\n\
+         - Do not claim capabilities you lack, do not invent facts.\n\
+         \n\
+         Output contract:\n\
+         - Answer only with the proposal body. No preamble, no signature."
+    )
+}
+
+pub(super) fn system_prompt_critique(id: &str, specialty: &str) -> String {
+    format!(
+        "You are a specialist agent in the Underpass Choreographer.\n\
+         Your agent id is \"{id}\". Your specialty is \"{specialty}\".\n\
+         \n\
+         Role:\n\
+         - Critique a peer's proposal for this task.\n\
+         - Flag concrete weaknesses; do not restate the proposal.\n\
+         - Prioritise critique that the peer can act on in a revision.\n\
+         \n\
+         Output contract:\n\
+         - Answer only with the critique body. No preamble."
+    )
+}
+
+pub(super) fn system_prompt_revise(id: &str, specialty: &str) -> String {
+    format!(
+        "You are a specialist agent in the Underpass Choreographer.\n\
+         Your agent id is \"{id}\". Your specialty is \"{specialty}\".\n\
+         \n\
+         Role:\n\
+         - Revise your own proposal in response to the supplied critique.\n\
+         - Address the concrete points raised; keep what already works.\n\
+         \n\
+         Output contract:\n\
+         - Answer only with the revised proposal body. No preamble."
+    )
+}
+
+pub(super) fn user_prompt_generate(request: &DraftRequest) -> String {
+    let rubric = serialize_rubric(&request.constraints);
+    let diverse_note = if request.diverse {
+        "You are one of several peers; propose a distinctive angle rather than a safest-seeming default."
+    } else {
+        "Propose the option you judge best on the merits."
+    };
+    format!(
+        "Task:\n{task}\n\n\
+         Rubric (opaque constraints to apply):\n{rubric}\n\n\
+         {diverse_note}\n\n\
+         Produce your proposal now.",
+        task = request.task.as_str(),
+    )
+}
+
+pub(super) fn user_prompt_critique(peer_content: &str, constraints: &TaskConstraints) -> String {
+    let rubric = serialize_rubric(constraints);
+    format!(
+        "Peer proposal to critique:\n---\n{peer_content}\n---\n\n\
+         Rubric (opaque constraints to apply):\n{rubric}\n\n\
+         Critique it now."
+    )
+}
+
+pub(super) fn user_prompt_revise(own_content: &str, critique: &Critique) -> String {
+    format!(
+        "Your previous proposal:\n---\n{own_content}\n---\n\n\
+         Critique to address:\n---\n{feedback}\n---\n\n\
+         Produce the revised proposal now.",
+        feedback = critique.feedback,
+    )
+}
+
+pub(super) fn serialize_rubric(constraints: &TaskConstraints) -> String {
+    let rubric = constraints.rubric();
+    if rubric.is_empty() {
+        "(empty)".to_owned()
+    } else {
+        serde_json::to_string_pretty(rubric.as_map())
+            .unwrap_or_else(|_| "(unrepresentable)".to_owned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn system_prompt_generate_is_domain_agnostic() {
+        let s = system_prompt_generate("a1", "triage");
+        assert!(s.contains("a1"));
+        assert!(s.contains("triage"));
+        for forbidden in ["story", "backlog", "sprint", "pull request"] {
+            assert!(
+                !s.to_lowercase().contains(forbidden),
+                "domain vocabulary leak: {forbidden}"
+            );
+        }
+    }
+
+    #[test]
+    fn system_prompts_address_their_specific_role() {
+        let g = system_prompt_generate("a", "x");
+        let c = system_prompt_critique("a", "x");
+        let r = system_prompt_revise("a", "x");
+        assert!(g.to_lowercase().contains("propose"));
+        assert!(c.to_lowercase().contains("critique"));
+        assert!(r.to_lowercase().contains("revise"));
+    }
+
+    #[test]
+    fn rubric_serialization_handles_empty() {
+        let c = TaskConstraints::default();
+        assert_eq!(serialize_rubric(&c), "(empty)");
+    }
+
+    #[test]
+    fn rubric_serialization_returns_json_for_populated_rubric() {
+        use choreo_core::value_objects::{NumAgents, Rounds, Rubric};
+        use serde_json::json;
+        use std::collections::BTreeMap;
+
+        let mut m = BTreeMap::new();
+        m.insert("rigor".to_owned(), json!("high"));
+        let rubric = Rubric::new(m).unwrap();
+        let c = TaskConstraints::new(
+            rubric,
+            Rounds::default(),
+            Some(NumAgents::new(3).unwrap()),
+            None,
+        );
+        let s = serialize_rubric(&c);
+        assert!(s.contains("rigor"));
+        assert!(s.contains("high"));
+    }
+
+    #[test]
+    fn user_prompt_generate_embeds_task_and_diversity_hint() {
+        use choreo_core::value_objects::TaskDescription;
+        let req = DraftRequest {
+            task: TaskDescription::new("describe the alert").unwrap(),
+            constraints: TaskConstraints::default(),
+            diverse: true,
+        };
+        let s = user_prompt_generate(&req);
+        assert!(s.contains("describe the alert"));
+        assert!(s.to_lowercase().contains("distinctive angle"));
+    }
+
+    #[test]
+    fn user_prompt_critique_embeds_peer_content() {
+        let s = user_prompt_critique("the peer's proposal body", &TaskConstraints::default());
+        assert!(s.contains("the peer's proposal body"));
+    }
+
+    #[test]
+    fn user_prompt_revise_embeds_own_content_and_feedback() {
+        let s = user_prompt_revise(
+            "v1 body",
+            &Critique {
+                feedback: "tighten the rubric".to_owned(),
+            },
+        );
+        assert!(s.contains("v1 body"));
+        assert!(s.contains("tighten the rubric"));
+    }
+}

--- a/crates/choreo-adapters/src/agents/vllm.rs
+++ b/crates/choreo-adapters/src/agents/vllm.rs
@@ -28,9 +28,23 @@ use choreo_core::entities::TaskConstraints;
 use choreo_core::error::DomainError;
 use choreo_core::ports::{AgentPort, Critique, DraftRequest, Revision};
 use choreo_core::value_objects::{AgentId, Specialty};
-use reqwest::{Client, RequestBuilder, StatusCode};
-use serde::{Deserialize, Serialize};
+use reqwest::{Client, RequestBuilder};
 use tracing::{debug, warn};
+
+use super::openai_compat::{self as wire, ChatMessage, ChatRequest, ChatResponse, ErrorStrings};
+use super::prompts;
+
+/// Static error reasons for the vLLM provider.
+const VLLM_ERRORS: ErrorStrings = ErrorStrings {
+    unauthorized: "vllm: unauthorized",
+    rate_limited: "vllm: rate-limited",
+    bad_request: "vllm: bad request",
+    upstream_error: "vllm: upstream error",
+    malformed_body: "vllm: malformed response body",
+    no_choices: "vllm: no choices in response",
+    missing_content: "vllm: choice has no message.content",
+    empty_content: "vllm: empty text content",
+};
 
 const DEFAULT_ENDPOINT: &str = "http://vllm-server:8000";
 const DEFAULT_MAX_TOKENS: u32 = 1024;
@@ -232,7 +246,7 @@ impl VllmAgent {
                 body = %body_text,
                 "vllm: upstream returned non-success"
             );
-            return Err(classify_error(status));
+            return Err(wire::classify_error(status, &VLLM_ERRORS));
         }
 
         let parsed: ChatResponse = response.json().await.map_err(|err| {
@@ -243,11 +257,11 @@ impl VllmAgent {
                 "vllm: malformed response body"
             );
             DomainError::InvariantViolated {
-                reason: "vllm: malformed response body",
+                reason: VLLM_ERRORS.malformed_body,
             }
         })?;
 
-        extract_text(parsed).inspect_err(|_| {
+        wire::extract_text(parsed, &VLLM_ERRORS).inspect_err(|_| {
             warn!(op, agent_id = self.id.as_str(), "vllm: empty text content");
         })
     }
@@ -264,8 +278,8 @@ impl AgentPort for VllmAgent {
     }
 
     async fn generate(&self, request: DraftRequest) -> Result<Revision, DomainError> {
-        let system = system_prompt_generate(self.id.as_str(), self.specialty.as_str());
-        let user = user_prompt_generate(&request);
+        let system = prompts::system_prompt_generate(self.id.as_str(), self.specialty.as_str());
+        let user = prompts::user_prompt_generate(&request);
         let content = self.complete(system, user, "generate").await?;
         Ok(Revision { content })
     }
@@ -275,8 +289,8 @@ impl AgentPort for VllmAgent {
         peer_content: &str,
         constraints: &TaskConstraints,
     ) -> Result<Critique, DomainError> {
-        let system = system_prompt_critique(self.id.as_str(), self.specialty.as_str());
-        let user = user_prompt_critique(peer_content, constraints);
+        let system = prompts::system_prompt_critique(self.id.as_str(), self.specialty.as_str());
+        let user = prompts::user_prompt_critique(peer_content, constraints);
         let feedback = self.complete(system, user, "critique").await?;
         Ok(Critique { feedback })
     }
@@ -286,183 +300,16 @@ impl AgentPort for VllmAgent {
         own_content: &str,
         critique: &Critique,
     ) -> Result<Revision, DomainError> {
-        let system = system_prompt_revise(self.id.as_str(), self.specialty.as_str());
-        let user = user_prompt_revise(own_content, critique);
+        let system = prompts::system_prompt_revise(self.id.as_str(), self.specialty.as_str());
+        let user = prompts::user_prompt_revise(own_content, critique);
         let content = self.complete(system, user, "revise").await?;
         Ok(Revision { content })
     }
 }
 
-// ---------------------------------------------------------------------------
-// Prompts (domain-agnostic, identical in shape to openai / anthropic)
-//
-// Deliberately duplicated across the three providers today. A follow-up
-// refactor slice extracts them into `agents::prompts` once the
-// divergence pressure proves stable to zero — keeping them local keeps
-// each provider PR reviewable in isolation.
-// ---------------------------------------------------------------------------
-
-fn system_prompt_generate(id: &str, specialty: &str) -> String {
-    format!(
-        "You are a specialist agent in the Underpass Choreographer.\n\
-         Your agent id is \"{id}\". Your specialty is \"{specialty}\".\n\
-         \n\
-         Role:\n\
-         - Propose a solution to the task, within your specialty.\n\
-         - Keep the proposal concrete, concise, and self-contained.\n\
-         - Do not claim capabilities you lack, do not invent facts.\n\
-         \n\
-         Output contract:\n\
-         - Answer only with the proposal body. No preamble, no signature."
-    )
-}
-
-fn system_prompt_critique(id: &str, specialty: &str) -> String {
-    format!(
-        "You are a specialist agent in the Underpass Choreographer.\n\
-         Your agent id is \"{id}\". Your specialty is \"{specialty}\".\n\
-         \n\
-         Role:\n\
-         - Critique a peer's proposal for this task.\n\
-         - Flag concrete weaknesses; do not restate the proposal.\n\
-         - Prioritise critique that the peer can act on in a revision.\n\
-         \n\
-         Output contract:\n\
-         - Answer only with the critique body. No preamble."
-    )
-}
-
-fn system_prompt_revise(id: &str, specialty: &str) -> String {
-    format!(
-        "You are a specialist agent in the Underpass Choreographer.\n\
-         Your agent id is \"{id}\". Your specialty is \"{specialty}\".\n\
-         \n\
-         Role:\n\
-         - Revise your own proposal in response to the supplied critique.\n\
-         - Address the concrete points raised; keep what already works.\n\
-         \n\
-         Output contract:\n\
-         - Answer only with the revised proposal body. No preamble."
-    )
-}
-
-fn user_prompt_generate(request: &DraftRequest) -> String {
-    let rubric = serialize_rubric(&request.constraints);
-    let diverse_note = if request.diverse {
-        "You are one of several peers; propose a distinctive angle rather than a safest-seeming default."
-    } else {
-        "Propose the option you judge best on the merits."
-    };
-    format!(
-        "Task:\n{task}\n\n\
-         Rubric (opaque constraints to apply):\n{rubric}\n\n\
-         {diverse_note}\n\n\
-         Produce your proposal now.",
-        task = request.task.as_str(),
-    )
-}
-
-fn user_prompt_critique(peer_content: &str, constraints: &TaskConstraints) -> String {
-    let rubric = serialize_rubric(constraints);
-    format!(
-        "Peer proposal to critique:\n---\n{peer_content}\n---\n\n\
-         Rubric (opaque constraints to apply):\n{rubric}\n\n\
-         Critique it now."
-    )
-}
-
-fn user_prompt_revise(own_content: &str, critique: &Critique) -> String {
-    format!(
-        "Your previous proposal:\n---\n{own_content}\n---\n\n\
-         Critique to address:\n---\n{feedback}\n---\n\n\
-         Produce the revised proposal now.",
-        feedback = critique.feedback,
-    )
-}
-
-fn serialize_rubric(constraints: &TaskConstraints) -> String {
-    let rubric = constraints.rubric();
-    if rubric.is_empty() {
-        "(empty)".to_owned()
-    } else {
-        serde_json::to_string_pretty(rubric.as_map())
-            .unwrap_or_else(|_| "(unrepresentable)".to_owned())
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Wire types (identical to openai::ChatRequest / ChatResponse)
-// ---------------------------------------------------------------------------
-
-#[derive(Serialize)]
-struct ChatRequest<'a> {
-    model: &'a str,
-    max_tokens: u32,
-    messages: Vec<ChatMessage<'a>>,
-}
-
-#[derive(Serialize)]
-struct ChatMessage<'a> {
-    role: &'a str,
-    content: String,
-}
-
-#[derive(Deserialize)]
-struct ChatResponse {
-    #[serde(default)]
-    choices: Vec<ChatChoice>,
-}
-
-#[derive(Deserialize)]
-struct ChatChoice {
-    #[serde(default)]
-    message: Option<ChatResponseMessage>,
-}
-
-#[derive(Deserialize)]
-struct ChatResponseMessage {
-    #[serde(default)]
-    content: Option<String>,
-}
-
-fn extract_text(resp: ChatResponse) -> Result<String, DomainError> {
-    let first = resp
-        .choices
-        .into_iter()
-        .next()
-        .ok_or(DomainError::InvariantViolated {
-            reason: "vllm: no choices in response",
-        })?;
-    let content = first
-        .message
-        .and_then(|m| m.content)
-        .ok_or(DomainError::InvariantViolated {
-            reason: "vllm: choice has no message.content",
-        })?;
-    if content.trim().is_empty() {
-        return Err(DomainError::InvariantViolated {
-            reason: "vllm: empty text content",
-        });
-    }
-    Ok(content)
-}
-
-fn classify_error(status: StatusCode) -> DomainError {
-    match status.as_u16() {
-        401 | 403 => DomainError::InvariantViolated {
-            reason: "vllm: unauthorized",
-        },
-        429 => DomainError::InvariantViolated {
-            reason: "vllm: rate-limited",
-        },
-        400..=499 => DomainError::InvariantViolated {
-            reason: "vllm: bad request",
-        },
-        _ => DomainError::InvariantViolated {
-            reason: "vllm: upstream error",
-        },
-    }
-}
+// Prompts live in `super::prompts`; wire types / extract_text /
+// classify_error live in `super::openai_compat`. This adapter only
+// carries its own config + optional-auth policy + error labels.
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -818,18 +665,6 @@ mod tests {
         ));
     }
 
-    // --- prompt assembly -----------------------------------------------
-
-    #[test]
-    fn system_prompt_is_domain_agnostic() {
-        let s = system_prompt_generate("a1", "triage");
-        assert!(s.contains("a1"));
-        assert!(s.contains("triage"));
-        for forbidden in ["story", "backlog", "sprint", "pull request"] {
-            assert!(
-                !s.to_lowercase().contains(forbidden),
-                "domain vocabulary leak: {forbidden}"
-            );
-        }
-    }
+    // Prompt / rubric tests live in `super::prompts` — covered once,
+    // owned by the module that holds the shared helpers.
 }


### PR DESCRIPTION
## Summary

Pure refactor. No behavioural change, no new features. Closes the
deliberate duplication across the three agent provider adapters
(Anthropic, OpenAI, vLLM) that each PR flagged as "extract once the
trio lands".

## What moved

### \`agents/prompts.rs\` (new)

The 7 domain-agnostic prompt builders:

- \`system_prompt_{generate,critique,revise}\`
- \`user_prompt_{generate,critique,revise}\`
- \`serialize_rubric\`

Gated by \`any(feature = "agent-anthropic", "agent-openai",
"agent-vllm")\`. All helpers are \`pub(super)\` — only sibling
modules under \`agents::\` see them.

### \`agents/openai_compat.rs\` (new)

Chat Completions wire types (\`ChatRequest\`, \`ChatMessage\`,
\`ChatResponse\`, \`ChatChoice\`, \`ChatResponseMessage\`),
\`extract_text\`, \`classify_error\`. Shared between OpenAI and vLLM
which speak the same wire. Gated by \`any(feature = "agent-openai",
"agent-vllm")\`.

### \`ErrorStrings\`

Small struct with the provider-tagged \`&'static str\` reasons each
adapter ships as a \`const\`. Keeps
\`DomainError::InvariantViolated { reason: &'static str }\` across
the board — no runtime formatting, no allocations in the error
path — while still letting \`tracing\` logs carry the provider
prefix.

## Adapters shrink to their real responsibility

| Adapter | What stays local |
|---|---|
| \`anthropic\` | Its Messages-API wire (different from OpenAI), bearer auth, error labels |
| \`openai\` | Bearer auth, error labels |
| \`vllm\` | Optional-bearer policy, cluster defaults, error labels |

Local prompt builders, Chat Completions wire types, and
\`extract_text\` / \`classify_error\` deleted from OpenAI and vLLM.
Deletions: ~600 lines across the two files; net code movement is
negative.

## Tests

- Prompt / rubric tests moved to \`agents::prompts::tests\` —
  covered once in the module that owns them.
- 11 new tests on \`agents::openai_compat::tests\` cover
  \`extract_text\` across all failure modes and \`classify_error\`
  across all status categories.
- Every existing adapter test passes **unchanged** — this is the
  proof of behavioural equivalence.

## Honesty & Evidence

- **292 unit tests pass** (128 core + 12 app + 147 adapters + 5
  binary). Net +12 vs 280 on main, because the new shared-module
  tests outweigh the 6 duplicated prompt / anchor tests I removed.
- \`cargo fmt\` + \`cargo clippy --features
  choreo-adapters/agent-anthropic --features
  choreo-adapters/agent-openai --features
  choreo-adapters/agent-vllm -D warnings\` clean.
- Domain-agnostic prompt regression still enforced by the single
  test in \`prompts.rs\`.
- \`DomainError\` shape unchanged. Every public API on every
  adapter keeps its signature.

## Contract Impact

- [x] No proto / AsyncAPI / Helm chart / core changes.

## Architecture Review

- [x] DDD + HEX preserved.
- [x] SRP improved — each adapter now owns only auth policy +
      config + error labels + (for Anthropic) its own wire.
- [x] DRY applied where identity was already proven; intentional
      local wire kept for Anthropic because it is genuinely a
      different shape.
- [x] No behaviour changes — safety net is the full adapter test
      suite from #11, #12, #13.