### PR TITLE
feat(persistence): phase 11a — Postgres deliberation repository

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -41,3 +41,29 @@ jobs:
 
       - name: Run NATS integration tests
         run: bash scripts/ci/integration-nats.sh
+
+  integration-postgres:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
+        with:
+          toolchain: 1.90.0
+
+      - name: Install protoc
+        run: bash scripts/ci/install-protoc.sh
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+
+      - name: Verify Docker (testcontainers backend)
+        run: docker version
+
+      - name: Run Postgres integration tests
+        run: bash scripts/ci/integration-postgres.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +115,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -216,6 +231,9 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -287,6 +305,12 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -362,6 +386,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sqlx",
  "thiserror 1.0.69",
  "time",
  "tokio",
@@ -456,6 +481,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,6 +529,36 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -618,7 +682,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -642,6 +708,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "downcast"
@@ -682,6 +754,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "equivalent"
@@ -708,6 +783,17 @@ dependencies = [
  "cfg-if",
  "home",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -758,6 +844,17 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
 
 [[package]]
 name = "fnv"
@@ -829,6 +926,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -958,6 +1066,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -966,6 +1076,15 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "heck"
@@ -984,6 +1103,24 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "home"
@@ -1089,7 +1226,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1359,6 +1496,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -1373,6 +1513,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1382,6 +1528,16 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.4",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1431,6 +1587,16 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -1521,10 +1687,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1533,6 +1735,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1562,6 +1765,12 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1686,6 +1895,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,6 +1914,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -2087,7 +2313,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -2102,6 +2328,26 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2432,6 +2678,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2500,6 +2757,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -2522,6 +2782,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2532,10 +2801,219 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap 2.14.0",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.11.1",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.11.1",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -3123,10 +3601,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-xid"
@@ -3178,6 +3677,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3215,6 +3720,12 @@ checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -3327,11 +3838,30 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,17 @@ prost-types = "0.13"
 # NATS
 async-nats = "0.38"
 
+# SQL / persistence
+sqlx = { version = "0.8", default-features = false, features = [
+    "runtime-tokio-rustls",
+    "postgres",
+    "macros",
+    "migrate",
+    "time",
+    "uuid",
+    "json",
+] }
+
 # config
 figment = { version = "0.10", features = ["env", "toml"] }
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ gate in this repository):
   registers one `NoopAgent` and one single-agent council per specialty
   so a fresh deployment is immediately exercisable end-to-end.
 
+**Persistence**:
+
+- Deliberations persist to Postgres when `CHOREO_POSTGRES_URL` is
+  set (the binary is built with the `postgres` feature); otherwise
+  the in-memory repository is wired. Migrations apply on startup —
+  a fresh cluster is immediately exercisable. Schema lives under
+  `crates/choreo-adapters/migrations/postgres/`.
+- Councils, agent registry, and statistics still run in memory;
+  they get their own persistent backings in later slices.
+
 **What is *not* wired yet**:
 
 - The wired `AgentFactoryPort` today only recognises `kind == "noop"`.
@@ -100,6 +110,7 @@ gate in this repository):
   slice.
 - `StreamDeliberation` streams phase transitions only; per-proposal,
   per-critique, and per-revision streaming arrives in a later slice.
-- Persistence beyond in-process memory.
+- Multi-replica persistence for councils, agent registry, and
+  statistics (they are still in-memory).
 
 See `docs/experiments/` for anything beyond these bullet points.

--- a/charts/choreographer/templates/deployment.yaml
+++ b/charts/choreographer/templates/deployment.yaml
@@ -65,6 +65,10 @@ spec:
             - name: CHOREO_SEED_SPECIALTIES
               value: {{ .Values.config.seedSpecialties | quote }}
             {{- end }}
+            {{- if and .Values.persistence .Values.persistence.postgres .Values.persistence.postgres.enabled .Values.persistence.postgres.url }}
+            - name: CHOREO_POSTGRES_URL
+              value: {{ .Values.persistence.postgres.url | quote }}
+            {{- end }}
           {{- if .Values.probes.liveness.enabled }}
           livenessProbe:
             httpGet:

--- a/charts/choreographer/values.yaml
+++ b/charts/choreographer/values.yaml
@@ -97,6 +97,20 @@ messaging:
     # Wildcard of inbound trigger subjects consumed by the service.
     triggerSubject: choreo.trigger.>
 
+# Persistent storage for deliberations.
+# When `enabled: true`, the binary wires the Postgres repository
+# (migrations apply on startup). Otherwise the in-memory repository
+# is used. Only deliberations persist at this phase; councils,
+# agent registry, and statistics remain in-memory.
+persistence:
+  postgres:
+    enabled: false
+    # Plain URL form. Real deployments should source this from a
+    # Secret-mounted file and set `urlFromSecret.name/key` instead of
+    # hard-coding here; those fields arrive with the chart-hardening
+    # slice.
+    url: ""
+
 tls:
   # Transport security mode for the gRPC service.
   # One of: "none" | "server" | "mutual".

