### PR TITLE
feat(agents): phase 9 — RegisterAgent / UnregisterAgent RPCs + AgentFactoryPort

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,12 @@ gate in this repository):
   serves the full `underpass.choreo.v1` gRPC contract.
 - Implemented RPCs: `Deliberate`, `Orchestrate`, `CreateCouncil`,
   `ListCouncils`, `DeleteCouncil`, `GetDeliberationResult`,
-  `ProcessTriggerEvent`.
-- Honestly `UNIMPLEMENTED` RPCs: `StreamDeliberation`, `RegisterAgent`,
-  `UnregisterAgent`, `GetStatus`, `GetMetrics`. They return
-  `UNIMPLEMENTED` so clients cannot mistake them for working.
+  `ProcessTriggerEvent`, `GetStatus`, `GetMetrics`, `RegisterAgent`,
+  `UnregisterAgent`. `RegisterAgent` currently materializes agents
+  with `kind == "noop"`; provider-backed kinds land through richer
+  `AgentFactoryPort` wirings in their respective feature slices.
+- Honestly `UNIMPLEMENTED` RPCs: `StreamDeliberation`. It returns
+  `UNIMPLEMENTED` so clients cannot mistake it for working.
 - Optional NATS messaging: when `CHOREO_NATS_ENABLED=true`, the service
   publishes all 5 outbound events (`choreo.task.*`,
   `choreo.deliberation.completed`, `choreo.phase.changed`) and
@@ -88,13 +90,13 @@ gate in this repository):
 
 **What is *not* wired yet**:
 
-- No real LLM / frontier / rule-based agent adapters — only the
-  deterministic `NoopAgent`. Provider adapters (vLLM, Anthropic,
-  OpenAI, …) land in later slices behind their own Cargo features.
-- Statistics / metrics reporting (the `StatisticsPort` is not yet in
-  core).
-- Deliberation streaming and runtime agent registration (their
-  matching RPCs return `UNIMPLEMENTED`).
+- The wired `AgentFactoryPort` today only recognises `kind == "noop"`.
+  Provider-specific factories (vLLM, Anthropic, OpenAI, …) exist as
+  standalone adapters behind their Cargo features but are not yet
+  composed into the binary's factory dispatch — that lands in a later
+  slice.
+- Deliberation streaming (`StreamDeliberation` RPC returns
+  `UNIMPLEMENTED`).
 - Persistence beyond in-process memory.
 
 See `docs/experiments/` for anything beyond these bullet points.

--- a/crates/choreo-adapters/src/grpc/mappers/agent.rs
+++ b/crates/choreo-adapters/src/grpc/mappers/agent.rs
@@ -3,17 +3,20 @@
 //! The domain model does not hold a typed `AgentSummary`; agents are
 //! opaque behind [`AgentPort`]. This adapter composes the proto
 //! summary from an [`AgentId`] plus a `kind` string supplied by the
-//! composition root (e.g. `"vllm"`, `"anthropic"`, `"rule"`).
+//! composition root (e.g. `"noop"`, `"vllm"`, `"anthropic"`,
+//! `"rule"`).
 
 use choreo_core::value_objects::{AgentId, Attributes, Specialty};
 use choreo_proto::v1 as pb;
 
 use super::attributes::attributes_to_struct;
 
