### PR TITLE
feat(observability): phase 8b — StatisticsPort + /metrics + GetStatus/GetMetrics RPCs

### DIFF
--- a/crates/choreo-adapters/src/grpc/service.rs
+++ b/crates/choreo-adapters/src/grpc/service.rs
@@ -428,9 +428,18 @@ mod tests {
     #[test]
     fn statistics_to_proto_maps_every_field() {
         let mut stats = Statistics::new();
-        stats.record_deliberation(&Specialty::new("triage").unwrap(), DurationMs::from_millis(100));
-        stats.record_deliberation(&Specialty::new("triage").unwrap(), DurationMs::from_millis(50));
-        stats.record_deliberation(&Specialty::new("reviewer").unwrap(), DurationMs::from_millis(200));
+        stats.record_deliberation(
+            &Specialty::new("triage").unwrap(),
+            DurationMs::from_millis(100),
+        );
+        stats.record_deliberation(
+            &Specialty::new("triage").unwrap(),
+            DurationMs::from_millis(50),
+        );
+        stats.record_deliberation(
+            &Specialty::new("reviewer").unwrap(),
+            DurationMs::from_millis(200),
+        );
         stats.record_orchestration(DurationMs::from_millis(400));
 
         let mapped = statistics_to_proto(&stats);

--- a/crates/choreo-adapters/src/grpc/service.rs
+++ b/crates/choreo-adapters/src/grpc/service.rs
@@ -10,6 +10,7 @@ use choreo_app::usecases::{
     GetDeliberationUseCase, ListCouncilsUseCase, OrchestrateUseCase,
 };
 use choreo_core::error::DomainError;
+use choreo_core::ports::StatisticsPort;
 use choreo_core::value_objects::{AgentId, Specialty, TaskId};
 use choreo_proto::v1 as pb;
 use choreo_proto::v1::choreographer_service_server::{
@@ -35,6 +36,9 @@ pub struct ChoreographerGrpcService {
     list_councils: Arc<ListCouncilsUseCase>,
     get_deliberation: Arc<GetDeliberationUseCase>,
     auto_dispatch: Arc<AutoDispatchService>,
+    statistics: Arc<dyn StatisticsPort>,
+    started_at: std::time::Instant,
+    service_version: &'static str,
 }
 
 impl std::fmt::Debug for ChoreographerGrpcService {
@@ -67,6 +71,8 @@ pub struct ChoreographerGrpcServiceBuilder {
     list_councils: Option<Arc<ListCouncilsUseCase>>,
     get_deliberation: Option<Arc<GetDeliberationUseCase>>,
     auto_dispatch: Option<Arc<AutoDispatchService>>,
+    statistics: Option<Arc<dyn StatisticsPort>>,
+    service_version: Option<&'static str>,
 }
 
 impl std::fmt::Debug for ChoreographerGrpcServiceBuilder {
@@ -93,6 +99,18 @@ impl ChoreographerGrpcServiceBuilder {
     setter!(list_councils, ListCouncilsUseCase, list_councils);
     setter!(get_deliberation, GetDeliberationUseCase, get_deliberation);
     setter!(auto_dispatch, AutoDispatchService, auto_dispatch);
+
+    #[must_use]
+    pub fn statistics(mut self, value: Arc<dyn StatisticsPort>) -> Self {
+        self.statistics = Some(value);
+        self
+    }
+
+    #[must_use]
+    pub fn service_version(mut self, value: &'static str) -> Self {
+        self.service_version = Some(value);
+        self
+    }
 
     /// Consume the builder. Missing dependencies are reported via
     /// [`DomainError::InvariantViolated`] so wiring errors surface
@@ -122,6 +140,11 @@ impl ChoreographerGrpcServiceBuilder {
             auto_dispatch: self.auto_dispatch.ok_or(DomainError::InvariantViolated {
                 reason: "grpc: auto_dispatch service is required",
             })?,
+            statistics: self.statistics.ok_or(DomainError::InvariantViolated {
+                reason: "grpc: statistics port is required",
+            })?,
+            started_at: std::time::Instant::now(),
+            service_version: self.service_version.unwrap_or(""),
         })
     }
 }
@@ -341,19 +364,96 @@ impl ChoreographerService for ChoreographerGrpcService {
 
     async fn get_status(
         &self,
-        _request: Request<pb::GetStatusRequest>,
+        request: Request<pb::GetStatusRequest>,
     ) -> GrpcResult<pb::GetStatusResponse> {
-        Err(Status::unimplemented(
-            "GetStatus is not implemented yet; see service docblock",
-        ))
+        let include_stats = request.into_inner().include_stats;
+        let stats = if include_stats {
+            Some(
+                self.statistics
+                    .snapshot()
+                    .await
+                    .map_err(domain_error_to_status)?,
+            )
+        } else {
+            None
+        };
+
+        Ok(Response::new(pb::GetStatusResponse {
+            version: self.service_version.to_owned(),
+            uptime_seconds: self.started_at.elapsed().as_secs(),
+            health: "healthy".to_owned(),
+            stats: stats.as_ref().map(statistics_to_proto),
+        }))
     }
 
     async fn get_metrics(
         &self,
         _request: Request<pb::GetMetricsRequest>,
     ) -> GrpcResult<pb::GetMetricsResponse> {
-        Err(Status::unimplemented(
-            "GetMetrics is not implemented yet; see service docblock",
-        ))
+        let snap = self
+            .statistics
+            .snapshot()
+            .await
+            .map_err(domain_error_to_status)?;
+        Ok(Response::new(pb::GetMetricsResponse {
+            stats: Some(statistics_to_proto(&snap)),
+        }))
+    }
+}
+
+/// Map the domain [`choreo_core::entities::Statistics`] into the
+/// protobuf `Statistics` message. Kept here, next to the only call
+/// sites, because it is a pure transport concern.
+fn statistics_to_proto(stats: &choreo_core::entities::Statistics) -> pb::Statistics {
+    let per_specialty_counts = stats
+        .per_specialty()
+        .iter()
+        .map(|(sp, count)| (sp.as_str().to_owned(), *count))
+        .collect();
+    pb::Statistics {
+        total_deliberations: stats.total_deliberations(),
+        total_orchestrations: stats.total_orchestrations(),
+        total_duration_ms: stats.total_duration().get(),
+        average_duration_ms: stats.average_duration_ms(),
+        per_specialty_counts,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use choreo_core::entities::Statistics;
+    use choreo_core::value_objects::{DurationMs, Specialty};
+
+    #[test]
+    fn statistics_to_proto_maps_every_field() {
+        let mut stats = Statistics::new();
+        stats.record_deliberation(&Specialty::new("triage").unwrap(), DurationMs::from_millis(100));
+        stats.record_deliberation(&Specialty::new("triage").unwrap(), DurationMs::from_millis(50));
+        stats.record_deliberation(&Specialty::new("reviewer").unwrap(), DurationMs::from_millis(200));
+        stats.record_orchestration(DurationMs::from_millis(400));
+
+        let mapped = statistics_to_proto(&stats);
+        assert_eq!(mapped.total_deliberations, 3);
+        assert_eq!(mapped.total_orchestrations, 1);
+        assert_eq!(mapped.total_duration_ms, 750);
+        // (100 + 50 + 200 + 400) / 4 ops = 187.5
+        assert!((mapped.average_duration_ms - 187.5).abs() < 1e-9);
+        assert_eq!(mapped.per_specialty_counts.get("triage").copied(), Some(2));
+        assert_eq!(
+            mapped.per_specialty_counts.get("reviewer").copied(),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn statistics_to_proto_empty_maps_zeros_and_empty_map() {
+        let stats = Statistics::default();
+        let mapped = statistics_to_proto(&stats);
+        assert_eq!(mapped.total_deliberations, 0);
+        assert_eq!(mapped.total_orchestrations, 0);
+        assert_eq!(mapped.total_duration_ms, 0);
+        assert!((mapped.average_duration_ms - 0.0).abs() < f64::EPSILON);
+        assert!(mapped.per_specialty_counts.is_empty());
     }
 }

--- a/crates/choreo-adapters/src/memory/mod.rs
+++ b/crates/choreo-adapters/src/memory/mod.rs
@@ -8,7 +8,9 @@
 mod agent_registry;
 mod council_registry;
 mod deliberation_repository;
+mod statistics;
 
 pub use agent_registry::InMemoryAgentRegistry;
 pub use council_registry::InMemoryCouncilRegistry;
 pub use deliberation_repository::InMemoryDeliberationRepository;
+pub use statistics::InMemoryStatistics;

--- a/crates/choreo-adapters/src/memory/statistics.rs
+++ b/crates/choreo-adapters/src/memory/statistics.rs
@@ -1,0 +1,133 @@
+//! In-memory [`StatisticsPort`] backed by a `RwLock<Statistics>`.
+//!
+//! Cheap to clone; internal state is shared through `Arc<RwLock>`.
+//! For multi-replica deployments, a persistent adapter (e.g. Redis
+//! / Neo4j / Postgres) drops in without touching the application
+//! layer — the port is the contract.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use choreo_core::entities::Statistics;
+use choreo_core::error::DomainError;
+use choreo_core::ports::StatisticsPort;
+use choreo_core::value_objects::{DurationMs, Specialty};
+use tokio::sync::RwLock;
+
+#[derive(Debug, Default, Clone)]
+pub struct InMemoryStatistics {
+    inner: Arc<RwLock<Statistics>>,
+}
+
+impl InMemoryStatistics {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl StatisticsPort for InMemoryStatistics {
+    async fn record_deliberation(
+        &self,
+        specialty: &Specialty,
+        duration: DurationMs,
+    ) -> Result<(), DomainError> {
+        self.inner
+            .write()
+            .await
+            .record_deliberation(specialty, duration);
+        Ok(())
+    }
+
+    async fn record_orchestration(&self, duration: DurationMs) -> Result<(), DomainError> {
+        self.inner.write().await.record_orchestration(duration);
+        Ok(())
+    }
+
+    async fn snapshot(&self) -> Result<Statistics, DomainError> {
+        Ok(self.inner.read().await.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sp(s: &str) -> Specialty {
+        Specialty::new(s).unwrap()
+    }
+
+    #[tokio::test]
+    async fn fresh_snapshot_is_empty() {
+        let stats = InMemoryStatistics::new();
+        let snap = stats.snapshot().await.unwrap();
+        assert_eq!(snap.total_deliberations(), 0);
+        assert_eq!(snap.total_orchestrations(), 0);
+        assert_eq!(snap.total_duration(), DurationMs::ZERO);
+        assert!(snap.per_specialty().is_empty());
+    }
+
+    #[tokio::test]
+    async fn record_deliberation_advances_counters() {
+        let stats = InMemoryStatistics::new();
+        stats
+            .record_deliberation(&sp("triage"), DurationMs::from_millis(100))
+            .await
+            .unwrap();
+        stats
+            .record_deliberation(&sp("triage"), DurationMs::from_millis(50))
+            .await
+            .unwrap();
+        stats
+            .record_deliberation(&sp("reviewer"), DurationMs::from_millis(200))
+            .await
+            .unwrap();
+
+        let snap = stats.snapshot().await.unwrap();
+        assert_eq!(snap.total_deliberations(), 3);
+        assert_eq!(snap.total_duration(), DurationMs::from_millis(350));
+        assert_eq!(snap.per_specialty().get(&sp("triage")).copied(), Some(2));
+        assert_eq!(snap.per_specialty().get(&sp("reviewer")).copied(), Some(1));
+    }
+
+    #[tokio::test]
+    async fn record_orchestration_advances_counters() {
+        let stats = InMemoryStatistics::new();
+        stats
+            .record_orchestration(DurationMs::from_millis(500))
+            .await
+            .unwrap();
+        let snap = stats.snapshot().await.unwrap();
+        assert_eq!(snap.total_orchestrations(), 1);
+        assert_eq!(snap.total_duration(), DurationMs::from_millis(500));
+    }
+
+    #[tokio::test]
+    async fn snapshot_returns_independent_clone() {
+        let stats = InMemoryStatistics::new();
+        stats
+            .record_deliberation(&sp("x"), DurationMs::from_millis(10))
+            .await
+            .unwrap();
+        let snap_a = stats.snapshot().await.unwrap();
+        stats
+            .record_deliberation(&sp("x"), DurationMs::from_millis(20))
+            .await
+            .unwrap();
+        let snap_b = stats.snapshot().await.unwrap();
+        assert_eq!(snap_a.total_deliberations(), 1);
+        assert_eq!(snap_b.total_deliberations(), 2);
+    }
+
+    #[tokio::test]
+    async fn clone_shares_state() {
+        let a = InMemoryStatistics::new();
+        let b = a.clone();
+        a.record_deliberation(&sp("x"), DurationMs::from_millis(5))
+            .await
+            .unwrap();
+        let snap = b.snapshot().await.unwrap();
+        assert_eq!(snap.total_deliberations(), 1);
+    }
+}

--- a/crates/choreo-app/src/usecases/deliberate.rs
+++ b/crates/choreo-app/src/usecases/deliberate.rs
@@ -29,7 +29,7 @@ use choreo_core::error::DomainError;
 use choreo_core::events::{DeliberationCompletedEvent, EventEnvelope};
 use choreo_core::ports::{
     AgentPort, AgentResolverPort, ClockPort, CouncilRegistryPort, DeliberationRepositoryPort,
-    DraftRequest, MessagingPort, ScoringPort, ValidatorPort,
+    DraftRequest, MessagingPort, ScoringPort, StatisticsPort, ValidatorPort,
 };
 use choreo_core::value_objects::{AgentId, EventId, ProposalId};
 use time::OffsetDateTime;
@@ -52,6 +52,7 @@ pub struct DeliberateUseCase {
     scoring: Arc<dyn ScoringPort>,
     repository: Arc<dyn DeliberationRepositoryPort>,
     messaging: Arc<dyn MessagingPort>,
+    statistics: Arc<dyn StatisticsPort>,
     source: String,
 }
 
@@ -74,6 +75,7 @@ impl DeliberateUseCase {
         scoring: Arc<dyn ScoringPort>,
         repository: Arc<dyn DeliberationRepositoryPort>,
         messaging: Arc<dyn MessagingPort>,
+        statistics: Arc<dyn StatisticsPort>,
         source: impl Into<String>,
     ) -> Self {
         Self {
@@ -84,6 +86,7 @@ impl DeliberateUseCase {
             scoring,
             repository,
             messaging,
+            statistics,
             source: source.into(),
         }
     }
@@ -134,6 +137,11 @@ impl DeliberateUseCase {
         self.repository.save(&deliberation).await?;
 
         let duration = deliberation.duration().unwrap_or_default();
+
+        self.statistics
+            .record_deliberation(deliberation.specialty(), duration)
+            .await?;
+
         let completion_event = DeliberationCompletedEvent::new(
             self.envelope(completed_at)?,
             deliberation.task_id().clone(),
@@ -551,6 +559,28 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct NullStats;
+    #[async_trait]
+    impl choreo_core::ports::StatisticsPort for NullStats {
+        async fn record_deliberation(
+            &self,
+            _specialty: &Specialty,
+            _duration: choreo_core::value_objects::DurationMs,
+        ) -> Result<(), DomainError> {
+            Ok(())
+        }
+        async fn record_orchestration(
+            &self,
+            _duration: choreo_core::value_objects::DurationMs,
+        ) -> Result<(), DomainError> {
+            Ok(())
+        }
+        async fn snapshot(&self) -> Result<choreo_core::entities::Statistics, DomainError> {
+            Ok(choreo_core::entities::Statistics::default())
+        }
+    }
+
     // --- Fixture helpers --------------------------------------------------
 
     fn specialty() -> Specialty {
@@ -595,6 +625,7 @@ mod tests {
         let repo = Arc::new(InMemoryRepo::default());
         let bus = Arc::new(NullBus::default());
 
+        let stats: Arc<dyn choreo_core::ports::StatisticsPort> = Arc::new(NullStats);
         let usecase = DeliberateUseCase::new(
             clock,
             registry,
@@ -603,6 +634,7 @@ mod tests {
             scoring,
             repo.clone(),
             bus.clone(),
+            stats,
             "choreographer",
         );
         (usecase, repo, bus)

--- a/crates/choreo-app/src/usecases/orchestrate.rs
+++ b/crates/choreo-app/src/usecases/orchestrate.rs
@@ -32,6 +32,7 @@ pub struct OrchestrateUseCase {
     executor: Arc<dyn ExecutorPort>,
     messaging: Arc<dyn MessagingPort>,
     clock: Arc<dyn ClockPort>,
+    statistics: Arc<dyn choreo_core::ports::StatisticsPort>,
     source: String,
 }
 
@@ -50,6 +51,7 @@ impl OrchestrateUseCase {
         executor: Arc<dyn ExecutorPort>,
         messaging: Arc<dyn MessagingPort>,
         clock: Arc<dyn ClockPort>,
+        statistics: Arc<dyn choreo_core::ports::StatisticsPort>,
         source: impl Into<String>,
     ) -> Self {
         Self {
@@ -57,6 +59,7 @@ impl OrchestrateUseCase {
             executor,
             messaging,
             clock,
+            statistics,
             source: source.into(),
         }
     }
@@ -90,6 +93,15 @@ impl OrchestrateUseCase {
 
         match self.executor.execute(&winner, &execution_options).await {
             Ok(execution) => {
+                // The deliberation's own duration already went into
+                // the stats through `DeliberateUseCase`; here we
+                // record the orchestration end-to-end duration,
+                // which for the noop executor is just the executor
+                // call's reported duration.
+                self.statistics
+                    .record_orchestration(execution.duration)
+                    .await?;
+
                 self.messaging
                     .publish_task_completed(&TaskCompletedEvent::new(
                         self.envelope(self.clock.now())?,

--- a/crates/choreo-core/src/ports/mod.rs
+++ b/crates/choreo-core/src/ports/mod.rs
@@ -23,6 +23,7 @@ mod deliberation_repository;
 mod executor;
 mod messaging;
 mod scoring;
+mod statistics;
 mod validator;
 
 pub use agent::{AgentPort, Critique, DraftRequest, Revision};
@@ -34,4 +35,5 @@ pub use deliberation_repository::DeliberationRepositoryPort;
 pub use executor::{ExecutionOutcome, ExecutorPort};
 pub use messaging::{DomainEvent, MessagingPort, SubscriptionHandler};
 pub use scoring::ScoringPort;
+pub use statistics::StatisticsPort;
 pub use validator::ValidatorPort;

--- a/crates/choreo-core/src/ports/statistics.rs
+++ b/crates/choreo-core/src/ports/statistics.rs
@@ -1,0 +1,34 @@
+//! [`StatisticsPort`] — operational counter surface.
+//!
+//! Every [`DeliberateUseCase`](super) invocation that completes
+//! records its duration and specialty through this port; every
+//! [`OrchestrateUseCase`](super) invocation records the orchestration
+//! duration. Adapters decide where the numbers live — in-memory for
+//! a single replica, external store for multi-replica setups — and
+//! whatever Prometheus / gRPC exposer the composition root wires
+//! reads [`Statistics`] through `snapshot`.
+
+use async_trait::async_trait;
+
+use crate::entities::Statistics;
+use crate::error::DomainError;
+use crate::value_objects::{DurationMs, Specialty};
+
+#[async_trait]
+pub trait StatisticsPort: Send + Sync {
+    /// Record that a deliberation for `specialty` completed in
+    /// `duration`.
+    async fn record_deliberation(
+        &self,
+        specialty: &Specialty,
+        duration: DurationMs,
+    ) -> Result<(), DomainError>;
+
+    /// Record that an orchestration (deliberate + execute) completed
+    /// in `duration`.
+    async fn record_orchestration(&self, duration: DurationMs) -> Result<(), DomainError>;
+
+    /// Read-only snapshot. Callers receive a clone so the returned
+    /// value is safe to serialise without holding any lock.
+    async fn snapshot(&self) -> Result<Statistics, DomainError>;
+}

--- a/crates/choreo-proto/proto/underpass/choreo/v1/choreo.proto
+++ b/crates/choreo-proto/proto/underpass/choreo/v1/choreo.proto
@@ -39,12 +39,12 @@ import "google/protobuf/timestamp.proto";
 //
 //   Deliberate, Orchestrate, GetDeliberationResult,
 //   CreateCouncil, ListCouncils, DeleteCouncil,
-//   ProcessTriggerEvent
+//   ProcessTriggerEvent, GetStatus, GetMetrics
 //     -> backed by a use case in `choreo-app/src/usecases/` (or
-//        `services/auto_dispatch.rs` for ProcessTriggerEvent).
+//        `services/auto_dispatch.rs` for ProcessTriggerEvent;
+//        `StatisticsPort::snapshot` for GetStatus / GetMetrics).
 //
-//   StreamDeliberation, RegisterAgent, UnregisterAgent,
-//   GetStatus, GetMetrics
+//   StreamDeliberation, RegisterAgent, UnregisterAgent
 //     -> declared here because they belong to the contract, but the
 //        server returns `UNIMPLEMENTED` until their backing use cases
 //        land. Enumerate what is real (not what is planned) per the

--- a/crates/choreo-tests-integration/tests/nats_trigger_subscriber.rs
+++ b/crates/choreo-tests-integration/tests/nats_trigger_subscriber.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 use choreo_adapters::clock::SystemClock;
 use choreo_adapters::memory::{
     InMemoryAgentRegistry, InMemoryCouncilRegistry, InMemoryDeliberationRepository,
+    InMemoryStatistics,
 };
 use choreo_adapters::nats::{NatsMessaging, NatsSubjects, NatsTriggerSubscriber};
 use choreo_adapters::noop::NoopAgent;
@@ -31,7 +32,7 @@ use choreo_app::usecases::DeliberateUseCase;
 use choreo_core::entities::{Council, DeliberationPhase};
 use choreo_core::ports::{
     AgentPort, ClockPort, CouncilRegistryPort, DeliberationRepositoryPort, MessagingPort,
-    ScoringPort, ValidatorPort,
+    ScoringPort, StatisticsPort, ValidatorPort,
 };
 use choreo_core::value_objects::{AgentId, CouncilId, Specialty, TaskId};
 use futures::StreamExt;
@@ -107,6 +108,7 @@ async fn trigger_event_over_nats_drives_full_pipeline() {
     let scoring: Arc<dyn ScoringPort> = Arc::new(UniformScoring::new());
     let messaging: Arc<dyn MessagingPort> =
         Arc::new(NatsMessaging::new(client.clone(), subjects.clone()));
+    let statistics: Arc<dyn StatisticsPort> = Arc::new(InMemoryStatistics::new());
 
     let deliberate = Arc::new(DeliberateUseCase::new(
         clock.clone(),
@@ -116,6 +118,7 @@ async fn trigger_event_over_nats_drives_full_pipeline() {
         scoring,
         repo.clone(),
         messaging.clone(),
+        statistics,
         "integration-test",
     ));
 

--- a/crates/choreo/src/compose.rs
+++ b/crates/choreo/src/compose.rs
@@ -6,6 +6,7 @@ use choreo_adapters::clock::SystemClock;
 use choreo_adapters::config::EnvConfiguration;
 use choreo_adapters::memory::{
     InMemoryAgentRegistry, InMemoryCouncilRegistry, InMemoryDeliberationRepository,
+    InMemoryStatistics,
 };
 use choreo_adapters::nats::{NatsConfig, NatsMessaging, NatsTriggerSubscriber};
 use choreo_adapters::noop::{NoopExecutor, NoopMessaging};
@@ -18,7 +19,8 @@ use choreo_app::usecases::{
 };
 use choreo_core::error::DomainError;
 use choreo_core::ports::{
-    ConfigurationPort, ExecutorPort, MessagingPort, ScoringPort, ServiceConfig, ValidatorPort,
+    ConfigurationPort, ExecutorPort, MessagingPort, ScoringPort, ServiceConfig, StatisticsPort,
+    ValidatorPort,
 };
 use thiserror::Error;
 use tracing::info;
@@ -89,6 +91,8 @@ pub async fn compose() -> Result<Application, ComposeError> {
         nats_client,
     } = wire_messaging(&service_config).await?;
 
+    let statistics: Arc<dyn StatisticsPort> = Arc::new(InMemoryStatistics::new());
+
     let deliberate = Arc::new(DeliberateUseCase::new(
         clock.clone(),
         council_registry.clone(),
@@ -97,6 +101,7 @@ pub async fn compose() -> Result<Application, ComposeError> {
         scoring,
         repository.clone(),
         messaging.clone(),
+        statistics.clone(),
         "choreographer",
     ));
 
@@ -105,6 +110,7 @@ pub async fn compose() -> Result<Application, ComposeError> {
         executor,
         messaging.clone(),
         clock.clone(),
+        statistics.clone(),
         "choreographer",
     ));
 
@@ -142,9 +148,15 @@ pub async fn compose() -> Result<Application, ComposeError> {
         .list_councils(list_councils)
         .get_deliberation(get_deliberation)
         .auto_dispatch(auto_dispatch)
+        .statistics(statistics.clone())
+        .service_version(env!("CARGO_PKG_VERSION"))
         .build()?;
 
-    let health_state = crate::health::HealthState::new(nats_client, env!("CARGO_PKG_VERSION"));
+    let health_state = crate::health::HealthState::new(
+        nats_client,
+        statistics.clone(),
+        env!("CARGO_PKG_VERSION"),
+    );
 
     info!(
         grpc_port = service_config.grpc_port,

--- a/crates/choreo/src/compose.rs
+++ b/crates/choreo/src/compose.rs
@@ -152,11 +152,8 @@ pub async fn compose() -> Result<Application, ComposeError> {
         .service_version(env!("CARGO_PKG_VERSION"))
         .build()?;
 
-    let health_state = crate::health::HealthState::new(
-        nats_client,
-        statistics.clone(),
-        env!("CARGO_PKG_VERSION"),
-    );
+    let health_state =
+        crate::health::HealthState::new(nats_client, statistics.clone(), env!("CARGO_PKG_VERSION"));
 
     info!(
         grpc_port = service_config.grpc_port,

--- a/crates/choreo/src/health.rs
+++ b/crates/choreo/src/health.rs
@@ -21,22 +21,24 @@ use std::sync::Arc;
 use async_nats::connection::State as NatsConnectionState;
 use axum::{
     extract::State,
-    http::StatusCode,
+    http::{header, StatusCode},
     response::{IntoResponse, Response},
     routing::get,
     Json, Router,
 };
+use choreo_core::ports::StatisticsPort;
 use serde::Serialize;
 
 /// Read-only handles the health endpoints need. Cloning a
 /// `HealthState` is cheap — every inner handle is already an `Arc`
 /// or a lightweight client.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct HealthState {
     /// `Some` when NATS messaging was wired at composition time.
     /// `None` when the service is running with `NoopMessaging`; in
     /// that case readiness never fails on NATS.
     nats: Option<async_nats::Client>,
+    statistics: Arc<dyn StatisticsPort>,
     service_version: Arc<str>,
 }
 
@@ -51,9 +53,14 @@ impl std::fmt::Debug for HealthState {
 
 impl HealthState {
     #[must_use]
-    pub fn new(nats: Option<async_nats::Client>, service_version: impl Into<String>) -> Self {
+    pub fn new(
+        nats: Option<async_nats::Client>,
+        statistics: Arc<dyn StatisticsPort>,
+        service_version: impl Into<String>,
+    ) -> Self {
         Self {
             nats,
+            statistics,
             service_version: Arc::from(service_version.into().into_boxed_str()),
         }
     }
@@ -65,6 +72,7 @@ pub fn router(state: HealthState) -> Router {
     Router::new()
         .route("/healthz", get(healthz))
         .route("/readyz", get(readyz))
+        .route("/metrics", get(metrics))
         .with_state(state)
 }
 
@@ -130,6 +138,104 @@ async fn readyz(State(state): State<HealthState>) -> Response {
     (code, Json(body)).into_response()
 }
 
+/// Prometheus text format exposition.
+///
+/// Hand-rolled (no client library) to avoid another dependency for
+/// five counters and a gauge. The format is specified at
+/// <https://prometheus.io/docs/instrumenting/exposition_formats/>.
+/// One metric family per `# HELP` / `# TYPE` pair; samples follow.
+async fn metrics(State(state): State<HealthState>) -> Response {
+    use std::fmt::Write as _;
+
+    let snap = match state.statistics.snapshot().await {
+        Ok(s) => s,
+        Err(err) => {
+            tracing::error!(error = %err, "metrics snapshot failed");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "statistics snapshot failed\n",
+            )
+                .into_response();
+        }
+    };
+
+    let ready_gauge = match &state.nats {
+        Some(client) if client.connection_state() != NatsConnectionState::Connected => 0,
+        _ => 1,
+    };
+
+    let total_ops = snap
+        .total_deliberations()
+        .saturating_add(snap.total_orchestrations());
+    let total_deliberations = snap.total_deliberations();
+    let total_orchestrations = snap.total_orchestrations();
+    let total_duration_ms = snap.total_duration().get();
+
+    // `write!` into String is infallible; unwrap is safe here.
+    let mut body = String::new();
+    body.push_str("# HELP choreo_deliberations_total Count of deliberations completed.\n");
+    body.push_str("# TYPE choreo_deliberations_total counter\n");
+    writeln!(body, "choreo_deliberations_total {total_deliberations}").unwrap();
+
+    body.push_str("# HELP choreo_orchestrations_total Count of orchestrations completed.\n");
+    body.push_str("# TYPE choreo_orchestrations_total counter\n");
+    writeln!(body, "choreo_orchestrations_total {total_orchestrations}").unwrap();
+
+    body.push_str(
+        "# HELP choreo_deliberations_specialty_total Count of deliberations per specialty.\n",
+    );
+    body.push_str("# TYPE choreo_deliberations_specialty_total counter\n");
+    for (specialty, count) in snap.per_specialty() {
+        let label = escape_label_value(specialty.as_str());
+        writeln!(
+            body,
+            "choreo_deliberations_specialty_total{{specialty=\"{label}\"}} {count}"
+        )
+        .unwrap();
+    }
+
+    body.push_str(
+        "# HELP choreo_operation_duration_milliseconds Summed duration across deliberations and orchestrations.\n",
+    );
+    body.push_str("# TYPE choreo_operation_duration_milliseconds summary\n");
+    writeln!(
+        body,
+        "choreo_operation_duration_milliseconds_sum {total_duration_ms}"
+    )
+    .unwrap();
+    writeln!(
+        body,
+        "choreo_operation_duration_milliseconds_count {total_ops}"
+    )
+    .unwrap();
+
+    body.push_str("# HELP choreo_service_ready 1 when every wired dependency is reachable.\n");
+    body.push_str("# TYPE choreo_service_ready gauge\n");
+    writeln!(body, "choreo_service_ready {ready_gauge}").unwrap();
+
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "text/plain; version=0.0.4")],
+        body,
+    )
+        .into_response()
+}
+
+/// Escape a Prometheus label value per the exposition format:
+/// backslash, double-quote, and newline must be escaped.
+fn escape_label_value(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
 fn check_nats(client: &async_nats::Client) -> CheckResult {
     match client.connection_state() {
         NatsConnectionState::Connected => CheckResult {
@@ -159,8 +265,14 @@ mod tests {
     use super::*;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
+    use choreo_adapters::memory::InMemoryStatistics;
+    use choreo_core::value_objects::{DurationMs, Specialty};
     use serde_json::Value;
     use tower::ServiceExt; // for `oneshot`
+
+    fn stats() -> Arc<dyn StatisticsPort> {
+        Arc::new(InMemoryStatistics::new())
+    }
 
     async fn body_json(resp: Response) -> Value {
         let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
@@ -169,9 +281,16 @@ mod tests {
         serde_json::from_slice(&bytes).expect("valid json")
     }
 
+    async fn body_text(resp: Response) -> String {
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("body bytes");
+        String::from_utf8(bytes.to_vec()).expect("utf8")
+    }
+
     #[tokio::test]
     async fn healthz_returns_200_with_alive_status() {
-        let app = router(HealthState::new(None, "0.1.0"));
+        let app = router(HealthState::new(None, stats(), "0.1.0"));
         let resp = app
             .oneshot(
                 Request::builder()
@@ -190,7 +309,7 @@ mod tests {
 
     #[tokio::test]
     async fn readyz_without_nats_returns_200_and_reports_not_wired() {
-        let app = router(HealthState::new(None, "0.1.0"));
+        let app = router(HealthState::new(None, stats(), "0.1.0"));
         let resp = app
             .oneshot(
                 Request::builder()
@@ -219,7 +338,7 @@ mod tests {
         // hitting /healthz with `None` and asserting response shape.
         // The structural invariant is enforced by the implementation
         // of `healthz` never touching `state.nats`.
-        let app = router(HealthState::new(None, "9.9.9"));
+        let app = router(HealthState::new(None, stats(), "9.9.9"));
         let resp = app
             .oneshot(
                 Request::builder()
@@ -236,7 +355,7 @@ mod tests {
 
     #[tokio::test]
     async fn unknown_route_is_404() {
-        let app = router(HealthState::new(None, "0.1.0"));
+        let app = router(HealthState::new(None, stats(), "0.1.0"));
         let resp = app
             .oneshot(
                 Request::builder()
@@ -251,7 +370,7 @@ mod tests {
 
     #[tokio::test]
     async fn post_to_healthz_is_method_not_allowed() {
-        let app = router(HealthState::new(None, "0.1.0"));
+        let app = router(HealthState::new(None, stats(), "0.1.0"));
         let resp = app
             .oneshot(
                 Request::builder()
@@ -270,12 +389,97 @@ mod tests {
         // Paranoia: make sure nothing sensitive sneaks into the
         // Debug output. Right now there are no secrets here, but
         // this test locks the invariant as the state grows.
-        let state = HealthState::new(None, "0.1.0");
+        let state = HealthState::new(None, stats(), "0.1.0");
         let shown = format!("{state:?}");
         assert!(shown.contains("HealthState"));
         assert!(shown.contains("nats_wired"));
         assert!(!shown.to_lowercase().contains("secret"));
         assert!(!shown.to_lowercase().contains("token"));
         assert!(!shown.to_lowercase().contains("api_key"));
+    }
+
+    #[tokio::test]
+    async fn metrics_emits_prometheus_text_with_zero_counters_on_fresh_boot() {
+        let app = router(HealthState::new(None, stats(), "0.1.0"));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers()
+                .get(header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
+            Some("text/plain; version=0.0.4")
+        );
+        let text = body_text(resp).await;
+        assert!(text.contains("# TYPE choreo_deliberations_total counter"));
+        assert!(text.contains("choreo_deliberations_total 0"));
+        assert!(text.contains("choreo_orchestrations_total 0"));
+        assert!(text.contains("choreo_operation_duration_milliseconds_sum 0"));
+        assert!(text.contains("choreo_operation_duration_milliseconds_count 0"));
+        assert!(text.contains("choreo_service_ready 1"));
+    }
+
+    #[tokio::test]
+    async fn metrics_reflects_recorded_operations_and_specialty_labels() {
+        let stats_adapter = Arc::new(InMemoryStatistics::new());
+        stats_adapter
+            .record_deliberation(
+                &Specialty::new("triage").unwrap(),
+                DurationMs::from_millis(150),
+            )
+            .await
+            .unwrap();
+        stats_adapter
+            .record_deliberation(
+                &Specialty::new("reviewer").unwrap(),
+                DurationMs::from_millis(200),
+            )
+            .await
+            .unwrap();
+        stats_adapter
+            .record_orchestration(DurationMs::from_millis(400))
+            .await
+            .unwrap();
+
+        let state = HealthState::new(None, stats_adapter.clone(), "0.1.0");
+        let app = router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let text = body_text(resp).await;
+        assert!(text.contains("choreo_deliberations_total 2"));
+        assert!(text.contains("choreo_orchestrations_total 1"));
+        assert!(
+            text.contains("choreo_deliberations_specialty_total{specialty=\"triage\"} 1"),
+            "missing triage label:\n{text}"
+        );
+        assert!(
+            text.contains("choreo_deliberations_specialty_total{specialty=\"reviewer\"} 1"),
+            "missing reviewer label:\n{text}"
+        );
+        assert!(text.contains("choreo_operation_duration_milliseconds_sum 750"));
+        assert!(text.contains("choreo_operation_duration_milliseconds_count 3"));
+    }
+
+    #[test]
+    fn label_value_escaping_handles_backslash_quote_and_newline() {
+        assert_eq!(escape_label_value("plain"), "plain");
+        assert_eq!(escape_label_value("a\\b"), "a\\\\b");
+        assert_eq!(escape_label_value("a\"b"), "a\\\"b");
+        assert_eq!(escape_label_value("a\nb"), "a\\nb");
     }
 }


### PR DESCRIPTION
## Summary

- Introduce `StatisticsPort` in the domain; in-memory adapter records counters through the use-case layer (no primitive obsession, no direct adapter coupling)
- Prometheus text-format `/metrics` endpoint on the HTTP health router (hand-rolled; 5 metric families: deliberations, orchestrations, per-specialty, duration summary, readiness gauge)
- `GetStatus` / `GetMetrics` gRPC RPCs now backed by `StatisticsPort::snapshot` — no longer `UNIMPLEMENTED`. Proto docblock updated so the honesty list reflects what's real.

## What changed

- `choreo-core`: new `StatisticsPort` trait (alphabetical in `ports/mod.rs`)
- `choreo-adapters`: new `InMemoryStatistics` backed by `Arc<RwLock<Statistics>>`; gRPC service + builder now take a statistics port, `statistics_to_proto` mapper
- `choreo-app`: `DeliberateUseCase` records after save; `OrchestrateUseCase` records orchestration duration on executor success
- `choreo` (binary): composition wires `InMemoryStatistics` once and threads into both use cases, the gRPC builder, and `HealthState`; `/metrics` route added to the health router
- `choreo-proto`: proto docblock moved GetStatus/GetMetrics out of the UNIMPLEMENTED list
- Integration test updated to pass the statistics port through `DeliberateUseCase::new`

## Tests added

- `InMemoryStatistics`: fresh snapshot empty, record_deliberation advances counters, record_orchestration advances, snapshot returns independent clone, clone shares state
- `statistics_to_proto`: empty → zeros + empty map; populated → every field mapped
- `/metrics`: zero counters on fresh boot + content-type assertion; reflects recorded ops with escaped specialty labels
- Label-value escaping (backslash, double-quote, newline)

## Test plan
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace`
- [ ] CI green on all 11 checks
- [ ] Manual: `curl /metrics` returns Prometheus text with `Content-Type: text/plain; version=0.0.4` (covered by unit test — verified through axum `oneshot`, no compose boot required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)