--- a/crates/choreo-adapters/Cargo.toml
+++ b/crates/choreo-adapters/Cargo.toml
@@ -21,6 +21,12 @@ default = ["grpc", "nats"]
 grpc = ["dep:prost-types"]
 nats = ["dep:async-nats"]
 
+# Persistence. Postgres adapter for DeliberationRepositoryPort.
+# Other registries (councils, agents, statistics) remain in-memory
+# in this slice; they will grow their own persistent backings in
+# later slices.
+postgres = ["dep:sqlx"]
+
 # Agent providers (LLMs, humans-in-the-loop, rule engines, ...).
 # Each is a peer adapter behind its own feature flag — none is privileged.
 agent-vllm = ["_http"]
@@ -52,6 +58,7 @@ uuid = { workspace = true }
 prost-types = { workspace = true, optional = true }
 async-nats = { workspace = true, optional = true }
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false, optional = true }
+sqlx = { workspace = true, optional = true }
 
 [dev-dependencies]
 mockall = { workspace = true }

--- a/crates/choreo-adapters/migrations/postgres/0001_deliberations.sql
+++ b/crates/choreo-adapters/migrations/postgres/0001_deliberations.sql
@@ -1,0 +1,24 @@
+-- Phase 11a: deliberation persistence.
+--
+-- One row per deliberation, keyed by the task id that originated it.
+-- The full aggregate is stored as JSONB so the schema does not couple
+-- to any particular provider or use-case vocabulary. Query-friendly
+-- projections (specialty, phase, winner_proposal_id) are kept as
+-- plain columns for indexable filters without having to parse the
+-- JSON every time.
+
+CREATE TABLE IF NOT EXISTS deliberations (
+    task_id              TEXT PRIMARY KEY,
+    specialty            TEXT NOT NULL,
+    phase                TEXT NOT NULL,
+    winner_proposal_id   TEXT,
+    body                 JSONB NOT NULL,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at           TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS deliberations_specialty_idx
+    ON deliberations (specialty);
+
+CREATE INDEX IF NOT EXISTS deliberations_phase_idx
+    ON deliberations (phase);

--- a/crates/choreo-adapters/src/config.rs
+++ b/crates/choreo-adapters/src/config.rs
@@ -24,6 +24,7 @@ use tracing::debug;
 /// | `CHOREO_NATS_URL`          | `nats://nats:4222`    |
 /// | `CHOREO_TRIGGER_SUBJECT`   | `choreo.trigger.>`    |
 /// | `CHOREO_PUBLISH_PREFIX`    | `choreo`              |
+/// | `CHOREO_POSTGRES_URL`      | (unset)               |
 ///
 /// The adapter performs no IO at construction; `load` returns a
 /// snapshot of the current environment.
@@ -45,6 +46,7 @@ struct Defaults {
     nats_url: String,
     trigger_subject: String,
     publish_prefix: String,
+    postgres_url: String,
 }
 
 impl Default for Defaults {
@@ -56,6 +58,7 @@ impl Default for Defaults {
             nats_url: "nats://nats:4222".to_owned(),
             trigger_subject: "choreo.trigger.>".to_owned(),
             publish_prefix: "choreo".to_owned(),
+            postgres_url: String::new(),
         }
     }
 }
@@ -73,6 +76,12 @@ impl ConfigurationPort for EnvConfiguration {
             }
         })?;
 
+        let postgres_url = if loaded.postgres_url.trim().is_empty() {
+            None
+        } else {
+            Some(loaded.postgres_url)
+        };
+
         Ok(ServiceConfig {
             grpc_port: loaded.grpc_port,
             http_port: loaded.http_port,
@@ -80,6 +89,7 @@ impl ConfigurationPort for EnvConfiguration {
             nats_url: loaded.nats_url,
             trigger_subject: loaded.trigger_subject,
             publish_prefix: loaded.publish_prefix,
+            postgres_url,
         })
     }
 }
@@ -128,6 +138,28 @@ mod tests {
         assert_eq!(cfg.grpc_port, 50099);
         assert!(!cfg.nats_enabled);
         assert_eq!(cfg.publish_prefix, "choreo.prod");
+
+        clear_env();
+    }
+
+    #[tokio::test]
+    async fn postgres_url_defaults_to_none_and_trims_empty() {
+        let _guard = ENV_LOCK.lock().await;
+        clear_env();
+
+        let cfg = EnvConfiguration::new().load().await.unwrap();
+        assert!(cfg.postgres_url.is_none());
+
+        std::env::set_var("CHOREO_POSTGRES_URL", "   ");
+        let cfg = EnvConfiguration::new().load().await.unwrap();
+        assert!(
+            cfg.postgres_url.is_none(),
+            "whitespace-only must be treated as unset"
+        );
+
+        std::env::set_var("CHOREO_POSTGRES_URL", "postgres://x/y");
+        let cfg = EnvConfiguration::new().load().await.unwrap();
+        assert_eq!(cfg.postgres_url.as_deref(), Some("postgres://x/y"));
 
         clear_env();
     }