-/// Not wired today: `CouncilSummary.agents` stays empty until
-/// `RegisterAgent` / `AgentRegistryPort` land (see service docblock).
-/// Kept on the module surface so future handlers can opt in without
-/// reinventing the projection.
+/// Project domain fields into a proto `AgentSummary`.
+///
+/// Kept on the module surface so list/status handlers can project
+/// agent info when they start resolving live handles; `CouncilSummary`
+/// responses still carry an empty `agents` list today because the
+/// council aggregate stores only ids.
 #[allow(dead_code)]
 #[must_use]
 pub fn agent_summary_from(

--- a/crates/choreo-adapters/src/grpc/service.rs
+++ b/crates/choreo-adapters/src/grpc/service.rs
@@ -7,11 +7,12 @@ use async_trait::async_trait;
 use choreo_app::services::AutoDispatchService;
 use choreo_app::usecases::{
     CreateCouncilInput, CreateCouncilUseCase, DeleteCouncilUseCase, DeliberateUseCase,
-    GetDeliberationUseCase, ListCouncilsUseCase, OrchestrateUseCase,
+    GetDeliberationUseCase, ListCouncilsUseCase, OrchestrateUseCase, RegisterAgentUseCase,
+    UnregisterAgentUseCase,
 };
 use choreo_core::error::DomainError;
-use choreo_core::ports::StatisticsPort;
-use choreo_core::value_objects::{AgentId, Specialty, TaskId};
+use choreo_core::ports::{AgentDescriptor, StatisticsPort};
+use choreo_core::value_objects::{AgentId, AgentKind, Specialty, TaskId};
 use choreo_proto::v1 as pb;
 use choreo_proto::v1::choreographer_service_server::{
     ChoreographerService, ChoreographerServiceServer,
@@ -35,6 +36,8 @@ pub struct ChoreographerGrpcService {
     delete_council: Arc<DeleteCouncilUseCase>,
     list_councils: Arc<ListCouncilsUseCase>,
     get_deliberation: Arc<GetDeliberationUseCase>,
+    register_agent: Arc<RegisterAgentUseCase>,
+    unregister_agent: Arc<UnregisterAgentUseCase>,
     auto_dispatch: Arc<AutoDispatchService>,
     statistics: Arc<dyn StatisticsPort>,
     started_at: std::time::Instant,
@@ -70,6 +73,8 @@ pub struct ChoreographerGrpcServiceBuilder {
     delete_council: Option<Arc<DeleteCouncilUseCase>>,
     list_councils: Option<Arc<ListCouncilsUseCase>>,
     get_deliberation: Option<Arc<GetDeliberationUseCase>>,
+    register_agent: Option<Arc<RegisterAgentUseCase>>,
+    unregister_agent: Option<Arc<UnregisterAgentUseCase>>,
     auto_dispatch: Option<Arc<AutoDispatchService>>,
     statistics: Option<Arc<dyn StatisticsPort>>,
     service_version: Option<&'static str>,
@@ -98,6 +103,8 @@ impl ChoreographerGrpcServiceBuilder {
     setter!(delete_council, DeleteCouncilUseCase, delete_council);
     setter!(list_councils, ListCouncilsUseCase, list_councils);
     setter!(get_deliberation, GetDeliberationUseCase, get_deliberation);
+    setter!(register_agent, RegisterAgentUseCase, register_agent);
+    setter!(unregister_agent, UnregisterAgentUseCase, unregister_agent);
     setter!(auto_dispatch, AutoDispatchService, auto_dispatch);
 
     #[must_use]
@@ -136,6 +143,14 @@ impl ChoreographerGrpcServiceBuilder {
                 .get_deliberation
                 .ok_or(DomainError::InvariantViolated {
                     reason: "grpc: get_deliberation use case is required",
+                })?,
+            register_agent: self.register_agent.ok_or(DomainError::InvariantViolated {
+                reason: "grpc: register_agent use case is required",
+            })?,
+            unregister_agent: self
+                .unregister_agent
+                .ok_or(DomainError::InvariantViolated {
+                    reason: "grpc: unregister_agent use case is required",
                 })?,
             auto_dispatch: self.auto_dispatch.ok_or(DomainError::InvariantViolated {
                 reason: "grpc: auto_dispatch service is required",
@@ -311,20 +326,39 @@ impl ChoreographerService for ChoreographerGrpcService {
 
     async fn register_agent(
         &self,
-        _request: Request<pb::RegisterAgentRequest>,
+        request: Request<pb::RegisterAgentRequest>,
     ) -> GrpcResult<pb::RegisterAgentResponse> {
-        Err(Status::unimplemented(
-            "RegisterAgent is not implemented yet; see service docblock",
-        ))
+        let descriptor =
+            descriptor_from_register_request(request.into_inner()).map_err(|err| match err {
+                DescriptorError::MissingAgentSummary => {
+                    Status::invalid_argument("agent summary is required")
+                }
+                DescriptorError::Domain(err) => domain_error_to_status(err),
+            })?;
+        let id = self
+            .register_agent
+            .execute(descriptor)
+            .await
+            .map_err(domain_error_to_status)?;
+        Ok(Response::new(pb::RegisterAgentResponse {
+            agent_id: id.into_inner(),
+        }))
     }
 
     async fn unregister_agent(
         &self,
-        _request: Request<pb::UnregisterAgentRequest>,
+        request: Request<pb::UnregisterAgentRequest>,
     ) -> GrpcResult<pb::UnregisterAgentResponse> {
-        Err(Status::unimplemented(
-            "UnregisterAgent is not implemented yet; see service docblock",
-        ))
+        let id = AgentId::new(request.into_inner().agent_id).map_err(domain_error_to_status)?;
+        match self.unregister_agent.execute(&id).await {
+            Ok(()) => Ok(Response::new(pb::UnregisterAgentResponse {
+                unregistered: true,
+            })),
+            Err(DomainError::NotFound { .. }) => Ok(Response::new(pb::UnregisterAgentResponse {
+                unregistered: false,
+            })),
+            Err(err) => Err(domain_error_to_status(err)),
+        }
     }
 
     async fn process_trigger_event(
@@ -401,6 +435,43 @@ impl ChoreographerService for ChoreographerGrpcService {
     }
 }
 
+/// Errors surfaced while turning a [`pb::RegisterAgentRequest`] into a
+/// domain [`AgentDescriptor`].
+#[derive(Debug)]
+enum DescriptorError {
+    MissingAgentSummary,
+    Domain(DomainError),
+}
+
+impl From<DomainError> for DescriptorError {
+    fn from(err: DomainError) -> Self {
+        Self::Domain(err)
+    }
+}
+
+/// Map the proto request into a domain descriptor.
+///
+/// Precedence on specialty: the dedicated top-level `specialty` field
+/// on the request wins when non-empty; otherwise the nested
+/// `agent.specialty` is used. This keeps the proto backwards-
+/// compatible without encoding two sources of truth downstream.
+fn descriptor_from_register_request(
+    req: pb::RegisterAgentRequest,
+) -> Result<AgentDescriptor, DescriptorError> {
+    let summary = req.agent.ok_or(DescriptorError::MissingAgentSummary)?;
+    let specialty_str = if req.specialty.trim().is_empty() {
+        summary.specialty
+    } else {
+        req.specialty
+    };
+    Ok(AgentDescriptor {
+        id: AgentId::new(summary.agent_id)?,
+        specialty: Specialty::new(specialty_str)?,
+        kind: AgentKind::new(summary.kind)?,
+        attributes: super::mappers::attributes_from_struct(req.agent_config)?,
+    })
+}
+
 /// Map the domain [`choreo_core::entities::Statistics`] into the
 /// protobuf `Statistics` message. Kept here, next to the only call
 /// sites, because it is a pure transport concern.
@@ -464,5 +535,62 @@ mod tests {
         assert_eq!(mapped.total_duration_ms, 0);
         assert!((mapped.average_duration_ms - 0.0).abs() < f64::EPSILON);
         assert!(mapped.per_specialty_counts.is_empty());
+    }
+
+    fn summary(id: &str, specialty: &str, kind: &str) -> pb::AgentSummary {
+        pb::AgentSummary {
+            agent_id: id.to_owned(),
+            specialty: specialty.to_owned(),
+            kind: kind.to_owned(),
+            attributes: None,
+        }
+    }
+
+    #[test]
+    fn descriptor_from_request_uses_top_level_specialty_when_present() {
+        let req = pb::RegisterAgentRequest {
+            specialty: "reviewer".to_owned(),
+            agent: Some(summary("a1", "triage", "noop")),
+            agent_config: None,
+        };
+        let d = descriptor_from_register_request(req).unwrap();
+        assert_eq!(d.id.as_str(), "a1");
+        assert_eq!(d.specialty.as_str(), "reviewer");
+        assert_eq!(d.kind.as_str(), "noop");
+        assert!(d.attributes.is_empty());
+    }
+
+    #[test]
+    fn descriptor_from_request_falls_back_to_nested_specialty_when_empty() {
+        let req = pb::RegisterAgentRequest {
+            specialty: "   ".to_owned(),
+            agent: Some(summary("a1", "triage", "noop")),
+            agent_config: None,
+        };
+        let d = descriptor_from_register_request(req).unwrap();
+        assert_eq!(d.specialty.as_str(), "triage");
+    }
+
+    #[test]
+    fn descriptor_from_request_missing_agent_is_reported() {
+        let req = pb::RegisterAgentRequest {
+            specialty: "triage".to_owned(),
+            agent: None,
+            agent_config: None,
+        };
+        let err = descriptor_from_register_request(req).unwrap_err();
+        assert!(matches!(err, DescriptorError::MissingAgentSummary));
+    }
+
+    #[test]
+    fn descriptor_from_request_domain_validation_propagates() {
+        // Empty kind fails at AgentKind construction.
+        let req = pb::RegisterAgentRequest {
+            specialty: "triage".to_owned(),
+            agent: Some(summary("a1", "triage", "")),
+            agent_config: None,
+        };
+        let err = descriptor_from_register_request(req).unwrap_err();
+        assert!(matches!(err, DescriptorError::Domain(_)));
     }
 }

--- a/crates/choreo-adapters/src/memory/agent_registry.rs
+++ b/crates/choreo-adapters/src/memory/agent_registry.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use choreo_core::error::DomainError;
-use choreo_core::ports::{AgentPort, AgentResolverPort};
+use choreo_core::ports::{AgentPort, AgentRegistryPort, AgentResolverPort};
 use choreo_core::value_objects::AgentId;
 use tokio::sync::RwLock;
 
@@ -69,6 +69,17 @@ impl AgentResolverPort for InMemoryAgentRegistry {
             .get(id)
             .cloned()
             .ok_or(DomainError::NotFound { what: "agent" })
+    }
+}
+
+#[async_trait]
+impl AgentRegistryPort for InMemoryAgentRegistry {
+    async fn register(&self, agent: Arc<dyn AgentPort>) -> Result<(), DomainError> {
+        self.insert(agent).await
+    }
+
+    async fn unregister(&self, id: &AgentId) -> Result<(), DomainError> {
+        self.remove(id).await
     }
 }
 

--- a/crates/choreo-adapters/src/noop/agent_factory.rs
+++ b/crates/choreo-adapters/src/noop/agent_factory.rs
@@ -1,0 +1,74 @@
+//! No-op [`AgentFactoryPort`] — materializes [`NoopAgent`]s for the
+//! `"noop"` kind and rejects every other kind with
+//! [`DomainError::InvariantViolated`].
+//!
+//! The composition root wires this factory unconditionally so a fresh
+//! deployment can exercise `RegisterAgent` without any provider feature
+//! enabled. Provider-backed factories (vLLM, Anthropic, OpenAI, …) can
+//! be composed alongside this one via a dispatching factory when those
+//! slices land; this adapter owns only `kind == "noop"`.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use choreo_core::error::DomainError;
+use choreo_core::ports::{AgentDescriptor, AgentFactoryPort, AgentPort};
+
+use super::agent::NoopAgent;
+
+pub const NOOP_AGENT_KIND: &str = "noop";
+
+#[derive(Debug, Default, Clone)]
+pub struct NoopAgentFactory;
+
+impl NoopAgentFactory {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl AgentFactoryPort for NoopAgentFactory {
+    async fn create(&self, descriptor: AgentDescriptor) -> Result<Arc<dyn AgentPort>, DomainError> {
+        if descriptor.kind.as_str() != NOOP_AGENT_KIND {
+            return Err(DomainError::InvariantViolated {
+                reason: "noop agent factory only accepts kind=\"noop\"",
+            });
+        }
+        Ok(Arc::new(NoopAgent::new(
+            descriptor.id,
+            descriptor.specialty,
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use choreo_core::value_objects::{AgentId, AgentKind, Attributes, Specialty};
+
+    fn descriptor(id: &str, kind: &str) -> AgentDescriptor {
+        AgentDescriptor {
+            id: AgentId::new(id).unwrap(),
+            specialty: Specialty::new("triage").unwrap(),
+            kind: AgentKind::new(kind).unwrap(),
+            attributes: Attributes::empty(),
+        }
+    }
+
+    #[tokio::test]
+    async fn noop_kind_is_materialized() {
+        let factory = NoopAgentFactory::new();
+        let agent = factory.create(descriptor("a1", "noop")).await.unwrap();
+        assert_eq!(agent.id().as_str(), "a1");
+        assert_eq!(agent.specialty().as_str(), "triage");
+    }
+
+    #[tokio::test]
+    async fn unsupported_kind_is_rejected_with_invariant_violation() {
+        let factory = NoopAgentFactory::new();
+        let err = factory.create(descriptor("a1", "vllm")).await.unwrap_err();
+        assert!(matches!(err, DomainError::InvariantViolated { .. }));
+    }
+}

--- a/crates/choreo-adapters/src/noop/mod.rs
+++ b/crates/choreo-adapters/src/noop/mod.rs
@@ -6,9 +6,11 @@
 //! and are also used extensively in tests.
 
 mod agent;
+mod agent_factory;
 mod executor;
 mod messaging;
 
 pub use agent::NoopAgent;
+pub use agent_factory::{NoopAgentFactory, NOOP_AGENT_KIND};
 pub use executor::NoopExecutor;
 pub use messaging::NoopMessaging;

--- a/crates/choreo-app/src/usecases/mod.rs
+++ b/crates/choreo-app/src/usecases/mod.rs
@@ -10,6 +10,8 @@ mod deliberate;
 mod get_deliberation;
 mod list_councils;
 mod orchestrate;
+mod register_agent;
+mod unregister_agent;
 
 pub use create_council::{CreateCouncilInput, CreateCouncilUseCase};
 pub use delete_council::DeleteCouncilUseCase;
@@ -17,3 +19,5 @@ pub use deliberate::{DeliberateOutput, DeliberateUseCase};
 pub use get_deliberation::GetDeliberationUseCase;
 pub use list_councils::ListCouncilsUseCase;
 pub use orchestrate::{OrchestrateOutput, OrchestrateUseCase};
+pub use register_agent::RegisterAgentUseCase;
+pub use unregister_agent::UnregisterAgentUseCase;

--- a/crates/choreo-app/src/usecases/register_agent.rs
+++ b/crates/choreo-app/src/usecases/register_agent.rs
@@ -1,0 +1,202 @@
+//! [`RegisterAgentUseCase`] — materialize an agent from a descriptor
+//! via [`AgentFactoryPort`] and store it in the registry through
+//! [`AgentRegistryPort`].
+//!
+//! This use case does **not** attach the agent to any council. Council
+//! membership stays under the responsibility of
+//! [`crate::usecases::CreateCouncilUseCase`]; registering the agent
+//! only makes it resolvable by id — subsequent calls to
+//! `CreateCouncil` or `Deliberate` may then include it.
+//!
+//! Returns the [`AgentId`] that was registered so gRPC handlers can
+//! echo it back in the response.
+
+use std::sync::Arc;
+
+use choreo_core::error::DomainError;
+use choreo_core::ports::{AgentDescriptor, AgentFactoryPort, AgentRegistryPort};
+use choreo_core::value_objects::AgentId;
+use tracing::info;
+
+pub struct RegisterAgentUseCase {
+    factory: Arc<dyn AgentFactoryPort>,
+    registry: Arc<dyn AgentRegistryPort>,
+}
+
+impl std::fmt::Debug for RegisterAgentUseCase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RegisterAgentUseCase").finish()
+    }
+}
+
+impl RegisterAgentUseCase {
+    #[must_use]
+    pub fn new(factory: Arc<dyn AgentFactoryPort>, registry: Arc<dyn AgentRegistryPort>) -> Self {
+        Self { factory, registry }
+    }
+
+    pub async fn execute(&self, descriptor: AgentDescriptor) -> Result<AgentId, DomainError> {
+        let id = descriptor.id.clone();
+        let kind = descriptor.kind.clone();
+        let specialty = descriptor.specialty.clone();
+
+        let agent = self.factory.create(descriptor).await?;
+        self.registry.register(agent).await?;
+
+        info!(
+            agent_id = id.as_str(),
+            specialty = specialty.as_str(),
+            kind = kind.as_str(),
+            "agent registered"
+        );
+        Ok(id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use choreo_core::entities::TaskConstraints;
+    use choreo_core::ports::{AgentPort, Critique, DraftRequest, Revision};
+    use choreo_core::value_objects::{AgentKind, Attributes, Specialty};
+    use std::sync::Mutex;
+
+    #[derive(Debug)]
+    struct StubAgent {
+        id: AgentId,
+        specialty: Specialty,
+    }
+    #[async_trait]
+    impl AgentPort for StubAgent {
+        fn id(&self) -> &AgentId {
+            &self.id
+        }
+        fn specialty(&self) -> &Specialty {
+            &self.specialty
+        }
+        async fn generate(&self, _request: DraftRequest) -> Result<Revision, DomainError> {
+            Ok(Revision {
+                content: String::new(),
+            })
+        }
+        async fn critique(
+            &self,
+            _peer_content: &str,
+            _constraints: &TaskConstraints,
+        ) -> Result<Critique, DomainError> {
+            Ok(Critique {
+                feedback: String::new(),
+            })
+        }
+        async fn revise(&self, own: &str, _critique: &Critique) -> Result<Revision, DomainError> {
+            Ok(Revision {
+                content: own.to_owned(),
+            })
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingFactory {
+        kind_accepted: &'static str,
+        created: Mutex<Vec<AgentId>>,
+    }
+    #[async_trait]
+    impl AgentFactoryPort for RecordingFactory {
+        async fn create(
+            &self,
+            descriptor: AgentDescriptor,
+        ) -> Result<Arc<dyn AgentPort>, DomainError> {
+            if descriptor.kind.as_str() != self.kind_accepted {
+                return Err(DomainError::InvariantViolated {
+                    reason: "test factory: unsupported kind",
+                });
+            }
+            self.created.lock().unwrap().push(descriptor.id.clone());
+            Ok(Arc::new(StubAgent {
+                id: descriptor.id,
+                specialty: descriptor.specialty,
+            }))
+        }
+    }
+
+    #[derive(Default)]
+    struct InMemoryRegistry {
+        inserted: Mutex<Vec<AgentId>>,
+        reject_second: bool,
+    }
+    #[async_trait]
+    impl AgentRegistryPort for InMemoryRegistry {
+        async fn register(&self, agent: Arc<dyn AgentPort>) -> Result<(), DomainError> {
+            let mut v = self.inserted.lock().unwrap();
+            if self.reject_second && !v.is_empty() {
+                return Err(DomainError::AlreadyExists { what: "agent" });
+            }
+            v.push(agent.id().clone());
+            Ok(())
+        }
+        async fn unregister(&self, _id: &AgentId) -> Result<(), DomainError> {
+            unimplemented!()
+        }
+    }
+
+    fn descriptor(id: &str, kind: &str) -> AgentDescriptor {
+        AgentDescriptor {
+            id: AgentId::new(id).unwrap(),
+            specialty: Specialty::new("triage").unwrap(),
+            kind: AgentKind::new(kind).unwrap(),
+            attributes: Attributes::empty(),
+        }
+    }
+
+    #[tokio::test]
+    async fn happy_path_creates_and_registers() {
+        let factory = Arc::new(RecordingFactory {
+            kind_accepted: "noop",
+            ..RecordingFactory::default()
+        });
+        let registry = Arc::new(InMemoryRegistry::default());
+        let usecase = RegisterAgentUseCase::new(factory.clone(), registry.clone());
+
+        let id = usecase.execute(descriptor("a1", "noop")).await.unwrap();
+        assert_eq!(id.as_str(), "a1");
+        assert_eq!(factory.created.lock().unwrap().len(), 1);
+        assert_eq!(registry.inserted.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn factory_rejection_propagates_unchanged() {
+        let factory = Arc::new(RecordingFactory {
+            kind_accepted: "noop",
+            ..RecordingFactory::default()
+        });
+        let registry = Arc::new(InMemoryRegistry::default());
+        let usecase = RegisterAgentUseCase::new(factory, registry.clone());
+
+        let err = usecase.execute(descriptor("a1", "vllm")).await.unwrap_err();
+        assert!(matches!(err, DomainError::InvariantViolated { .. }));
+        // Registry must stay empty when factory rejects.
+        assert!(registry.inserted.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn registry_rejection_does_not_eat_created_agent() {
+        let factory = Arc::new(RecordingFactory {
+            kind_accepted: "noop",
+            ..RecordingFactory::default()
+        });
+        let registry = Arc::new(InMemoryRegistry {
+            reject_second: true,
+            ..InMemoryRegistry::default()
+        });
+        let usecase = RegisterAgentUseCase::new(factory.clone(), registry.clone());
+
+        usecase.execute(descriptor("a1", "noop")).await.unwrap();
+        let err = usecase.execute(descriptor("a2", "noop")).await.unwrap_err();
+        assert!(matches!(err, DomainError::AlreadyExists { what: "agent" }));
+        // Factory was invoked twice (even though only one made it to
+        // the registry). This is by design: the factory owns the
+        // agent's lifetime and can clean up its side effects if any.
+        assert_eq!(factory.created.lock().unwrap().len(), 2);
+    }
+}

--- a/crates/choreo-app/src/usecases/unregister_agent.rs
+++ b/crates/choreo-app/src/usecases/unregister_agent.rs
@@ -1,0 +1,91 @@
+//! [`UnregisterAgentUseCase`] — remove an agent from the registry by
+//! id.
+//!
+//! Does **not** scrub councils that reference the id. Subsequent
+//! deliberations that include the id will fail with
+//! [`DomainError::NotFound`] at resolve time — which is louder than
+//! silently editing council membership, and matches the semantics of
+//! `DeleteCouncil` (it does not unregister member agents either).
+
+use std::sync::Arc;
+
+use choreo_core::error::DomainError;
+use choreo_core::ports::AgentRegistryPort;
+use choreo_core::value_objects::AgentId;
+use tracing::info;
+
+pub struct UnregisterAgentUseCase {
+    registry: Arc<dyn AgentRegistryPort>,
+}
+
+impl std::fmt::Debug for UnregisterAgentUseCase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UnregisterAgentUseCase").finish()
+    }
+}
+
+impl UnregisterAgentUseCase {
+    #[must_use]
+    pub fn new(registry: Arc<dyn AgentRegistryPort>) -> Self {
+        Self { registry }
+    }
+
+    pub async fn execute(&self, id: &AgentId) -> Result<(), DomainError> {
+        self.registry.unregister(id).await?;
+        info!(agent_id = id.as_str(), "agent unregistered");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use choreo_core::ports::AgentPort;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct StubRegistry {
+        removed: Mutex<Vec<AgentId>>,
+        miss: bool,
+    }
+    #[async_trait]
+    impl AgentRegistryPort for StubRegistry {
+        async fn register(&self, _agent: Arc<dyn AgentPort>) -> Result<(), DomainError> {
+            unimplemented!()
+        }
+        async fn unregister(&self, id: &AgentId) -> Result<(), DomainError> {
+            if self.miss {
+                return Err(DomainError::NotFound { what: "agent" });
+            }
+            self.removed.lock().unwrap().push(id.clone());
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn happy_path_unregisters() {
+        let registry = Arc::new(StubRegistry::default());
+        let usecase = UnregisterAgentUseCase::new(registry.clone());
+        usecase.execute(&AgentId::new("a1").unwrap()).await.unwrap();
+        assert_eq!(
+            registry.removed.lock().unwrap()[0].as_str(),
+            "a1",
+            "registry must receive the exact id"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_agent_surfaces_as_not_found() {
+        let registry = Arc::new(StubRegistry {
+            miss: true,
+            ..StubRegistry::default()
+        });
+        let usecase = UnregisterAgentUseCase::new(registry);
+        let err = usecase
+            .execute(&AgentId::new("missing").unwrap())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, DomainError::NotFound { what: "agent" }));
+    }
+}

--- a/crates/choreo-core/src/ports/agent_factory.rs
+++ b/crates/choreo-core/src/ports/agent_factory.rs
@@ -1,0 +1,44 @@
+//! [`AgentFactoryPort`] — materialize an [`AgentPort`] from a typed
+//! descriptor.
+//!
+//! Callers (the composition root and the `RegisterAgent` RPC) do not
+//! construct agent implementations directly; they hand a descriptor to
+//! this factory and receive a live handle back. That keeps the set of
+//! wired providers (vLLM, Anthropic, OpenAI, rule-based, human-in-the-
+//! loop, …) behind Cargo features at the adapter layer, exactly like
+//! every other provider-specific concern in this crate.
+//!
+//! The `kind` field in [`AgentDescriptor`] names the provider the
+//! factory should dispatch to. Adapters return
+//! [`DomainError::InvariantViolated`] when asked for a kind they do
+//! not support; the composition root is responsible for wiring a
+//! factory that recognises every kind the deployment intends to accept.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::error::DomainError;
+use crate::ports::agent::AgentPort;
+use crate::value_objects::{AgentId, AgentKind, Attributes, Specialty};
+
+/// Everything the factory needs to build a live agent. Mirrors the
+/// `AgentSummary` proto, but kept in domain shapes so use cases never
+/// touch wire types.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentDescriptor {
+    pub id: AgentId,
+    pub specialty: Specialty,
+    pub kind: AgentKind,
+    pub attributes: Attributes,
+}
+
+#[async_trait]
+pub trait AgentFactoryPort: Send + Sync {
+    /// Produce a live agent matching `descriptor`.
+    ///
+    /// Adapters that do not recognise `descriptor.kind` must return
+    /// [`DomainError::InvariantViolated`] with a reason naming the
+    /// unsupported kind, so operators see the mismatch loudly.
+    async fn create(&self, descriptor: AgentDescriptor) -> Result<Arc<dyn AgentPort>, DomainError>;
+}

--- a/crates/choreo-core/src/ports/agent_registry.rs
+++ b/crates/choreo-core/src/ports/agent_registry.rs
@@ -1,0 +1,30 @@
+//! [`AgentRegistryPort`] — write side of the agent registry.
+//!
+//! The read side is [`AgentResolverPort`](super::AgentResolverPort):
+//! use cases that need live handles go through the resolver. This port
+//! exists so operator-facing RPCs (`RegisterAgent`, `UnregisterAgent`)
+//! can mutate the registry without coupling to a concrete adapter.
+//!
+//! Kept segregated from the resolver per ISP: the deliberation use
+//! case does not need write access, and an adapter may reasonably
+//! implement read but not write (e.g. a cache in front of a static
+//! config file).
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::error::DomainError;
+use crate::ports::agent::AgentPort;
+use crate::value_objects::AgentId;
+
+#[async_trait]
+pub trait AgentRegistryPort: Send + Sync {
+    /// Register `agent` under its [`AgentPort::id`]. Returns
+    /// [`DomainError::AlreadyExists`] if the id is taken.
+    async fn register(&self, agent: Arc<dyn AgentPort>) -> Result<(), DomainError>;
+
+    /// Unregister the agent with `id`. Returns
+    /// [`DomainError::NotFound`] when no such agent is present.
+    async fn unregister(&self, id: &AgentId) -> Result<(), DomainError>;
+}

--- a/crates/choreo-core/src/ports/mod.rs
+++ b/crates/choreo-core/src/ports/mod.rs
@@ -15,6 +15,8 @@
 //!   change.
 
 mod agent;
+mod agent_factory;
+mod agent_registry;
 mod agent_resolver;
 mod clock;
 mod configuration;
@@ -27,6 +29,8 @@ mod statistics;
 mod validator;
 
 pub use agent::{AgentPort, Critique, DraftRequest, Revision};
+pub use agent_factory::{AgentDescriptor, AgentFactoryPort};
+pub use agent_registry::AgentRegistryPort;
 pub use agent_resolver::AgentResolverPort;
 pub use clock::ClockPort;
 pub use configuration::{ConfigurationPort, ServiceConfig};

--- a/crates/choreo-core/src/value_objects/agent_kind.rs
+++ b/crates/choreo-core/src/value_objects/agent_kind.rs
@@ -1,0 +1,127 @@
+//! [`AgentKind`] value object.
+//!
+//! Identifier that tells the [`AgentFactoryPort`](crate::ports::AgentFactoryPort)
+//! which provider adapter should materialize an agent from a
+//! descriptor. The choreographer does not enumerate kinds itself —
+//! operators pick the labels (`"noop"`, `"vllm"`, `"anthropic"`,
+//! `"openai"`, `"rule"`, `"human"`, …) that match the factories wired
+//! in their composition root.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::DomainError;
+
+const MAX_AGENT_KIND_LEN: usize = 64;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct AgentKind(String);
+
+impl AgentKind {
+    pub fn new(raw: impl Into<String>) -> Result<Self, DomainError> {
+        let trimmed = raw.into().trim().to_owned();
+        if trimmed.is_empty() {
+            return Err(DomainError::EmptyField {
+                field: "agent.kind",
+            });
+        }
+        if trimmed.len() > MAX_AGENT_KIND_LEN {
+            return Err(DomainError::FieldTooLong {
+                field: "agent.kind",
+                actual: trimmed.len(),
+                max: MAX_AGENT_KIND_LEN,
+            });
+        }
+        if trimmed.chars().any(char::is_control) {
+            return Err(DomainError::InvalidCharacters {
+                field: "agent.kind",
+            });
+        }
+        Ok(Self(trimmed))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    #[must_use]
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Display for AgentKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl TryFrom<&str> for AgentKind {
+    type Error = DomainError;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<String> for AgentKind {
+    type Error = DomainError;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn arbitrary_label_is_accepted() {
+        let k = AgentKind::new("vllm").unwrap();
+        assert_eq!(k.as_str(), "vllm");
+    }
+
+    #[test]
+    fn label_is_trimmed() {
+        assert_eq!(AgentKind::new("  noop  ").unwrap().as_str(), "noop");
+    }
+
+    #[test]
+    fn empty_is_rejected() {
+        assert!(matches!(
+            AgentKind::new("   ").unwrap_err(),
+            DomainError::EmptyField {
+                field: "agent.kind"
+            }
+        ));
+    }
+
+    #[test]
+    fn overlong_is_rejected() {
+        let err = AgentKind::new("a".repeat(MAX_AGENT_KIND_LEN + 1)).unwrap_err();
+        assert!(matches!(err, DomainError::FieldTooLong { .. }));
+    }
+
+    #[test]
+    fn control_characters_are_rejected() {
+        assert!(matches!(
+            AgentKind::new("bad\nkind").unwrap_err(),
+            DomainError::InvalidCharacters {
+                field: "agent.kind"
+            }
+        ));
+    }
+
+    #[test]
+    fn display_matches_inner() {
+        assert_eq!(AgentKind::new("rule").unwrap().to_string(), "rule");
+    }
+
+    #[test]
+    fn serde_is_transparent() {
+        let k = AgentKind::new("anthropic").unwrap();
+        assert_eq!(serde_json::to_string(&k).unwrap(), "\"anthropic\"");
+    }
+}

--- a/crates/choreo-core/src/value_objects/mod.rs
+++ b/crates/choreo-core/src/value_objects/mod.rs
@@ -4,6 +4,7 @@
 //! of primitives. Each value object validates its invariants on
 //! construction and cannot be mutated afterwards.
 
+mod agent_kind;
 mod attributes;
 mod duration;
 mod ids;
@@ -14,6 +15,7 @@ mod score;
 mod specialty;
 mod task_description;
 
+pub use agent_kind::AgentKind;
 pub use attributes::Attributes;
 pub use duration::DurationMs;
 pub use ids::{AgentId, CouncilId, EventId, ProposalId, TaskId};

--- a/crates/choreo-proto/proto/underpass/choreo/v1/choreo.proto
+++ b/crates/choreo-proto/proto/underpass/choreo/v1/choreo.proto
@@ -39,15 +39,21 @@ import "google/protobuf/timestamp.proto";
 //
 //   Deliberate, Orchestrate, GetDeliberationResult,
 //   CreateCouncil, ListCouncils, DeleteCouncil,
-//   ProcessTriggerEvent, GetStatus, GetMetrics
+//   ProcessTriggerEvent, GetStatus, GetMetrics,
+//   RegisterAgent, UnregisterAgent
 //     -> backed by a use case in `choreo-app/src/usecases/` (or
 //        `services/auto_dispatch.rs` for ProcessTriggerEvent;
-//        `StatisticsPort::snapshot` for GetStatus / GetMetrics).
+//        `StatisticsPort::snapshot` for GetStatus / GetMetrics;
+//        `AgentFactoryPort` + `AgentRegistryPort` for RegisterAgent /
+//        UnregisterAgent). RegisterAgent currently materializes only
+//        `kind == "noop"` — provider-backed kinds (vLLM, Anthropic,
+//        OpenAI, …) are wired in their respective feature slices by
+//        composing a richer AgentFactoryPort in the binary.
 //
-//   StreamDeliberation, RegisterAgent, UnregisterAgent
-//     -> declared here because they belong to the contract, but the
-//        server returns `UNIMPLEMENTED` until their backing use cases
-//        land. Enumerate what is real (not what is planned) per the
+//   StreamDeliberation
+//     -> declared here because it belongs to the contract, but the
+//        server returns `UNIMPLEMENTED` until a streaming backing
+//        lands. Enumerate what is real (not what is planned) per the
 //        project's honesty principles.
 service ChoreographerService {
   // ---- Deliberation ----------------------------------------------------

--- a/crates/choreo/src/compose.rs
+++ b/crates/choreo/src/compose.rs
@@ -9,18 +9,18 @@ use choreo_adapters::memory::{
     InMemoryStatistics,
 };
 use choreo_adapters::nats::{NatsConfig, NatsMessaging, NatsTriggerSubscriber};
-use choreo_adapters::noop::{NoopExecutor, NoopMessaging};
+use choreo_adapters::noop::{NoopAgentFactory, NoopExecutor, NoopMessaging};
 use choreo_adapters::scoring::UniformScoring;
 use choreo_adapters::validators::ContentNonEmptyValidator;
 use choreo_app::services::AutoDispatchService;
 use choreo_app::usecases::{
     CreateCouncilUseCase, DeleteCouncilUseCase, DeliberateUseCase, GetDeliberationUseCase,
-    ListCouncilsUseCase, OrchestrateUseCase,
+    ListCouncilsUseCase, OrchestrateUseCase, RegisterAgentUseCase, UnregisterAgentUseCase,
 };
 use choreo_core::error::DomainError;
 use choreo_core::ports::{
-    ConfigurationPort, ExecutorPort, MessagingPort, ScoringPort, ServiceConfig, StatisticsPort,
-    ValidatorPort,
+    AgentFactoryPort, AgentRegistryPort, ConfigurationPort, ExecutorPort, MessagingPort,
+    ScoringPort, ServiceConfig, StatisticsPort, ValidatorPort,
 };
 use thiserror::Error;
 use tracing::info;
@@ -123,6 +123,14 @@ pub async fn compose() -> Result<Application, ComposeError> {
     let list_councils = Arc::new(ListCouncilsUseCase::new(council_registry.clone()));
     let get_deliberation = Arc::new(GetDeliberationUseCase::new(repository.clone()));
 
+    let agent_factory: Arc<dyn AgentFactoryPort> = Arc::new(NoopAgentFactory::new());
+    let agent_registry_port: Arc<dyn AgentRegistryPort> = agent_registry.clone();
+    let register_agent = Arc::new(RegisterAgentUseCase::new(
+        agent_factory,
+        agent_registry_port.clone(),
+    ));
+    let unregister_agent = Arc::new(UnregisterAgentUseCase::new(agent_registry_port));
+
     let auto_dispatch = Arc::new(AutoDispatchService::new(
         deliberate.clone(),
         "Investigate the incoming trigger event.",
@@ -147,6 +155,8 @@ pub async fn compose() -> Result<Application, ComposeError> {
         .delete_council(delete_council)
         .list_councils(list_councils)
         .get_deliberation(get_deliberation)
+        .register_agent(register_agent)
+        .unregister_agent(unregister_agent)
         .auto_dispatch(auto_dispatch)
         .statistics(statistics.clone())
         .service_version(env!("CARGO_PKG_VERSION"))


### PR DESCRIPTION
## Summary

- Brings `RegisterAgent` and `UnregisterAgent` out of the UNIMPLEMENTED honesty list — only `StreamDeliberation` remains
- New hexagonal ports: `AgentRegistryPort` (write side of the resolver) and `AgentFactoryPort` (materialize `AgentPort` from a typed descriptor)
- `NoopAgentFactory` is the only factory wired today (`kind == \"noop\"`); provider-specific factories (vLLM, Anthropic, OpenAI, …) exist as feature-gated adapters and land in their own slice via a dispatching factory
- New value object `AgentKind` (validated trimmed non-empty label, ≤ 64 chars, no control chars)

## What changed

- `choreo-core`: new `AgentRegistryPort`, `AgentFactoryPort` + `AgentDescriptor`, `AgentKind` value object
- `choreo-adapters`: `InMemoryAgentRegistry` now implements `AgentRegistryPort` (forwards to existing `insert`/`remove`); new `NoopAgentFactory`; gRPC handlers replaced (no more UNIMPLEMENTED); new `descriptor_from_register_request` with specialty precedence (top-level wins over nested when non-empty)
- `choreo-app`: `RegisterAgentUseCase` + `UnregisterAgentUseCase`
- `choreo` (binary): composition wires `NoopAgentFactory` + both use cases; gRPC builder gets `register_agent` / `unregister_agent` setters
- `choreo-proto`: docblock honesty list updated; `RegisterAgent`/`UnregisterAgent` move from UNIMPLEMENTED to real
- `README.md`: \"What runs today\" and \"What is not wired yet\" updated

## Tests added

- `AgentKind`: 7 validation tests (accept, trim, empty, overlong, control chars, display, serde)
- `NoopAgentFactory`: noop kind materialized, unsupported kind rejected
- `RegisterAgentUseCase`: happy path, factory rejection leaves registry untouched, registry rejection after factory creates (both factory invocations recorded)
- `UnregisterAgentUseCase`: happy path, missing agent surfaces as NotFound
- `descriptor_from_register_request`: top-level specialty wins, nested fallback when empty, missing agent summary reported, domain validation propagates

## Test plan
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\`
- [x] \`cargo test --workspace\`
- [ ] CI green on all 11 checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)