### PR TITLE
feat(observability): phase 8a — HTTP health endpoints and proper k8s probes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,8 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
+ "hyper",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -153,10 +155,15 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper",
+ "tokio",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -177,6 +184,7 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -318,16 +326,19 @@ dependencies = [
  "anyhow",
  "async-nats",
  "async-trait",
+ "axum",
  "choreo-adapters",
  "choreo-app",
  "choreo-core",
  "choreo-proto",
  "figment",
  "serde",
+ "serde_json",
  "thiserror 1.0.69",
  "time",
  "tokio",
  "tonic",
+ "tower 0.4.13",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -2347,6 +2358,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2961,6 +2983,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2999,6 +3022,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/charts/choreographer/templates/deployment.yaml
+++ b/charts/choreographer/templates/deployment.yaml
@@ -38,9 +38,14 @@ spec:
             - name: grpc
               containerPort: {{ .Values.config.grpcPort }}
               protocol: TCP
+            - name: http
+              containerPort: {{ .Values.config.httpPort }}
+              protocol: TCP
           env:
             - name: CHOREO_GRPC_PORT
               value: {{ .Values.config.grpcPort | quote }}
+            - name: CHOREO_HTTP_PORT
+              value: {{ .Values.config.httpPort | quote }}
             - name: RUST_LOG
               value: {{ .Values.config.logLevel | quote }}
             {{- if .Values.messaging.nats.enabled }}
@@ -62,15 +67,17 @@ spec:
             {{- end }}
           {{- if .Values.probes.liveness.enabled }}
           livenessProbe:
-            tcpSocket:
-              port: grpc
+            httpGet:
+              path: /healthz
+              port: http
             initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
           {{- end }}
           {{- if .Values.probes.readiness.enabled }}
           readinessProbe:
-            tcpSocket:
-              port: grpc
+            httpGet:
+              path: /readyz
+              port: http
             initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
           {{- end }}

--- a/charts/choreographer/templates/service.yaml
+++ b/charts/choreographer/templates/service.yaml
@@ -16,5 +16,10 @@ spec:
       targetPort: grpc
       protocol: TCP
       appProtocol: grpc
+    - name: http
+      port: {{ .Values.service.httpPort }}
+      targetPort: http
+      protocol: TCP
+      appProtocol: http
   selector:
     {{- include "choreographer.selectorLabels" . | nindent 4 }}

--- a/charts/choreographer/values.yaml
+++ b/charts/choreographer/values.yaml
@@ -38,7 +38,11 @@ securityContext:
 
 service:
   type: ClusterIP
+  # gRPC is the product surface; HTTP carries only health endpoints
+  # (and, eventually, metrics). Both land on a single Service with
+  # two named ports so probes can hit HTTP without any DNS games.
   port: 50055
+  httpPort: 8080
   annotations: {}
 
 resources:
@@ -73,6 +77,9 @@ affinity: {}
 # through the `AgentPort` trait.
 config:
   grpcPort: 50055
+  # The service exposes HTTP on a separate port for health probes
+  # and future metrics. Kept small, plaintext, cluster-internal.
+  httpPort: 8080
   logLevel: info
   # Optional startup seeding. Comma-separated list of specialty
   # labels: for each one the binary registers a deterministic

--- a/crates/choreo-adapters/src/config.rs
+++ b/crates/choreo-adapters/src/config.rs
@@ -40,6 +40,7 @@ impl EnvConfiguration {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct Defaults {
     grpc_port: u16,
+    http_port: u16,
     nats_enabled: bool,
     nats_url: String,
     trigger_subject: String,
@@ -50,6 +51,7 @@ impl Default for Defaults {
     fn default() -> Self {
         Self {
             grpc_port: 50055,
+            http_port: 8080,
             nats_enabled: true,
             nats_url: "nats://nats:4222".to_owned(),
             trigger_subject: "choreo.trigger.>".to_owned(),
@@ -73,6 +75,7 @@ impl ConfigurationPort for EnvConfiguration {
 
         Ok(ServiceConfig {
             grpc_port: loaded.grpc_port,
+            http_port: loaded.http_port,
             nats_enabled: loaded.nats_enabled,
             nats_url: loaded.nats_url,
             trigger_subject: loaded.trigger_subject,
@@ -106,6 +109,7 @@ mod tests {
 
         let cfg = EnvConfiguration::new().load().await.unwrap();
         assert_eq!(cfg.grpc_port, 50055);
+        assert_eq!(cfg.http_port, 8080);
         assert!(cfg.nats_enabled);
         assert_eq!(cfg.nats_url, "nats://nats:4222");
         assert_eq!(cfg.trigger_subject, "choreo.trigger.>");

--- a/crates/choreo-core/src/ports/configuration.rs
+++ b/crates/choreo-core/src/ports/configuration.rs
@@ -12,6 +12,7 @@ use crate::error::DomainError;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ServiceConfig {
     pub grpc_port: u16,
+    pub http_port: u16,
     pub nats_enabled: bool,
     pub nats_url: String,
     pub trigger_subject: String,

--- a/crates/choreo/Cargo.toml
+++ b/crates/choreo/Cargo.toml
@@ -27,6 +27,7 @@ choreo-proto = { workspace = true }
 
 async-nats = { workspace = true }
 async-trait = { workspace = true }
+axum = "0.7"
 thiserror = { workspace = true }
 time = { workspace = true }
 uuid = { workspace = true }
@@ -37,3 +38,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 figment = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+tower = { version = "0.4", features = ["util"] }

--- a/crates/choreo/src/compose.rs
+++ b/crates/choreo/src/compose.rs
@@ -33,6 +33,7 @@ pub struct Application {
     pub repository: Arc<InMemoryDeliberationRepository>,
     pub grpc_service: choreo_adapters::grpc::ChoreographerGrpcService,
     pub nats_subscriber: Option<NatsTriggerSubscriber>,
+    pub health_state: crate::health::HealthState,
 }
 
 impl std::fmt::Debug for Application {
@@ -82,7 +83,11 @@ pub async fn compose() -> Result<Application, ComposeError> {
     let scoring: Arc<dyn ScoringPort> = Arc::new(UniformScoring::new());
     let executor: Arc<dyn ExecutorPort> = Arc::new(NoopExecutor::new());
 
-    let (messaging, nats_subscriber_factory) = wire_messaging(&service_config).await?;
+    let MessagingWiring {
+        port: messaging,
+        subscriber_factory: nats_subscriber_factory,
+        nats_client,
+    } = wire_messaging(&service_config).await?;
 
     let deliberate = Arc::new(DeliberateUseCase::new(
         clock.clone(),
@@ -139,8 +144,11 @@ pub async fn compose() -> Result<Application, ComposeError> {
         .auto_dispatch(auto_dispatch)
         .build()?;
 
+    let health_state = crate::health::HealthState::new(nats_client, env!("CARGO_PKG_VERSION"));
+
     info!(
         grpc_port = service_config.grpc_port,
+        http_port = service_config.http_port,
         nats_enabled = service_config.nats_enabled,
         trigger_subject = service_config.trigger_subject.as_str(),
         "choreographer wired"
@@ -153,6 +161,7 @@ pub async fn compose() -> Result<Application, ComposeError> {
         repository,
         grpc_service,
         nats_subscriber,
+        health_state,
     })
 }
 
@@ -190,29 +199,46 @@ async fn connect_nats_with_retry(
     })))
 }
 
-async fn wire_messaging(
-    cfg: &ServiceConfig,
-) -> Result<(Arc<dyn MessagingPort>, Option<SubscriberFactory>), ComposeError> {
+/// Everything `compose` needs out of the messaging wiring phase:
+/// the port implementation that use cases talk through, a factory
+/// for the inbound subscriber, and — when NATS is wired — a handle
+/// to the live client so the health endpoints can probe it.
+struct MessagingWiring {
+    port: Arc<dyn MessagingPort>,
+    subscriber_factory: Option<SubscriberFactory>,
+    nats_client: Option<async_nats::Client>,
+}
+
+async fn wire_messaging(cfg: &ServiceConfig) -> Result<MessagingWiring, ComposeError> {
     if !cfg.nats_enabled {
         info!("nats disabled; using noop messaging");
-        let messaging: Arc<dyn MessagingPort> = Arc::new(NoopMessaging::new());
-        return Ok((messaging, None));
+        let port: Arc<dyn MessagingPort> = Arc::new(NoopMessaging::new());
+        return Ok(MessagingWiring {
+            port,
+            subscriber_factory: None,
+            nats_client: None,
+        });
     }
 
     let nats_cfg = NatsConfig::new(&cfg.nats_url, &cfg.publish_prefix, &cfg.trigger_subject)?;
     let client = connect_nats_with_retry(&nats_cfg.url, NATS_CONNECT_BUDGET).await?;
     info!(url = nats_cfg.url.as_str(), "nats connected");
 
-    let messaging: Arc<dyn MessagingPort> = Arc::new(NatsMessaging::new(
+    let port: Arc<dyn MessagingPort> = Arc::new(NatsMessaging::new(
         client.clone(),
         nats_cfg.subjects.clone(),
     ));
 
     let subjects = nats_cfg.subjects.clone();
-    let factory: SubscriberFactory =
-        Box::new(move |dispatch| NatsTriggerSubscriber::new(client, subjects, dispatch));
+    let factory_client = client.clone();
+    let subscriber_factory: SubscriberFactory =
+        Box::new(move |dispatch| NatsTriggerSubscriber::new(factory_client, subjects, dispatch));
 
-    Ok((messaging, Some(factory)))
+    Ok(MessagingWiring {
+        port,
+        subscriber_factory: Some(subscriber_factory),
+        nats_client: Some(client),
+    })
 }
 
 #[cfg(test)]

--- a/crates/choreo/src/health.rs
+++ b/crates/choreo/src/health.rs
@@ -1,0 +1,281 @@
+//! HTTP health endpoints for Kubernetes probes and human operators.
+//!
+//! Two routes, both returning JSON:
+//!
+//! - `GET /healthz` — liveness. Returns `200 OK` as long as the
+//!   async runtime is responsive. Never checks external
+//!   dependencies: killing the pod when NATS is down does not fix
+//!   anything.
+//! - `GET /readyz` — readiness. Checks that every external
+//!   dependency the composition root wired is presently reachable
+//!   (NATS via `connection_state()` when enabled). Returns `200 OK`
+//!   when every check passes, `503 Service Unavailable` with a JSON
+//!   body listing the failing components otherwise.
+//!
+//! The module is transport-only: it builds an [`axum::Router`]
+//! given a [`HealthState`]. Composition and lifecycle belong to
+//! [`crate::runtime`].
+
+use std::sync::Arc;
+
+use async_nats::connection::State as NatsConnectionState;
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::get,
+    Json, Router,
+};
+use serde::Serialize;
+
+/// Read-only handles the health endpoints need. Cloning a
+/// `HealthState` is cheap — every inner handle is already an `Arc`
+/// or a lightweight client.
+#[derive(Clone, Default)]
+pub struct HealthState {
+    /// `Some` when NATS messaging was wired at composition time.
+    /// `None` when the service is running with `NoopMessaging`; in
+    /// that case readiness never fails on NATS.
+    nats: Option<async_nats::Client>,
+    service_version: Arc<str>,
+}
+
+impl std::fmt::Debug for HealthState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HealthState")
+            .field("nats_wired", &self.nats.is_some())
+            .field("service_version", &self.service_version)
+            .finish()
+    }
+}
+
+impl HealthState {
+    #[must_use]
+    pub fn new(nats: Option<async_nats::Client>, service_version: impl Into<String>) -> Self {
+        Self {
+            nats,
+            service_version: Arc::from(service_version.into().into_boxed_str()),
+        }
+    }
+}
+
+/// Build the health router. Mount it alongside the gRPC server on
+/// the HTTP port.
+pub fn router(state: HealthState) -> Router {
+    Router::new()
+        .route("/healthz", get(healthz))
+        .route("/readyz", get(readyz))
+        .with_state(state)
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct LivenessBody {
+    status: &'static str,
+    service: &'static str,
+    version: String,
+}
+
+async fn healthz(State(state): State<HealthState>) -> impl IntoResponse {
+    // Liveness must never consult external deps.
+    Json(LivenessBody {
+        status: "alive",
+        service: "underpass-choreographer",
+        version: state.service_version.as_ref().to_owned(),
+    })
+}
+
+#[derive(Serialize)]
+struct ReadinessBody {
+    status: &'static str,
+    service: &'static str,
+    version: String,
+    checks: Vec<CheckResult>,
+}
+
+#[derive(Serialize)]
+struct CheckResult {
+    name: &'static str,
+    healthy: bool,
+    detail: &'static str,
+}
+
+async fn readyz(State(state): State<HealthState>) -> Response {
+    let mut checks = Vec::new();
+
+    match &state.nats {
+        Some(client) => checks.push(check_nats(client)),
+        None => checks.push(CheckResult {
+            name: "nats",
+            healthy: true,
+            detail: "not wired (noop messaging)",
+        }),
+    }
+
+    let ready = checks.iter().all(|c| c.healthy);
+    let body = ReadinessBody {
+        status: if ready { "ready" } else { "not-ready" },
+        service: "underpass-choreographer",
+        version: state.service_version.as_ref().to_owned(),
+        checks,
+    };
+    let code = if ready {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    (code, Json(body)).into_response()
+}
+
+fn check_nats(client: &async_nats::Client) -> CheckResult {
+    match client.connection_state() {
+        NatsConnectionState::Connected => CheckResult {
+            name: "nats",
+            healthy: true,
+            detail: "connected",
+        },
+        NatsConnectionState::Pending => CheckResult {
+            name: "nats",
+            healthy: false,
+            detail: "connection pending",
+        },
+        NatsConnectionState::Disconnected => CheckResult {
+            name: "nats",
+            healthy: false,
+            detail: "disconnected",
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use serde_json::Value;
+    use tower::ServiceExt; // for `oneshot`
+
+    async fn body_json(resp: Response) -> Value {
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("body bytes");
+        serde_json::from_slice(&bytes).expect("valid json")
+    }
+
+    #[tokio::test]
+    async fn healthz_returns_200_with_alive_status() {
+        let app = router(HealthState::new(None, "0.1.0"));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/healthz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["status"], "alive");
+        assert_eq!(body["service"], "underpass-choreographer");
+        assert_eq!(body["version"], "0.1.0");
+    }
+
+    #[tokio::test]
+    async fn readyz_without_nats_returns_200_and_reports_not_wired() {
+        let app = router(HealthState::new(None, "0.1.0"));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/readyz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["status"], "ready");
+        let checks = body["checks"].as_array().unwrap();
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0]["name"], "nats");
+        assert_eq!(checks[0]["healthy"], true);
+        assert_eq!(checks[0]["detail"], "not wired (noop messaging)");
+    }
+
+    #[tokio::test]
+    async fn healthz_ignores_nats_state() {
+        // Even with a NATS client present, /healthz must not depend
+        // on NATS reachability — that is readiness's job. We cannot
+        // easily build a real `async_nats::Client` without a server
+        // here, so this test proves the route path independence by
+        // hitting /healthz with `None` and asserting response shape.
+        // The structural invariant is enforced by the implementation
+        // of `healthz` never touching `state.nats`.
+        let app = router(HealthState::new(None, "9.9.9"));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/healthz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["version"], "9.9.9");
+    }
+
+    #[tokio::test]
+    async fn unknown_route_is_404() {
+        let app = router(HealthState::new(None, "0.1.0"));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/nonexistent")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn post_to_healthz_is_method_not_allowed() {
+        let app = router(HealthState::new(None, "0.1.0"));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/healthz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    #[test]
+    fn health_state_debug_does_not_expose_secrets() {
+        // Paranoia: make sure nothing sensitive sneaks into the
+        // Debug output. Right now there are no secrets here, but
+        // this test locks the invariant as the state grows.
+        let state = HealthState::new(None, "0.1.0");
+        let shown = format!("{state:?}");
+        assert!(shown.contains("HealthState"));
+        assert!(shown.contains("nats_wired"));
+        assert!(!shown.to_lowercase().contains("secret"));
+        assert!(!shown.to_lowercase().contains("token"));
+        assert!(!shown.to_lowercase().contains("api_key"));
+    }
+}

--- a/crates/choreo/src/lib.rs
+++ b/crates/choreo/src/lib.rs
@@ -6,8 +6,10 @@
 //! be unit-tested without starting a server.
 
 pub mod compose;
+pub mod health;
 pub mod runtime;
 pub mod seeding;
 
 pub use compose::{compose, Application, ComposeError};
+pub use health::{router as health_router, HealthState};
 pub use runtime::serve;

--- a/crates/choreo/src/runtime.rs
+++ b/crates/choreo/src/runtime.rs
@@ -1,27 +1,39 @@
-//! gRPC server lifecycle.
+//! gRPC + HTTP server lifecycle.
 //!
-//! [`serve`] takes a composed [`Application`] and runs the server
-//! until a shutdown signal is received. Kept separate from
-//! [`crate::compose`] so wiring and lifetime are each
-//! unit-testable.
+//! [`serve`] takes a composed [`Application`] and runs two servers
+//! concurrently until a shutdown signal is received:
+//!
+//! - The gRPC server (`ChoreographerService`) on
+//!   `CHOREO_GRPC_PORT` (default 50055).
+//! - The HTTP server exposing `/healthz` and `/readyz` on
+//!   `CHOREO_HTTP_PORT` (default 8080).
+//!
+//! Both share the same shutdown signal (SIGTERM or SIGINT).
+//! Returning the first error wins; diagnostics on the other servers
+//! come through tracing.
 
 use std::net::SocketAddr;
 
 use anyhow::{Context, Result};
 use tokio::signal::unix::{signal, SignalKind};
+use tokio::sync::watch;
 use tracing::{error, info};
 
 use crate::compose::Application;
 
-/// Bind the gRPC server, spawn the optional NATS subscriber, and
-/// serve until SIGTERM or SIGINT.
+/// Bind gRPC + HTTP, spawn the optional NATS subscriber, and serve
+/// until SIGTERM or SIGINT.
 pub async fn serve(app: Application) -> Result<()> {
     let Application {
         service_config,
         grpc_service,
         nats_subscriber,
+        health_state,
         ..
     } = app;
+
+    // Shutdown channel: a single send triggers both servers.
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
     let subscriber_handle = match nats_subscriber {
         Some(subscriber) => Some(
@@ -33,7 +45,7 @@ pub async fn serve(app: Application) -> Result<()> {
         None => None,
     };
 
-    let addr: SocketAddr = format!("0.0.0.0:{}", service_config.grpc_port)
+    let grpc_addr: SocketAddr = format!("0.0.0.0:{}", service_config.grpc_port)
         .parse()
         .with_context(|| {
             format!(
@@ -41,15 +53,49 @@ pub async fn serve(app: Application) -> Result<()> {
                 service_config.grpc_port
             )
         })?;
-    info!(addr = %addr, "grpc server starting");
+    let http_addr: SocketAddr = format!("0.0.0.0:{}", service_config.http_port)
+        .parse()
+        .with_context(|| {
+            format!(
+                "invalid http bind address for port {}",
+                service_config.http_port
+            )
+        })?;
 
-    tonic::transport::Server::builder()
-        .add_service(grpc_service.into_server())
-        .serve_with_shutdown(addr, shutdown_signal())
-        .await
-        .context("grpc server terminated with error")?;
+    info!(grpc = %grpc_addr, http = %http_addr, "servers starting");
 
-    info!("grpc server stopped");
+    // Driver: one task waits for the OS signal and flips the watch.
+    tokio::spawn(async move {
+        shutdown_signal().await;
+        let _ = shutdown_tx.send(true);
+    });
+
+    let grpc_shutdown = wait_for_shutdown(shutdown_rx.clone());
+    let grpc_task = tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(grpc_service.into_server())
+            .serve_with_shutdown(grpc_addr, grpc_shutdown)
+            .await
+            .context("grpc server terminated with error")
+    });
+
+    let http_shutdown = wait_for_shutdown(shutdown_rx);
+    let http_task = tokio::spawn(async move {
+        let listener = tokio::net::TcpListener::bind(http_addr)
+            .await
+            .with_context(|| format!("failed to bind http listener on {http_addr}"))?;
+        axum::serve(listener, crate::health::router(health_state))
+            .with_graceful_shutdown(http_shutdown)
+            .await
+            .context("http server terminated with error")
+    });
+
+    // Await both. If one exits with an error we still try to drain
+    // the other so diagnostics aren't dropped.
+    let grpc_res = grpc_task.await.context("grpc server task join failed")?;
+    let http_res = http_task.await.context("http server task join failed")?;
+
+    info!("servers stopped");
 
     if let Some(handle) = subscriber_handle {
         handle.abort();
@@ -60,7 +106,17 @@ pub async fn serve(app: Application) -> Result<()> {
         }
     }
 
+    grpc_res?;
+    http_res?;
     Ok(())
+}
+
+async fn wait_for_shutdown(mut rx: watch::Receiver<bool>) {
+    while !*rx.borrow() {
+        if rx.changed().await.is_err() {
+            break;
+        }
+    }
 }
 
 async fn shutdown_signal() {


### PR DESCRIPTION
## Summary

First observability slice. Adds a small HTTP server alongside gRPC
with \`/healthz\` and \`/readyz\`, and wires Kubernetes probes to
hit them instead of a TCP-open check.

The k8s E2E used to claim the pod \"ready\" as soon as the gRPC
port was bound. Honest-lie: the pod could be accepting
connections while NATS was still disconnected. Now readiness
reports the actual state of wired dependencies.

## Endpoints

- \`GET /healthz\` — **liveness**. Always 200 while the async
  runtime is alive. **Never** consults external deps: killing the
  pod when NATS is down doesn't fix anything.
- \`GET /readyz\` — **readiness**. 200 when every wired
  dependency is reachable, **503** with a JSON body listing
  failing components otherwise. Today's only check is NATS via
  \`async_nats::Client::connection_state()\`. When NATS messaging
  is disabled, readiness reports \`"not wired (noop messaging)"\`
  and stays healthy.

## Core + composition

- \`ServiceConfig\` gains \`http_port: u16\` alongside \`grpc_port\`.
  \`EnvConfiguration\` reads \`CHOREO_HTTP_PORT\` (default 8080).
- \`compose::wire_messaging\` now returns a struct that carries the
  live NATS client when wired, so the composition root can thread
  it into the readiness probe. When NATS is disabled the client
  handle is \`None\` and the probe stays honest.
- \`Application\` grows \`health_state\`; \`serve\` spawns the HTTP
  server on a Tokio task and shares shutdown via a \`watch\`
  channel so SIGTERM/SIGINT drains both servers together.

## Chart

- New \`config.httpPort\` (default 8080) + \`service.httpPort\`.
- Deployment exposes two named container ports (\`grpc\` + \`http\`).
- **Breaking probe change** (pre-release chart): liveness /
  readiness switch from \`tcpSocket: grpc\` to \`httpGet\` hitting
  \`/healthz\` and \`/readyz\`. Liveness no longer spuriously passes
  while readiness is silently wrong.

## Honesty & Evidence

- **298 unit tests pass** (128 core + 12 app + 147 adapters + 11
  binary). 6 of the 11 binary tests are new and exercise the
  health router through \`tower::ServiceExt::oneshot\` so CI runs
  them without a live HTTP socket.
- \`cargo fmt\` + \`cargo clippy --features
  choreo-adapters/agent-anthropic … -D warnings\` clean.
- \`helm lint\` + \`helm template\` verified the rendered
  \`CHOREO_HTTP_PORT\` env var and the \`httpGet\` probes.
- E2E jobs will pick up the new probe style on this PR —
  evidence that the new probes work against a real pod.

## Contract Impact

- [x] No proto / AsyncAPI changes.
- [ ] ServiceConfig gains \`http_port\` — compatible with every
      existing consumer because all consumers are in-tree; the
      field is also populated with a sensible default by
      \`EnvConfiguration\`.
- [x] **Chart breaking**: probe scheme changed
      (\`tcpSocket\` → \`httpGet\`), service exposes a new port,
      deployment exposes a new container port. Pre-1.0 chart;
      justified by fixing the real honesty-lie around readiness.

## Architecture Review

- [x] DDD + HEX preserved — \`health\` is a transport module in
      the binary, not in core or adapters. It observes wired
      dependencies; it does not own them.
- [x] SRP — \`healthz\` only signals process liveness,
      \`readyz\` only reports dependency readiness.
- [x] Secrets cannot leak through Debug (regression test).
- [x] No domain vocabulary leakage.