--- a/crates/choreo-adapters/src/lib.rs
+++ b/crates/choreo-adapters/src/lib.rs
@@ -25,6 +25,7 @@
 //! | Feature            | Integration                                 |
 //! |--------------------|---------------------------------------------|
 //! | `nats`             | NATS JetStream messaging adapter            |
+//! | `postgres`         | Postgres deliberation repository (sqlx)     |
 //! | `agent-vllm`       | vLLM / OpenAI-compatible local inference    |
 //! | `agent-anthropic`  | Anthropic Messages API                      |
 //! | `agent-openai`     | OpenAI Chat Completions / Responses API     |
@@ -46,5 +47,8 @@ pub mod grpc;
 
 #[cfg(feature = "nats")]
 pub mod nats;
+
+#[cfg(feature = "postgres")]
+pub mod postgres;
 
 pub mod agents;

--- a/crates/choreo-adapters/src/postgres/deliberation_repository.rs
+++ b/crates/choreo-adapters/src/postgres/deliberation_repository.rs
@@ -1,0 +1,122 @@
+//! Postgres implementation of [`DeliberationRepositoryPort`].
+//!
+//! Storage shape: the full `Deliberation` aggregate is serialised as
+//! JSONB on `deliberations.body`; a handful of scalar columns are
+//! kept alongside for indexable filters (specialty, phase) and a
+//! cheap winner lookup. See `migrations/postgres/0001_deliberations.sql`.
+
+use async_trait::async_trait;
+use choreo_core::entities::{Deliberation, DeliberationPhase};
+use choreo_core::error::DomainError;
+use choreo_core::ports::DeliberationRepositoryPort;
+use choreo_core::value_objects::TaskId;
+use serde_json::Value as JsonValue;
+use sqlx::Row;
+
+use super::error::{serde_to_domain, sqlx_to_domain};
+use super::pool::PostgresPool;
+
+#[derive(Clone)]
+pub struct PostgresDeliberationRepository {
+    pool: PostgresPool,
+}
+
+impl std::fmt::Debug for PostgresDeliberationRepository {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PostgresDeliberationRepository").finish()
+    }
+}
+
+impl PostgresDeliberationRepository {
+    #[must_use]
+    pub fn new(pool: PostgresPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl DeliberationRepositoryPort for PostgresDeliberationRepository {
+    async fn save(&self, deliberation: &Deliberation) -> Result<(), DomainError> {
+        let body: JsonValue =
+            serde_json::to_value(deliberation).map_err(|e| serde_to_domain(&e, "save"))?;
+        let phase = phase_name(deliberation.phase());
+        let winner = deliberation
+            .ranking()
+            .first()
+            .map(|p| p.as_str().to_owned());
+
+        sqlx::query(
+            "
+            INSERT INTO deliberations
+                (task_id, specialty, phase, winner_proposal_id, body, updated_at)
+            VALUES ($1, $2, $3, $4, $5, NOW())
+            ON CONFLICT (task_id) DO UPDATE SET
+                specialty          = EXCLUDED.specialty,
+                phase              = EXCLUDED.phase,
+                winner_proposal_id = EXCLUDED.winner_proposal_id,
+                body               = EXCLUDED.body,
+                updated_at         = NOW()
+            ",
+        )
+        .bind(deliberation.task_id().as_str())
+        .bind(deliberation.specialty().as_str())
+        .bind(phase)
+        .bind(winner)
+        .bind(&body)
+        .execute(self.pool.inner())
+        .await
+        .map_err(|e| sqlx_to_domain(e, "save"))?;
+
+        Ok(())
+    }
+
+    async fn get(&self, task_id: &TaskId) -> Result<Deliberation, DomainError> {
+        let row = sqlx::query("SELECT body FROM deliberations WHERE task_id = $1")
+            .bind(task_id.as_str())
+            .fetch_one(self.pool.inner())
+            .await
+            .map_err(|e| sqlx_to_domain(e, "get"))?;
+        let body: JsonValue = row.try_get("body").map_err(|e| sqlx_to_domain(e, "get"))?;
+        serde_json::from_value(body).map_err(|e| serde_to_domain(&e, "get"))
+    }
+
+    async fn exists(&self, task_id: &TaskId) -> Result<bool, DomainError> {
+        let row = sqlx::query("SELECT 1 AS one FROM deliberations WHERE task_id = $1")
+            .bind(task_id.as_str())
+            .fetch_optional(self.pool.inner())
+            .await
+            .map_err(|e| sqlx_to_domain(e, "exists"))?;
+        Ok(row.is_some())
+    }
+}
+
+fn phase_name(phase: DeliberationPhase) -> &'static str {
+    match phase {
+        DeliberationPhase::Proposing => "Proposing",
+        DeliberationPhase::Revising => "Revising",
+        DeliberationPhase::Validating => "Validating",
+        DeliberationPhase::Scoring => "Scoring",
+        DeliberationPhase::Completed => "Completed",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_phase_has_a_stable_column_value() {
+        use std::collections::HashSet;
+        let names: HashSet<&str> = [
+            DeliberationPhase::Proposing,
+            DeliberationPhase::Revising,
+            DeliberationPhase::Validating,
+            DeliberationPhase::Scoring,
+            DeliberationPhase::Completed,
+        ]
+        .iter()
+        .map(|p| phase_name(*p))
+        .collect();
+        assert_eq!(names.len(), 5);
+    }
+}

--- a/crates/choreo-adapters/src/postgres/error.rs
+++ b/crates/choreo-adapters/src/postgres/error.rs
@@ -1,0 +1,35 @@
+//! Map sqlx errors to [`DomainError`].
+//!
+//! The core domain error enum only carries static strings — runtime
+//! detail belongs in structured logs, not in the variant payload.
+//! This module centralises the conversion so every Postgres adapter
+//! logs the original error identically and surfaces a small, stable
+//! set of domain variants upward.
+
+use choreo_core::error::DomainError;
+use sqlx::Error as SqlxError;
+
+/// Convert a generic sqlx error into a domain error, logging the
+/// original through `tracing::error!` for diagnostics.
+pub fn sqlx_to_domain(err: SqlxError, op: &'static str) -> DomainError {
+    match err {
+        SqlxError::RowNotFound => DomainError::NotFound {
+            what: "deliberation",
+        },
+        other => {
+            tracing::error!(error = %other, operation = op, "postgres operation failed");
+            DomainError::InvariantViolated {
+                reason: "postgres: persistence backend failed",
+            }
+        }
+    }
+}
+
+/// Convert a JSON serialization/deserialization failure into a domain
+/// error. Separate entry point so the logged reason is unambiguous.
+pub fn serde_to_domain(err: &serde_json::Error, op: &'static str) -> DomainError {
+    tracing::error!(error = %err, operation = op, "postgres row serde failed");
+    DomainError::InvariantViolated {
+        reason: "postgres: deliberation body could not be serialized",
+    }
+}

--- a/crates/choreo-adapters/src/postgres/mod.rs
+++ b/crates/choreo-adapters/src/postgres/mod.rs
@@ -1,0 +1,18 @@
+//! Postgres-backed adapters.
+//!
+//! Opt-in via the `postgres` Cargo feature. Ships a pool builder, a
+//! migration runner, and concrete implementations of the persistence
+//! ports. The schema (see `migrations/postgres/`) stays minimal: the
+//! full domain aggregate is stored as JSONB with a few indexable
+//! projections, so no wire-format-shaped table grows with provider
+//! vocabulary.
+//!
+//! Nothing here leaks sqlx types out of the module: callers outside
+//! only ever see domain ports and a `PostgresPool` handle.
+
+mod deliberation_repository;
+mod error;
+mod pool;
+
+pub use deliberation_repository::PostgresDeliberationRepository;
+pub use pool::{PostgresConfig, PostgresPool, PostgresPoolError};

--- a/crates/choreo-adapters/src/postgres/pool.rs
+++ b/crates/choreo-adapters/src/postgres/pool.rs
@@ -1,0 +1,99 @@
+//! Postgres connection pool + migration runner.
+//!
+//! One [`PostgresPool`] per service instance; cloning yields a
+//! shared-handle so it can be passed into multiple adapters (repository,
+//! future registries) without re-dialing the database.
+
+use std::time::Duration;
+
+use sqlx::migrate::Migrator;
+use sqlx::postgres::{PgPool, PgPoolOptions};
+use thiserror::Error;
+
+/// sqlx ships a migrator keyed on the workspace-relative path. The
+/// `.sql` files live next to this crate's `Cargo.toml`.
+static MIGRATOR: Migrator = sqlx::migrate!("./migrations/postgres");
+
+/// How the pool is configured.
+#[derive(Debug, Clone)]
+pub struct PostgresConfig {
+    pub url: String,
+    pub max_connections: u32,
+    pub acquire_timeout: Duration,
+}
+
+impl PostgresConfig {
+    #[must_use]
+    pub fn from_url(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            max_connections: 10,
+            acquire_timeout: Duration::from_secs(5),
+        }
+    }
+}
+
+/// Clone-friendly handle to a configured [`sqlx::PgPool`].
+#[derive(Clone)]
+pub struct PostgresPool {
+    inner: PgPool,
+}
+
+impl std::fmt::Debug for PostgresPool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PostgresPool").finish()
+    }
+}
+
+impl PostgresPool {
+    /// Dial the database and return a ready pool.
+    pub async fn connect(config: &PostgresConfig) -> Result<Self, PostgresPoolError> {
+        let inner = PgPoolOptions::new()
+            .max_connections(config.max_connections)
+            .acquire_timeout(config.acquire_timeout)
+            .connect(&config.url)
+            .await
+            .map_err(PostgresPoolError::Connect)?;
+        Ok(Self { inner })
+    }
+
+    /// Apply every embedded migration. Idempotent.
+    pub async fn run_migrations(&self) -> Result<(), PostgresPoolError> {
+        MIGRATOR
+            .run(&self.inner)
+            .await
+            .map_err(PostgresPoolError::Migrate)
+    }
+
+    pub(crate) fn inner(&self) -> &PgPool {
+        &self.inner
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum PostgresPoolError {
+    #[error("postgres connect failed: {0}")]
+    Connect(#[source] sqlx::Error),
+    #[error("postgres migrations failed: {0}")]
+    Migrate(#[source] sqlx::migrate::MigrateError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_from_url_sets_sensible_defaults() {
+        let cfg = PostgresConfig::from_url("postgres://localhost/db");
+        assert_eq!(cfg.url, "postgres://localhost/db");
+        assert_eq!(cfg.max_connections, 10);
+        assert_eq!(cfg.acquire_timeout, Duration::from_secs(5));
+    }
+
+    #[test]
+    fn pool_error_display_is_descriptive() {
+        let err = PostgresPoolError::Connect(sqlx::Error::PoolClosed);
+        let shown = format!("{err}");
+        assert!(shown.starts_with("postgres connect failed:"));
+    }
+}

--- a/crates/choreo-core/src/ports/configuration.rs
+++ b/crates/choreo-core/src/ports/configuration.rs
@@ -17,6 +17,10 @@ pub struct ServiceConfig {
     pub nats_url: String,
     pub trigger_subject: String,
     pub publish_prefix: String,
+    /// When set, deliberations persist to Postgres; otherwise the
+    /// in-memory repository is wired. Empty-string is treated as
+    /// unset so the chart can carry a placeholder default.
+    pub postgres_url: Option<String>,
 }
 
 #[async_trait]

--- a/crates/choreo-tests-integration/Cargo.toml
+++ b/crates/choreo-tests-integration/Cargo.toml
@@ -21,7 +21,7 @@ container-tests = []
 [dependencies]
 choreo-core = { workspace = true }
 choreo-app = { workspace = true }
-choreo-adapters = { workspace = true, features = ["nats"] }
+choreo-adapters = { workspace = true, features = ["nats", "postgres"] }
 
 [dev-dependencies]
 async-nats = { workspace = true }

--- a/crates/choreo-tests-integration/tests/postgres_deliberation_repository.rs
+++ b/crates/choreo-tests-integration/tests/postgres_deliberation_repository.rs
@@ -1,0 +1,210 @@
+//! Integration test: [`PostgresDeliberationRepository`] roundtrips a
+//! real, non-trivial [`Deliberation`] through a real Postgres container.
+//!
+//! Exercises:
+//!   1. Pool dial + migration runner.
+//!   2. `save` as upsert (insert + overwrite paths).
+//!   3. `get` returns a structurally equal aggregate after JSONB
+//!      serialisation and rehydration.
+//!   4. `exists` reflects presence / absence truthfully.
+//!   5. `get` for a missing task id surfaces `DomainError::NotFound`.
+//!
+//! Runs only when the `container-tests` feature is enabled (CI).
+
+#![cfg(feature = "container-tests")]
+
+use std::time::Duration;
+
+use choreo_adapters::postgres::{PostgresConfig, PostgresDeliberationRepository, PostgresPool};
+use choreo_core::entities::{
+    Deliberation, DeliberationPhase, Proposal, ValidationOutcome, ValidatorReport,
+};
+use choreo_core::error::DomainError;
+use choreo_core::ports::DeliberationRepositoryPort;
+use choreo_core::value_objects::{
+    AgentId, Attributes, ProposalId, Rounds, Score, Specialty, TaskId,
+};
+use testcontainers::{
+    core::{IntoContainerPort, WaitFor},
+    runners::AsyncRunner,
+    GenericImage, ImageExt,
+};
+use time::macros::datetime;
+
+const PG_IMAGE: &str = "postgres";
+const PG_TAG: &str = "16-alpine";
+const PG_USER: &str = "choreo";
+const PG_PASSWORD: &str = "choreo";
+const PG_DB: &str = "choreo";
+
+async fn start_postgres() -> (PostgresPool, testcontainers::ContainerAsync<GenericImage>) {
+    let container = GenericImage::new(PG_IMAGE, PG_TAG)
+        .with_exposed_port(5432_u16.tcp())
+        .with_wait_for(WaitFor::message_on_stderr(
+            "database system is ready to accept connections",
+        ))
+        .with_env_var("POSTGRES_USER", PG_USER)
+        .with_env_var("POSTGRES_PASSWORD", PG_PASSWORD)
+        .with_env_var("POSTGRES_DB", PG_DB)
+        .start()
+        .await
+        .expect("postgres container should start");
+    let port = container
+        .get_host_port_ipv4(5432_u16.tcp())
+        .await
+        .expect("host port");
+    let url = format!("postgres://{PG_USER}:{PG_PASSWORD}@127.0.0.1:{port}/{PG_DB}");
+
+    // Dial with retries — even after the readiness log line, the
+    // server can briefly refuse connections while finalising startup.
+    let mut cfg = PostgresConfig::from_url(url);
+    cfg.acquire_timeout = Duration::from_secs(10);
+
+    let mut last_err = None;
+    for _ in 0..20 {
+        match PostgresPool::connect(&cfg).await {
+            Ok(pool) => {
+                pool.run_migrations()
+                    .await
+                    .expect("migrations must apply on a fresh database");
+                return (pool, container);
+            }
+            Err(err) => {
+                last_err = Some(err);
+                tokio::time::sleep(Duration::from_millis(200)).await;
+            }
+        }
+    }
+    panic!("could not connect to postgres after warmup: {last_err:?}");
+}
+
+/// Build a fully-traversed Deliberation so the roundtrip covers
+/// proposals, outcomes, ranking, and the completed phase (the hard
+/// cases for JSONB serialisation).
+fn completed_deliberation(task: &str) -> Deliberation {
+    let now = datetime!(2026-04-15 12:00:00 UTC);
+    let specialty = Specialty::new("triage").unwrap();
+    let mut d = Deliberation::start(
+        TaskId::new(task).unwrap(),
+        specialty.clone(),
+        Rounds::default(),
+        now,
+    );
+    for id in ["p1", "p2"] {
+        let p = Proposal::new(
+            ProposalId::new(id).unwrap(),
+            AgentId::new(id).unwrap(),
+            specialty.clone(),
+            format!("content-{id}"),
+            Attributes::empty(),
+            now,
+        )
+        .unwrap();
+        d.add_proposal(p).unwrap();
+    }
+    for _ in 0..2 {
+        d.advance().unwrap();
+    }
+    let report = |passed| ValidatorReport::new("v", passed, "ok", Attributes::empty()).unwrap();
+    d.attach_outcome(
+        &ProposalId::new("p1").unwrap(),
+        ValidationOutcome::new(Score::new(0.3).unwrap(), vec![report(false)]),
+    )
+    .unwrap();
+    d.attach_outcome(
+        &ProposalId::new("p2").unwrap(),
+        ValidationOutcome::new(Score::new(0.9).unwrap(), vec![report(true)]),
+    )
+    .unwrap();
+    d.advance().unwrap();
+    let later = datetime!(2026-04-15 12:00:00.500 UTC);
+    d.complete(later).unwrap();
+    d
+}
+
+#[tokio::test]
+async fn postgres_repository_roundtrips_a_completed_deliberation() {
+    let (pool, _container) = start_postgres().await;
+    let repo = PostgresDeliberationRepository::new(pool);
+
+    let d = completed_deliberation("t-happy");
+    repo.save(&d).await.unwrap();
+
+    let got = repo.get(d.task_id()).await.unwrap();
+    assert_eq!(got.task_id(), d.task_id());
+    assert_eq!(got.specialty(), d.specialty());
+    assert_eq!(got.phase(), DeliberationPhase::Completed);
+    assert_eq!(got.proposals().len(), d.proposals().len());
+    assert_eq!(got.outcomes().len(), d.outcomes().len());
+    assert_eq!(got.ranking(), d.ranking());
+    // The winner (p2) is ranked first.
+    assert_eq!(
+        got.ranking().first().map(ProposalId::as_str),
+        Some("p2"),
+        "winner must round-trip with the same ranking"
+    );
+}
+
+#[tokio::test]
+async fn save_is_upsert_and_preserves_the_latest_body() {
+    let (pool, _container) = start_postgres().await;
+    let repo = PostgresDeliberationRepository::new(pool);
+
+    // First save — a mid-run deliberation (phase Proposing).
+    let mut d = Deliberation::start(
+        TaskId::new("t-upsert").unwrap(),
+        Specialty::new("triage").unwrap(),
+        Rounds::default(),
+        datetime!(2026-04-15 12:00:00 UTC),
+    );
+    d.add_proposal(
+        Proposal::new(
+            ProposalId::new("p1").unwrap(),
+            AgentId::new("a1").unwrap(),
+            Specialty::new("triage").unwrap(),
+            "initial-content".to_owned(),
+            Attributes::empty(),
+            datetime!(2026-04-15 12:00:00 UTC),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    repo.save(&d).await.unwrap();
+    let first = repo.get(d.task_id()).await.unwrap();
+    assert_eq!(first.phase(), DeliberationPhase::Proposing);
+
+    // Second save — a fully completed deliberation for the same id.
+    let completed = completed_deliberation("t-upsert");
+    repo.save(&completed).await.unwrap();
+    let second = repo.get(completed.task_id()).await.unwrap();
+    assert_eq!(
+        second.phase(),
+        DeliberationPhase::Completed,
+        "later save must overwrite the earlier body"
+    );
+    assert_eq!(second.proposals().len(), 2);
+}
+
+#[tokio::test]
+async fn exists_reflects_presence_and_missing_get_is_not_found() {
+    let (pool, _container) = start_postgres().await;
+    let repo = PostgresDeliberationRepository::new(pool);
+
+    let id = TaskId::new("t-absent").unwrap();
+    assert!(!repo.exists(&id).await.unwrap());
+
+    let err = repo.get(&id).await.unwrap_err();
+    assert!(
+        matches!(
+            err,
+            DomainError::NotFound {
+                what: "deliberation"
+            }
+        ),
+        "missing task must surface as NotFound, got {err:?}"
+    );
+
+    let d = completed_deliberation("t-absent");
+    repo.save(&d).await.unwrap();
+    assert!(repo.exists(&id).await.unwrap());
+}

--- a/crates/choreo/Cargo.toml
+++ b/crates/choreo/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 [dependencies]
 choreo-core = { workspace = true }
 choreo-app = { workspace = true }
-choreo-adapters = { workspace = true, features = ["grpc", "nats"] }
+choreo-adapters = { workspace = true, features = ["grpc", "nats", "postgres"] }
 choreo-proto = { workspace = true }
 
 async-nats = { workspace = true }

--- a/crates/choreo/src/compose.rs
+++ b/crates/choreo/src/compose.rs
@@ -10,6 +10,9 @@ use choreo_adapters::memory::{
 };
 use choreo_adapters::nats::{NatsConfig, NatsMessaging, NatsTriggerSubscriber};
 use choreo_adapters::noop::{NoopAgentFactory, NoopExecutor, NoopMessaging};
+use choreo_adapters::postgres::{
+    PostgresConfig, PostgresDeliberationRepository, PostgresPool, PostgresPoolError,
+};
 use choreo_adapters::scoring::UniformScoring;
 use choreo_adapters::validators::ContentNonEmptyValidator;
 use choreo_app::services::AutoDispatchService;
@@ -19,8 +22,8 @@ use choreo_app::usecases::{
 };
 use choreo_core::error::DomainError;
 use choreo_core::ports::{
-    AgentFactoryPort, AgentRegistryPort, ConfigurationPort, ExecutorPort, MessagingPort,
-    ScoringPort, ServiceConfig, StatisticsPort, ValidatorPort,
+    AgentFactoryPort, AgentRegistryPort, ConfigurationPort, DeliberationRepositoryPort,
+    ExecutorPort, MessagingPort, ScoringPort, ServiceConfig, StatisticsPort, ValidatorPort,
 };
 use thiserror::Error;
 use tracing::info;
@@ -32,7 +35,7 @@ pub struct Application {
     pub service_config: ServiceConfig,
     pub agent_registry: Arc<InMemoryAgentRegistry>,
     pub council_registry: Arc<InMemoryCouncilRegistry>,
-    pub repository: Arc<InMemoryDeliberationRepository>,
+    pub repository: Arc<dyn DeliberationRepositoryPort>,
     pub grpc_service: choreo_adapters::grpc::ChoreographerGrpcService,
     pub nats_subscriber: Option<NatsTriggerSubscriber>,
     pub health_state: crate::health::HealthState,
@@ -55,6 +58,9 @@ pub enum ComposeError {
 
     #[error("nats connection failed: {0}")]
     NatsConnect(#[source] async_nats::ConnectError),
+
+    #[error("postgres setup failed: {0}")]
+    Postgres(#[from] PostgresPoolError),
 
     #[error("seeding failed: {0}")]
     Seeding(#[from] SeedingError),
@@ -79,7 +85,7 @@ pub async fn compose() -> Result<Application, ComposeError> {
     let clock = Arc::new(SystemClock::new());
     let agent_registry = Arc::new(InMemoryAgentRegistry::new());
     let council_registry = Arc::new(InMemoryCouncilRegistry::new());
-    let repository = Arc::new(InMemoryDeliberationRepository::new());
+    let repository = wire_repository(&service_config).await?;
 
     let validators: Vec<Arc<dyn ValidatorPort>> = vec![Arc::new(ContentNonEmptyValidator::new())];
     let scoring: Arc<dyn ScoringPort> = Arc::new(UniformScoring::new());
@@ -258,6 +264,25 @@ async fn wire_messaging(cfg: &ServiceConfig) -> Result<MessagingWiring, ComposeE
         subscriber_factory: Some(subscriber_factory),
         nats_client: Some(client),
     })
+}
+
+/// Pick a [`DeliberationRepositoryPort`] implementation based on the
+/// environment: Postgres when `CHOREO_POSTGRES_URL` is set (migrations
+/// apply on startup so a fresh cluster is exercisable), in-memory
+/// otherwise.
+async fn wire_repository(
+    cfg: &ServiceConfig,
+) -> Result<Arc<dyn DeliberationRepositoryPort>, ComposeError> {
+    if let Some(url) = cfg.postgres_url.as_deref() {
+        let pg_cfg = PostgresConfig::from_url(url);
+        let pool = PostgresPool::connect(&pg_cfg).await?;
+        pool.run_migrations().await?;
+        info!("postgres deliberation repository wired");
+        Ok(Arc::new(PostgresDeliberationRepository::new(pool)))
+    } else {
+        info!("postgres disabled; using in-memory deliberation repository");
+        Ok(Arc::new(InMemoryDeliberationRepository::new()))
+    }
 }
 
 #[cfg(test)]

--- a/scripts/ci/integration-postgres.sh
+++ b/scripts/ci/integration-postgres.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Postgres integration tests. testcontainers spins a real Postgres per
+# test so we validate wire behaviour — including the migration runner
+# and JSONB roundtrip — instead of mocks.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT_DIR}"
+
+# Keep container-backed suites single-threaded to avoid parallel startup
+# spikes saturating the runner.
+RUST_TEST_THREADS=1 cargo test \
+  -p choreo-tests-integration \
+  --features container-tests \
+  --test postgres_deliberation_repository \
+  --locked \
+  -- --test-threads=1


### PR DESCRIPTION
## Summary

- First persistent backing. \`DeliberationRepositoryPort\` gains a Postgres implementation; deliberations survive process restarts when \`CHOREO_POSTGRES_URL\` is set
- In-memory fallback preserved byte-for-byte — flip by env only; no mandatory infra for existing deployments
- Councils, agent registry, and statistics remain in-memory this slice (11b / 11c will follow)

## What changed

- \`choreo-adapters\`: new \`postgres\` feature; \`PostgresPool\` / \`PostgresConfig\` / \`PostgresDeliberationRepository\` / centralised \`sqlx_to_domain\` / \`serde_to_domain\` error mappers
- Migrations: \`crates/choreo-adapters/migrations/postgres/0001_deliberations.sql\` — one row per task id, full aggregate as JSONB, scalar projections (specialty, phase, winner_proposal_id) for indexable filters
- \`choreo-core\`: \`ServiceConfig.postgres_url: Option<String>\`
- \`choreo-adapters::config\`: env adapter recognises \`CHOREO_POSTGRES_URL\`, treats whitespace as unset
- \`choreo\` binary: \`compose.rs\` picks the repository impl based on config; migrations run at startup; \`ComposeError::Postgres\` variant for diagnostics
- Helm chart: \`persistence.postgres.enabled/url\` gate \`CHOREO_POSTGRES_URL\` (off by default)
- CI: new \`integration-postgres\` job backed by \`scripts/ci/integration-postgres.sh\`

## Design choices

- **JSONB over columnar mapping**: the aggregate is use-case-agnostic; normalising it would couple the schema to domain invariants that still shift. Scalar projections give us indexable filters without that coupling.
- **Static-string domain errors**: sqlx runtime details logged via \`tracing::error!\` with structured fields; the domain surface only sees \`NotFound\` / \`InvariantViolated\` so the core's strict-string contract stays intact.
- **Upsert on save**: mirrors in-memory semantics (last write wins per task id).
- **Migrations embedded via \`sqlx::migrate!\`**: reproducible; no external migrate binary in the container image.

## Tests added

- Unit: pool config defaults, pool error display, phase→column-name stability, \`CHOREO_POSTGRES_URL\` empty-string handling
- Integration (testcontainers, gated by \`container-tests\` feature, run by \`integration-postgres\` CI job):
  - Completed-deliberation roundtrip (proposals + outcomes + ranking survive JSONB)
  - \`save\` is upsert (mid-phase → completed overwrite)
  - \`exists\` reflects presence; missing get surfaces \`DomainError::NotFound\`

## Verified locally

\`podman\`-backed testcontainers run; all 3 integration tests green against real Postgres 16.

## Test plan
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\`
- [x] \`cargo test --workspace\`
- [x] Integration tests locally via testcontainers + podman
- [ ] CI green on all 12 checks (adds \`integration-postgres\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)