### PR TITLE
feat(persistence): phase 11b — Postgres council + agent registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,19 @@ gate in this repository):
 
 **Persistence**:
 
-- Deliberations persist to Postgres when `CHOREO_POSTGRES_URL` is
-  set (the binary is built with the `postgres` feature); otherwise
-  the in-memory repository is wired. Migrations apply on startup —
-  a fresh cluster is immediately exercisable. Schema lives under
+- When `CHOREO_POSTGRES_URL` is set, deliberations, councils, and
+  the agent registry persist to Postgres; otherwise the in-memory
+  defaults are wired. Persistence choice is binary: all four backings
+  are either Postgres or in-memory together, so no replica reads from
+  a split source of truth. Migrations apply on startup — a fresh
+  cluster is immediately exercisable. Schema lives under
   `crates/choreo-adapters/migrations/postgres/`.
-- Councils, agent registry, and statistics still run in memory;
-  they get their own persistent backings in later slices.
+- Agents persist as descriptors (`id`, `specialty`, `kind`,
+  `attributes`); live `AgentPort` handles are rehydrated through the
+  wired `AgentFactoryPort` on resolve, so no pickled provider state
+  crosses the database boundary.
+- Statistics still run in memory; its persistent backing lands in
+  the next sub-slice (11c).
 
 **What is *not* wired yet**:
 
@@ -110,7 +116,7 @@ gate in this repository):
   slice.
 - `StreamDeliberation` streams phase transitions only; per-proposal,
   per-critique, and per-revision streaming arrives in a later slice.
-- Multi-replica persistence for councils, agent registry, and
-  statistics (they are still in-memory).
+- Statistics still live in memory; a persistent backing for the
+  `StatisticsPort` is the last persistence sub-slice (11c).
 
 See `docs/experiments/` for anything beyond these bullet points.

--- a/crates/choreo-adapters/migrations/postgres/0002_councils.sql
+++ b/crates/choreo-adapters/migrations/postgres/0002_councils.sql
@@ -1,0 +1,17 @@
+-- Phase 11b: council persistence.
+--
+-- One row per specialty (the current contract guarantees a single
+-- council per specialty — `CouncilRegistryPort::get(&Specialty)`).
+-- The full aggregate lives in a JSONB body; specialty stays as the
+-- primary key so existence checks and deletes are trivial.
+
+CREATE TABLE IF NOT EXISTS councils (
+    specialty   TEXT PRIMARY KEY,
+    council_id  TEXT NOT NULL,
+    body        JSONB NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS councils_council_id_idx
+    ON councils (council_id);

--- a/crates/choreo-adapters/migrations/postgres/0003_agents.sql
+++ b/crates/choreo-adapters/migrations/postgres/0003_agents.sql
@@ -1,0 +1,21 @@
+-- Phase 11b: agent descriptor persistence.
+--
+-- One row per agent id. The descriptor (id, specialty, kind,
+-- attributes) is what we persist; live `AgentPort` handles are
+-- rehydrated on resolve by piping the descriptor through the wired
+-- `AgentFactoryPort`. That keeps the same agent set visible across
+-- replicas without pickling provider-specific client state.
+
+CREATE TABLE IF NOT EXISTS agents (
+    agent_id    TEXT PRIMARY KEY,
+    specialty   TEXT NOT NULL,
+    kind        TEXT NOT NULL,
+    attributes  JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS agents_specialty_idx
+    ON agents (specialty);
+
+CREATE INDEX IF NOT EXISTS agents_kind_idx
+    ON agents (kind);

--- a/crates/choreo-adapters/src/postgres/agent_registry.rs
+++ b/crates/choreo-adapters/src/postgres/agent_registry.rs
@@ -1,0 +1,155 @@
+//! Postgres implementation of [`AgentRegistryPort`] + [`AgentResolverPort`].
+//!
+//! Rows persist the typed [`AgentDescriptor`] (id, specialty, kind,
+//! attributes). On read, descriptors are rehydrated into live
+//! `Arc<dyn AgentPort>` handles via the wired [`AgentFactoryPort`];
+//! no pickled provider state crosses the database boundary. That keeps
+//! the registry content portable across replicas — each replica can
+//! materialize its own live handles using whatever factory it has
+//! feature-enabled.
+//!
+//! Adapter-specific limitation in this slice: `register(agent)` asks
+//! the passed-in agent for its id / specialty, but then we need a
+//! descriptor to persist — we only store kind="noop" today because
+//! the composition root only wires the NoopAgentFactory. When the
+//! dispatching factory lands (with vLLM / Anthropic / OpenAI kinds),
+//! we will switch register to take an [`AgentDescriptor`] directly so
+//! the persisted kind is an honest reflection of the wiring.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use choreo_core::error::DomainError;
+use choreo_core::ports::{
+    AgentDescriptor, AgentFactoryPort, AgentPort, AgentRegistryPort, AgentResolverPort,
+};
+use choreo_core::value_objects::{AgentId, AgentKind, Attributes, Specialty};
+use serde_json::Value as JsonValue;
+use sqlx::Row;
+
+use super::error::{serde_to_domain, sqlx_to_domain};
+use super::pool::PostgresPool;
+
+#[derive(Clone)]
+pub struct PostgresAgentRegistry {
+    pool: PostgresPool,
+    factory: Arc<dyn AgentFactoryPort>,
+}
+
+impl std::fmt::Debug for PostgresAgentRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PostgresAgentRegistry").finish()
+    }
+}
+
+impl PostgresAgentRegistry {
+    #[must_use]
+    pub fn new(pool: PostgresPool, factory: Arc<dyn AgentFactoryPort>) -> Self {
+        Self { pool, factory }
+    }
+
+    /// Persist a full [`AgentDescriptor`]. Used by wiring / registration
+    /// paths that already have a descriptor in hand; the
+    /// [`AgentRegistryPort::register`] surface degrades to this by
+    /// reconstructing a descriptor with `kind = "noop"` because that
+    /// is the only kind the noop factory recognises today.
+    pub async fn insert_descriptor(&self, descriptor: &AgentDescriptor) -> Result<(), DomainError> {
+        let attributes: JsonValue = serde_json::to_value(&descriptor.attributes)
+            .map_err(|e| serde_to_domain(&e, "insert_descriptor"))?;
+        let result = sqlx::query(
+            "
+            INSERT INTO agents (agent_id, specialty, kind, attributes)
+            VALUES ($1, $2, $3, $4)
+            ON CONFLICT (agent_id) DO NOTHING
+            ",
+        )
+        .bind(descriptor.id.as_str())
+        .bind(descriptor.specialty.as_str())
+        .bind(descriptor.kind.as_str())
+        .bind(&attributes)
+        .execute(self.pool.inner())
+        .await
+        .map_err(|e| sqlx_to_domain(e, "insert_descriptor"))?;
+        if result.rows_affected() == 0 {
+            return Err(DomainError::AlreadyExists { what: "agent" });
+        }
+        Ok(())
+    }
+
+    async fn load_descriptor(&self, id: &AgentId) -> Result<Option<AgentDescriptor>, DomainError> {
+        let row = sqlx::query(
+            "SELECT agent_id, specialty, kind, attributes FROM agents WHERE agent_id = $1",
+        )
+        .bind(id.as_str())
+        .fetch_optional(self.pool.inner())
+        .await
+        .map_err(|e| sqlx_to_domain(e, "resolve"))?;
+        let Some(row) = row else {
+            return Ok(None);
+        };
+        Ok(Some(descriptor_from_row(&row)?))
+    }
+}
+
+#[async_trait]
+impl AgentRegistryPort for PostgresAgentRegistry {
+    async fn register(&self, agent: Arc<dyn AgentPort>) -> Result<(), DomainError> {
+        // The port surface carries a live agent, but we persist
+        // descriptors only. Until a dispatching factory lands, every
+        // agent is materialised by NoopAgentFactory, so recording
+        // kind="noop" is the honest projection.
+        let descriptor = AgentDescriptor {
+            id: agent.id().clone(),
+            specialty: agent.specialty().clone(),
+            kind: AgentKind::new("noop")?,
+            attributes: Attributes::empty(),
+        };
+        self.insert_descriptor(&descriptor).await
+    }
+
+    async fn unregister(&self, id: &AgentId) -> Result<(), DomainError> {
+        let result = sqlx::query("DELETE FROM agents WHERE agent_id = $1")
+            .bind(id.as_str())
+            .execute(self.pool.inner())
+            .await
+            .map_err(|e| sqlx_to_domain(e, "unregister"))?;
+        if result.rows_affected() == 0 {
+            return Err(DomainError::NotFound { what: "agent" });
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl AgentResolverPort for PostgresAgentRegistry {
+    async fn resolve(&self, id: &AgentId) -> Result<Arc<dyn AgentPort>, DomainError> {
+        let descriptor = self
+            .load_descriptor(id)
+            .await?
+            .ok_or(DomainError::NotFound { what: "agent" })?;
+        self.factory.create(descriptor).await
+    }
+}
+
+fn descriptor_from_row(row: &sqlx::postgres::PgRow) -> Result<AgentDescriptor, DomainError> {
+    let agent_id: String = row
+        .try_get("agent_id")
+        .map_err(|e| sqlx_to_domain(e, "resolve"))?;
+    let specialty: String = row
+        .try_get("specialty")
+        .map_err(|e| sqlx_to_domain(e, "resolve"))?;
+    let kind: String = row
+        .try_get("kind")
+        .map_err(|e| sqlx_to_domain(e, "resolve"))?;
+    let attrs_value: JsonValue = row
+        .try_get("attributes")
+        .map_err(|e| sqlx_to_domain(e, "resolve"))?;
+    let attributes: Attributes =
+        serde_json::from_value(attrs_value).map_err(|e| serde_to_domain(&e, "resolve"))?;
+    Ok(AgentDescriptor {
+        id: AgentId::new(agent_id)?,
+        specialty: Specialty::new(specialty)?,
+        kind: AgentKind::new(kind)?,
+        attributes,
+    })
+}

--- a/crates/choreo-adapters/src/postgres/council_registry.rs
+++ b/crates/choreo-adapters/src/postgres/council_registry.rs
@@ -1,0 +1,132 @@
+//! Postgres implementation of [`CouncilRegistryPort`].
+//!
+//! Storage shape mirrors the deliberation repository: the full
+//! aggregate lives on `councils.body` as JSONB and the specialty is
+//! the primary key. `register` rejects a duplicate specialty;
+//! `replace` requires the council to already exist so the two
+//! operations stay distinguishable from the port surface.
+
+use async_trait::async_trait;
+use choreo_core::entities::Council;
+use choreo_core::error::DomainError;
+use choreo_core::ports::CouncilRegistryPort;
+use choreo_core::value_objects::Specialty;
+use serde_json::Value as JsonValue;
+use sqlx::Row;
+
+use super::error::{serde_to_domain, sqlx_to_domain};
+use super::pool::PostgresPool;
+
+#[derive(Clone)]
+pub struct PostgresCouncilRegistry {
+    pool: PostgresPool,
+}
+
+impl std::fmt::Debug for PostgresCouncilRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PostgresCouncilRegistry").finish()
+    }
+}
+
+impl PostgresCouncilRegistry {
+    #[must_use]
+    pub fn new(pool: PostgresPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl CouncilRegistryPort for PostgresCouncilRegistry {
+    async fn register(&self, council: Council) -> Result<(), DomainError> {
+        let body: JsonValue =
+            serde_json::to_value(&council).map_err(|e| serde_to_domain(&e, "register"))?;
+        let result = sqlx::query(
+            "
+            INSERT INTO councils (specialty, council_id, body, updated_at)
+            VALUES ($1, $2, $3, NOW())
+            ON CONFLICT (specialty) DO NOTHING
+            ",
+        )
+        .bind(council.specialty().as_str())
+        .bind(council.id().as_str())
+        .bind(&body)
+        .execute(self.pool.inner())
+        .await
+        .map_err(|e| sqlx_to_domain(e, "register"))?;
+
+        if result.rows_affected() == 0 {
+            return Err(DomainError::AlreadyExists { what: "council" });
+        }
+        Ok(())
+    }
+
+    async fn replace(&self, council: Council) -> Result<(), DomainError> {
+        let body: JsonValue =
+            serde_json::to_value(&council).map_err(|e| serde_to_domain(&e, "replace"))?;
+        let result = sqlx::query(
+            "
+            UPDATE councils SET
+                council_id = $2,
+                body       = $3,
+                updated_at = NOW()
+            WHERE specialty = $1
+            ",
+        )
+        .bind(council.specialty().as_str())
+        .bind(council.id().as_str())
+        .bind(&body)
+        .execute(self.pool.inner())
+        .await
+        .map_err(|e| sqlx_to_domain(e, "replace"))?;
+
+        if result.rows_affected() == 0 {
+            return Err(DomainError::NotFound { what: "council" });
+        }
+        Ok(())
+    }
+
+    async fn get(&self, specialty: &Specialty) -> Result<Council, DomainError> {
+        let row = sqlx::query("SELECT body FROM councils WHERE specialty = $1")
+            .bind(specialty.as_str())
+            .fetch_optional(self.pool.inner())
+            .await
+            .map_err(|e| sqlx_to_domain(e, "get"))?
+            .ok_or(DomainError::NotFound { what: "council" })?;
+        let body: JsonValue = row.try_get("body").map_err(|e| sqlx_to_domain(e, "get"))?;
+        serde_json::from_value(body).map_err(|e| serde_to_domain(&e, "get"))
+    }
+
+    async fn list(&self) -> Result<Vec<Council>, DomainError> {
+        let rows = sqlx::query("SELECT body FROM councils ORDER BY specialty")
+            .fetch_all(self.pool.inner())
+            .await
+            .map_err(|e| sqlx_to_domain(e, "list"))?;
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            let body: JsonValue = row.try_get("body").map_err(|e| sqlx_to_domain(e, "list"))?;
+            out.push(serde_json::from_value(body).map_err(|e| serde_to_domain(&e, "list"))?);
+        }
+        Ok(out)
+    }
+
+    async fn delete(&self, specialty: &Specialty) -> Result<(), DomainError> {
+        let result = sqlx::query("DELETE FROM councils WHERE specialty = $1")
+            .bind(specialty.as_str())
+            .execute(self.pool.inner())
+            .await
+            .map_err(|e| sqlx_to_domain(e, "delete"))?;
+        if result.rows_affected() == 0 {
+            return Err(DomainError::NotFound { what: "council" });
+        }
+        Ok(())
+    }
+
+    async fn contains(&self, specialty: &Specialty) -> Result<bool, DomainError> {
+        let row = sqlx::query("SELECT 1 AS one FROM councils WHERE specialty = $1")
+            .bind(specialty.as_str())
+            .fetch_optional(self.pool.inner())
+            .await
+            .map_err(|e| sqlx_to_domain(e, "contains"))?;
+        Ok(row.is_some())
+    }
+}

--- a/crates/choreo-adapters/src/postgres/mod.rs
+++ b/crates/choreo-adapters/src/postgres/mod.rs
@@ -10,9 +10,13 @@
 //! Nothing here leaks sqlx types out of the module: callers outside
 //! only ever see domain ports and a `PostgresPool` handle.
 
+mod agent_registry;
+mod council_registry;
 mod deliberation_repository;
 mod error;
 mod pool;
 
+pub use agent_registry::PostgresAgentRegistry;
+pub use council_registry::PostgresCouncilRegistry;
 pub use deliberation_repository::PostgresDeliberationRepository;
 pub use pool::{PostgresConfig, PostgresPool, PostgresPoolError};

--- a/crates/choreo-core/src/ports/agent_factory.rs
+++ b/crates/choreo-core/src/ports/agent_factory.rs
@@ -17,6 +17,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 
 use crate::error::DomainError;
 use crate::ports::agent::AgentPort;
@@ -25,7 +26,7 @@ use crate::value_objects::{AgentId, AgentKind, Attributes, Specialty};
 /// Everything the factory needs to build a live agent. Mirrors the
 /// `AgentSummary` proto, but kept in domain shapes so use cases never
 /// touch wire types.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AgentDescriptor {
     pub id: AgentId,
     pub specialty: Specialty,

--- a/crates/choreo-tests-integration/Cargo.toml
+++ b/crates/choreo-tests-integration/Cargo.toml
@@ -16,12 +16,17 @@ workspace = true
 # Opt-in: CI enables this feature to actually run the tests. Without
 # the feature the crate compiles but exercises nothing, so `cargo
 # test --workspace` stays fast and network-free.
-container-tests = []
+container-tests = ["dep:testcontainers", "dep:tokio"]
 
 [dependencies]
 choreo-core = { workspace = true }
 choreo-app = { workspace = true }
 choreo-adapters = { workspace = true, features = ["nats", "postgres"] }
+# Shared test fixtures (postgres_fixture) need testcontainers +
+# tokio at library build time; both are optional so `cargo build`
+# without the feature stays minimal.
+testcontainers = { version = "0.23", optional = true }
+tokio = { workspace = true, optional = true }
 
 [dev-dependencies]
 async-nats = { workspace = true }

--- a/crates/choreo-tests-integration/src/lib.rs
+++ b/crates/choreo-tests-integration/src/lib.rs
@@ -1,6 +1,9 @@
 //! Integration tests for the Choreographer's adapters.
 //!
-//! The library itself is empty; the actual scenarios live under
-//! `tests/` and are gated by the `container-tests` feature so
-//! running `cargo test --workspace` in isolation does not require a
-//! container runtime.
+//! The actual scenarios live under `tests/` and are gated by the
+//! `container-tests` feature. This `lib.rs` also exposes shared
+//! fixture helpers (e.g. `postgres_fixture::start`) that multiple
+//! test files would otherwise duplicate.
+
+#[cfg(feature = "container-tests")]
+pub mod postgres_fixture;

--- a/crates/choreo-tests-integration/src/postgres_fixture.rs
+++ b/crates/choreo-tests-integration/src/postgres_fixture.rs
@@ -1,0 +1,61 @@
+//! Shared fixture for Postgres integration tests.
+//!
+//! Every test gets its own Postgres container — keeps tests isolated
+//! and lets testcontainers reap resources cleanly per case. The
+//! `start` helper returns both the pool (with migrations applied)
+//! and the container handle so the test's lifetime keeps the
+//! container alive.
+
+use std::time::Duration;
+
+use choreo_adapters::postgres::{PostgresConfig, PostgresPool};
+use testcontainers::{
+    core::{IntoContainerPort, WaitFor},
+    runners::AsyncRunner,
+    GenericImage, ImageExt,
+};
+
+const PG_IMAGE: &str = "postgres";
+const PG_TAG: &str = "16-alpine";
+const PG_USER: &str = "choreo";
+const PG_PASSWORD: &str = "choreo";
+const PG_DB: &str = "choreo";
+
+pub async fn start() -> (PostgresPool, testcontainers::ContainerAsync<GenericImage>) {
+    let container = GenericImage::new(PG_IMAGE, PG_TAG)
+        .with_exposed_port(5432_u16.tcp())
+        .with_wait_for(WaitFor::message_on_stderr(
+            "database system is ready to accept connections",
+        ))
+        .with_env_var("POSTGRES_USER", PG_USER)
+        .with_env_var("POSTGRES_PASSWORD", PG_PASSWORD)
+        .with_env_var("POSTGRES_DB", PG_DB)
+        .start()
+        .await
+        .expect("postgres container should start");
+    let port = container
+        .get_host_port_ipv4(5432_u16.tcp())
+        .await
+        .expect("host port");
+    let url = format!("postgres://{PG_USER}:{PG_PASSWORD}@127.0.0.1:{port}/{PG_DB}");
+
+    let mut cfg = PostgresConfig::from_url(url);
+    cfg.acquire_timeout = Duration::from_secs(10);
+
+    let mut last_err = None;
+    for _ in 0..20 {
+        match PostgresPool::connect(&cfg).await {
+            Ok(pool) => {
+                pool.run_migrations()
+                    .await
+                    .expect("migrations must apply on a fresh database");
+                return (pool, container);
+            }
+            Err(err) => {
+                last_err = Some(err);
+                tokio::time::sleep(Duration::from_millis(200)).await;
+            }
+        }
+    }
+    panic!("could not connect to postgres after warmup: {last_err:?}");
+}

--- a/crates/choreo-tests-integration/tests/postgres_agent_registry.rs
+++ b/crates/choreo-tests-integration/tests/postgres_agent_registry.rs
@@ -1,0 +1,162 @@
+//! Integration test: [`PostgresAgentRegistry`] exercises
+//! `AgentRegistryPort` (write) + `AgentResolverPort` (read, via
+//! factory rehydration) against a real Postgres container.
+//!
+//! Runs only when the `container-tests` feature is enabled (CI).
+
+#![cfg(feature = "container-tests")]
+
+use std::sync::Arc;
+
+use choreo_adapters::noop::NoopAgentFactory;
+use choreo_adapters::postgres::PostgresAgentRegistry;
+use choreo_core::entities::TaskConstraints;
+use choreo_core::error::DomainError;
+use choreo_core::ports::{
+    AgentDescriptor, AgentFactoryPort, AgentPort, AgentRegistryPort, AgentResolverPort, Critique,
+    DraftRequest, Revision,
+};
+use choreo_core::value_objects::{AgentId, AgentKind, Attributes, Specialty};
+use choreo_tests_integration::postgres_fixture;
+
+fn factory() -> Arc<dyn AgentFactoryPort> {
+    Arc::new(NoopAgentFactory::new())
+}
+
+fn noop_descriptor(id: &str, specialty: &str) -> AgentDescriptor {
+    AgentDescriptor {
+        id: AgentId::new(id).unwrap(),
+        specialty: Specialty::new(specialty).unwrap(),
+        kind: AgentKind::new("noop").unwrap(),
+        attributes: Attributes::empty(),
+    }
+}
+
+#[derive(Debug)]
+struct StubAgent {
+    id: AgentId,
+    specialty: Specialty,
+}
+#[async_trait::async_trait]
+impl AgentPort for StubAgent {
+    fn id(&self) -> &AgentId {
+        &self.id
+    }
+    fn specialty(&self) -> &Specialty {
+        &self.specialty
+    }
+    async fn generate(&self, _: DraftRequest) -> Result<Revision, DomainError> {
+        Ok(Revision {
+            content: String::new(),
+        })
+    }
+    async fn critique(&self, _: &str, _: &TaskConstraints) -> Result<Critique, DomainError> {
+        Ok(Critique {
+            feedback: String::new(),
+        })
+    }
+    async fn revise(&self, own: &str, _: &Critique) -> Result<Revision, DomainError> {
+        Ok(Revision {
+            content: own.to_owned(),
+        })
+    }
+}
+
+#[tokio::test]
+async fn insert_descriptor_roundtrips_through_resolve() {
+    let (pool, _container) = postgres_fixture::start().await;
+    let registry = PostgresAgentRegistry::new(pool, factory());
+
+    registry
+        .insert_descriptor(&noop_descriptor("a1", "triage"))
+        .await
+        .unwrap();
+
+    let resolved = registry
+        .resolve(&AgentId::new("a1").unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resolved.id().as_str(), "a1");
+    assert_eq!(resolved.specialty().as_str(), "triage");
+}
+
+#[tokio::test]
+async fn duplicate_insert_is_already_exists() {
+    let (pool, _container) = postgres_fixture::start().await;
+    let registry = PostgresAgentRegistry::new(pool, factory());
+
+    registry
+        .insert_descriptor(&noop_descriptor("a1", "triage"))
+        .await
+        .unwrap();
+    let err = registry
+        .insert_descriptor(&noop_descriptor("a1", "triage"))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, DomainError::AlreadyExists { what: "agent" }));
+}
+
+#[tokio::test]
+async fn register_via_port_trait_persists_then_unregister_removes() {
+    let (pool, _container) = postgres_fixture::start().await;
+    let registry = PostgresAgentRegistry::new(pool, factory());
+
+    let agent: Arc<dyn AgentPort> = Arc::new(StubAgent {
+        id: AgentId::new("a-port").unwrap(),
+        specialty: Specialty::new("triage").unwrap(),
+    });
+    registry.register(agent).await.unwrap();
+    // Post-register the descriptor resolves to a live NoopAgent (the
+    // wired factory only knows the "noop" kind; the port contract
+    // does not expose which concrete type is returned).
+    let resolved = registry
+        .resolve(&AgentId::new("a-port").unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resolved.id().as_str(), "a-port");
+
+    registry
+        .unregister(&AgentId::new("a-port").unwrap())
+        .await
+        .unwrap();
+    let err = registry
+        .resolve(&AgentId::new("a-port").unwrap())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, DomainError::NotFound { what: "agent" }));
+}
+
+#[tokio::test]
+async fn unregister_missing_is_not_found() {
+    let (pool, _container) = postgres_fixture::start().await;
+    let registry = PostgresAgentRegistry::new(pool, factory());
+
+    let err = registry
+        .unregister(&AgentId::new("ghost").unwrap())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, DomainError::NotFound { what: "agent" }));
+}
+
+#[tokio::test]
+async fn resolve_propagates_factory_rejection_for_unsupported_kind() {
+    let (pool, _container) = postgres_fixture::start().await;
+    let registry = PostgresAgentRegistry::new(pool, factory());
+
+    let descriptor = AgentDescriptor {
+        id: AgentId::new("a-vllm").unwrap(),
+        specialty: Specialty::new("triage").unwrap(),
+        kind: AgentKind::new("vllm").unwrap(),
+        attributes: Attributes::empty(),
+    };
+    registry.insert_descriptor(&descriptor).await.unwrap();
+
+    // The noop factory rejects every non-"noop" kind — a deliberate
+    // honesty signal that the deployment's factory is not wired for
+    // the registered kind.
+    let err = registry
+        .resolve(&AgentId::new("a-vllm").unwrap())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, DomainError::InvariantViolated { .. }));
+}

--- a/crates/choreo-tests-integration/tests/postgres_council_registry.rs
+++ b/crates/choreo-tests-integration/tests/postgres_council_registry.rs
@@ -1,0 +1,128 @@
+//! Integration test: [`PostgresCouncilRegistry`] exercises the full
+//! write + read surface against a real Postgres container.
+//!
+//! Covers: register (insert path + duplicate rejection), replace
+//! (update path + missing-specialty rejection), get, list, delete,
+//! contains.
+//!
+//! Runs only when the `container-tests` feature is enabled (CI).
+
+#![cfg(feature = "container-tests")]
+
+use choreo_adapters::postgres::PostgresCouncilRegistry;
+use choreo_core::entities::Council;
+use choreo_core::error::DomainError;
+use choreo_core::ports::CouncilRegistryPort;
+use choreo_core::value_objects::{AgentId, CouncilId, Specialty};
+use choreo_tests_integration::postgres_fixture;
+use time::macros::datetime;
+
+fn council(specialty: &str, council_id: &str, agents: &[&str]) -> Council {
+    let agent_ids: Vec<AgentId> = agents.iter().map(|a| AgentId::new(*a).unwrap()).collect();
+    Council::new(
+        CouncilId::new(council_id).unwrap(),
+        Specialty::new(specialty).unwrap(),
+        agent_ids,
+        datetime!(2026-04-15 12:00:00 UTC),
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+async fn register_roundtrips_through_get_and_list() {
+    let (pool, _container) = postgres_fixture::start().await;
+    let registry = PostgresCouncilRegistry::new(pool);
+
+    registry
+        .register(council("triage", "c-triage", &["a1"]))
+        .await
+        .unwrap();
+    registry
+        .register(council("reviewer", "c-reviewer", &["a2", "a3"]))
+        .await
+        .unwrap();
+
+    let fetched = registry
+        .get(&Specialty::new("triage").unwrap())
+        .await
+        .unwrap();
+    assert_eq!(fetched.specialty().as_str(), "triage");
+    assert_eq!(fetched.size(), 1);
+    assert_eq!(fetched.id().as_str(), "c-triage");
+
+    let listed = registry.list().await.unwrap();
+    assert_eq!(listed.len(), 2);
+    // Ordering follows the index on `specialty`.
+    assert_eq!(listed[0].specialty().as_str(), "reviewer");
+    assert_eq!(listed[1].specialty().as_str(), "triage");
+}
+
+#[tokio::test]
+async fn duplicate_register_surfaces_as_already_exists() {
+    let (pool, _container) = postgres_fixture::start().await;
+    let registry = PostgresCouncilRegistry::new(pool);
+
+    registry
+        .register(council("triage", "c1", &["a1"]))
+        .await
+        .unwrap();
+    let err = registry
+        .register(council("triage", "c2", &["a2"]))
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        DomainError::AlreadyExists { what: "council" }
+    ));
+}
+
+#[tokio::test]
+async fn replace_updates_only_when_specialty_exists() {
+    let (pool, _container) = postgres_fixture::start().await;
+    let registry = PostgresCouncilRegistry::new(pool);
+
+    // Replacing a missing specialty is NotFound.
+    let err = registry
+        .replace(council("triage", "c1", &["a1"]))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, DomainError::NotFound { what: "council" }));
+
+    // After register, replace updates in place.
+    registry
+        .register(council("triage", "c1", &["a1"]))
+        .await
+        .unwrap();
+    registry
+        .replace(council("triage", "c2", &["a1", "a2"]))
+        .await
+        .unwrap();
+    let got = registry
+        .get(&Specialty::new("triage").unwrap())
+        .await
+        .unwrap();
+    assert_eq!(got.id().as_str(), "c2", "replace must persist the new id");
+    assert_eq!(got.size(), 2);
+}
+
+#[tokio::test]
+async fn delete_and_contains_reflect_presence() {
+    let (pool, _container) = postgres_fixture::start().await;
+    let registry = PostgresCouncilRegistry::new(pool);
+
+    let triage = Specialty::new("triage").unwrap();
+    assert!(!registry.contains(&triage).await.unwrap());
+
+    registry
+        .register(council("triage", "c1", &["a1"]))
+        .await
+        .unwrap();
+    assert!(registry.contains(&triage).await.unwrap());
+
+    registry.delete(&triage).await.unwrap();
+    assert!(!registry.contains(&triage).await.unwrap());
+
+    // Deleting twice surfaces NotFound.
+    let err = registry.delete(&triage).await.unwrap_err();
+    assert!(matches!(err, DomainError::NotFound { what: "council" }));
+}

--- a/crates/choreo-tests-integration/tests/postgres_deliberation_repository.rs
+++ b/crates/choreo-tests-integration/tests/postgres_deliberation_repository.rs
@@ -13,9 +13,7 @@
 
 #![cfg(feature = "container-tests")]
 
-use std::time::Duration;
-
-use choreo_adapters::postgres::{PostgresConfig, PostgresDeliberationRepository, PostgresPool};
+use choreo_adapters::postgres::PostgresDeliberationRepository;
 use choreo_core::entities::{
     Deliberation, DeliberationPhase, Proposal, ValidationOutcome, ValidatorReport,
 };
@@ -24,59 +22,8 @@ use choreo_core::ports::DeliberationRepositoryPort;
 use choreo_core::value_objects::{
     AgentId, Attributes, ProposalId, Rounds, Score, Specialty, TaskId,
 };
-use testcontainers::{
-    core::{IntoContainerPort, WaitFor},
-    runners::AsyncRunner,
-    GenericImage, ImageExt,
-};
+use choreo_tests_integration::postgres_fixture;
 use time::macros::datetime;
-
-const PG_IMAGE: &str = "postgres";
-const PG_TAG: &str = "16-alpine";
-const PG_USER: &str = "choreo";
-const PG_PASSWORD: &str = "choreo";
-const PG_DB: &str = "choreo";
-
-async fn start_postgres() -> (PostgresPool, testcontainers::ContainerAsync<GenericImage>) {
-    let container = GenericImage::new(PG_IMAGE, PG_TAG)
-        .with_exposed_port(5432_u16.tcp())
-        .with_wait_for(WaitFor::message_on_stderr(
-            "database system is ready to accept connections",
-        ))
-        .with_env_var("POSTGRES_USER", PG_USER)
-        .with_env_var("POSTGRES_PASSWORD", PG_PASSWORD)
-        .with_env_var("POSTGRES_DB", PG_DB)
-        .start()
-        .await
-        .expect("postgres container should start");
-    let port = container
-        .get_host_port_ipv4(5432_u16.tcp())
-        .await
-        .expect("host port");
-    let url = format!("postgres://{PG_USER}:{PG_PASSWORD}@127.0.0.1:{port}/{PG_DB}");
-
-    // Dial with retries — even after the readiness log line, the
-    // server can briefly refuse connections while finalising startup.
-    let mut cfg = PostgresConfig::from_url(url);
-    cfg.acquire_timeout = Duration::from_secs(10);
-
-    let mut last_err = None;
-    for _ in 0..20 {
-        match PostgresPool::connect(&cfg).await {
-            Ok(pool) => {
-                pool.run_migrations()
-                    .await
-                    .expect("migrations must apply on a fresh database");
-                return (pool, container);
-            }
-            Err(err) => {
-                last_err = Some(err);
-                tokio::time::sleep(Duration::from_millis(200)).await;
-            }
-        }
-    }
-    panic!("could not connect to postgres after warmup: {last_err:?}");
-}
 
 /// Build a fully-traversed Deliberation so the roundtrip covers
 /// proposals, outcomes, ranking, and the completed phase (the hard
@@ -124,7 +71,7 @@ fn completed_deliberation(task: &str) -> Deliberation {
 
 #[tokio::test]
 async fn postgres_repository_roundtrips_a_completed_deliberation() {
-    let (pool, _container) = start_postgres().await;
+    let (pool, _container) = postgres_fixture::start().await;
     let repo = PostgresDeliberationRepository::new(pool);
 
     let d = completed_deliberation("t-happy");
@@ -147,7 +94,7 @@ async fn postgres_repository_roundtrips_a_completed_deliberation() {
 
 #[tokio::test]
 async fn save_is_upsert_and_preserves_the_latest_body() {
-    let (pool, _container) = start_postgres().await;
+    let (pool, _container) = postgres_fixture::start().await;
     let repo = PostgresDeliberationRepository::new(pool);
 
     // First save — a mid-run deliberation (phase Proposing).
@@ -187,7 +134,7 @@ async fn save_is_upsert_and_preserves_the_latest_body() {
 
 #[tokio::test]
 async fn exists_reflects_presence_and_missing_get_is_not_found() {
-    let (pool, _container) = start_postgres().await;
+    let (pool, _container) = postgres_fixture::start().await;
     let repo = PostgresDeliberationRepository::new(pool);
 
     let id = TaskId::new("t-absent").unwrap();

--- a/crates/choreo/src/compose.rs
+++ b/crates/choreo/src/compose.rs
@@ -11,7 +11,8 @@ use choreo_adapters::memory::{
 use choreo_adapters::nats::{NatsConfig, NatsMessaging, NatsTriggerSubscriber};
 use choreo_adapters::noop::{NoopAgentFactory, NoopExecutor, NoopMessaging};
 use choreo_adapters::postgres::{
-    PostgresConfig, PostgresDeliberationRepository, PostgresPool, PostgresPoolError,
+    PostgresAgentRegistry, PostgresConfig, PostgresCouncilRegistry, PostgresDeliberationRepository,
+    PostgresPool, PostgresPoolError,
 };
 use choreo_adapters::scoring::UniformScoring;
 use choreo_adapters::validators::ContentNonEmptyValidator;
@@ -22,8 +23,9 @@ use choreo_app::usecases::{
 };
 use choreo_core::error::DomainError;
 use choreo_core::ports::{
-    AgentFactoryPort, AgentRegistryPort, ConfigurationPort, DeliberationRepositoryPort,
-    ExecutorPort, MessagingPort, ScoringPort, ServiceConfig, StatisticsPort, ValidatorPort,
+    AgentFactoryPort, AgentRegistryPort, AgentResolverPort, ConfigurationPort, CouncilRegistryPort,
+    DeliberationRepositoryPort, ExecutorPort, MessagingPort, ScoringPort, ServiceConfig,
+    StatisticsPort, ValidatorPort,
 };
 use thiserror::Error;
 use tracing::info;
@@ -33,8 +35,9 @@ use crate::seeding::SeedingError;
 /// Aggregate of every handle the composition root produces.
 pub struct Application {
     pub service_config: ServiceConfig,
-    pub agent_registry: Arc<InMemoryAgentRegistry>,
-    pub council_registry: Arc<InMemoryCouncilRegistry>,
+    pub agent_registry: Arc<dyn AgentRegistryPort>,
+    pub agent_resolver: Arc<dyn AgentResolverPort>,
+    pub council_registry: Arc<dyn CouncilRegistryPort>,
     pub repository: Arc<dyn DeliberationRepositoryPort>,
     pub grpc_service: choreo_adapters::grpc::ChoreographerGrpcService,
     pub nats_subscriber: Option<NatsTriggerSubscriber>,
@@ -83,13 +86,21 @@ pub async fn compose() -> Result<Application, ComposeError> {
     let service_config = EnvConfiguration::new().load().await?;
 
     let clock = Arc::new(SystemClock::new());
-    let agent_registry = Arc::new(InMemoryAgentRegistry::new());
-    let council_registry = Arc::new(InMemoryCouncilRegistry::new());
-    let repository = wire_repository(&service_config).await?;
-
     let validators: Vec<Arc<dyn ValidatorPort>> = vec![Arc::new(ContentNonEmptyValidator::new())];
     let scoring: Arc<dyn ScoringPort> = Arc::new(UniformScoring::new());
     let executor: Arc<dyn ExecutorPort> = Arc::new(NoopExecutor::new());
+    let agent_factory: Arc<dyn AgentFactoryPort> = Arc::new(NoopAgentFactory::new());
+
+    // Pick the persistent backings together so the three registries
+    // and the deliberation repository always live on the same pool
+    // (or all in-memory). Running one Postgres and two in-memory
+    // would split the source of truth across replicas.
+    let Persistence {
+        repository,
+        council_registry,
+        agent_registry,
+        agent_resolver,
+    } = wire_persistence(&service_config, agent_factory.clone()).await?;
 
     let MessagingWiring {
         port: messaging,
@@ -102,7 +113,7 @@ pub async fn compose() -> Result<Application, ComposeError> {
     let deliberate = Arc::new(DeliberateUseCase::new(
         clock.clone(),
         council_registry.clone(),
-        agent_registry.clone(),
+        agent_resolver.clone(),
         validators,
         scoring,
         repository.clone(),
@@ -123,19 +134,17 @@ pub async fn compose() -> Result<Application, ComposeError> {
     let create_council = Arc::new(CreateCouncilUseCase::new(
         clock.clone(),
         council_registry.clone(),
-        agent_registry.clone(),
+        agent_resolver.clone(),
     ));
     let delete_council = Arc::new(DeleteCouncilUseCase::new(council_registry.clone()));
     let list_councils = Arc::new(ListCouncilsUseCase::new(council_registry.clone()));
     let get_deliberation = Arc::new(GetDeliberationUseCase::new(repository.clone()));
 
-    let agent_factory: Arc<dyn AgentFactoryPort> = Arc::new(NoopAgentFactory::new());
-    let agent_registry_port: Arc<dyn AgentRegistryPort> = agent_registry.clone();
     let register_agent = Arc::new(RegisterAgentUseCase::new(
         agent_factory,
-        agent_registry_port.clone(),
+        agent_registry.clone(),
     ));
-    let unregister_agent = Arc::new(UnregisterAgentUseCase::new(agent_registry_port));
+    let unregister_agent = Arc::new(UnregisterAgentUseCase::new(agent_registry.clone()));
 
     let auto_dispatch = Arc::new(AutoDispatchService::new(
         deliberate.clone(),
@@ -182,6 +191,7 @@ pub async fn compose() -> Result<Application, ComposeError> {
     Ok(Application {
         service_config,
         agent_registry,
+        agent_resolver,
         council_registry,
         repository,
         grpc_service,
@@ -266,22 +276,46 @@ async fn wire_messaging(cfg: &ServiceConfig) -> Result<MessagingWiring, ComposeE
     })
 }
 
-/// Pick a [`DeliberationRepositoryPort`] implementation based on the
-/// environment: Postgres when `CHOREO_POSTGRES_URL` is set (migrations
-/// apply on startup so a fresh cluster is exercisable), in-memory
-/// otherwise.
-async fn wire_repository(
+/// Composite of the four persistent handles the app needs. Kept as a
+/// single bag so the composition root wires them together — either
+/// all backed by Postgres, or all in-memory. Splitting the source of
+/// truth across replicas (half Postgres, half in-memory) is not a
+/// useful configuration today.
+struct Persistence {
+    repository: Arc<dyn DeliberationRepositoryPort>,
+    council_registry: Arc<dyn CouncilRegistryPort>,
+    agent_registry: Arc<dyn AgentRegistryPort>,
+    agent_resolver: Arc<dyn AgentResolverPort>,
+}
+
+/// Pick persistent backings based on config. When `CHOREO_POSTGRES_URL`
+/// is set, every registry that has a Postgres adapter goes through
+/// it; migrations apply on startup so a fresh cluster is exercisable.
+/// Otherwise the in-memory defaults are wired.
+async fn wire_persistence(
     cfg: &ServiceConfig,
-) -> Result<Arc<dyn DeliberationRepositoryPort>, ComposeError> {
+    agent_factory: Arc<dyn AgentFactoryPort>,
+) -> Result<Persistence, ComposeError> {
     if let Some(url) = cfg.postgres_url.as_deref() {
-        let pg_cfg = PostgresConfig::from_url(url);
-        let pool = PostgresPool::connect(&pg_cfg).await?;
+        let pool = PostgresPool::connect(&PostgresConfig::from_url(url)).await?;
         pool.run_migrations().await?;
-        info!("postgres deliberation repository wired");
-        Ok(Arc::new(PostgresDeliberationRepository::new(pool)))
+        let agents = Arc::new(PostgresAgentRegistry::new(pool.clone(), agent_factory));
+        info!("postgres persistence wired (deliberations, councils, agents)");
+        Ok(Persistence {
+            repository: Arc::new(PostgresDeliberationRepository::new(pool.clone())),
+            council_registry: Arc::new(PostgresCouncilRegistry::new(pool)),
+            agent_registry: agents.clone(),
+            agent_resolver: agents,
+        })
     } else {
-        info!("postgres disabled; using in-memory deliberation repository");
-        Ok(Arc::new(InMemoryDeliberationRepository::new()))
+        info!("postgres disabled; using in-memory persistence");
+        let agents = Arc::new(InMemoryAgentRegistry::new());
+        Ok(Persistence {
+            repository: Arc::new(InMemoryDeliberationRepository::new()),
+            council_registry: Arc::new(InMemoryCouncilRegistry::new()),
+            agent_registry: agents.clone(),
+            agent_resolver: agents,
+        })
     }
 }
 

--- a/crates/choreo/src/seeding.rs
+++ b/crates/choreo/src/seeding.rs
@@ -10,11 +10,10 @@
 //! adapter-specific channels (future slices: RegisterAgent RPC,
 //! config-driven factories).
 
-use choreo_adapters::memory::{InMemoryAgentRegistry, InMemoryCouncilRegistry};
 use choreo_adapters::noop::NoopAgent;
 use choreo_core::entities::Council;
 use choreo_core::error::DomainError;
-use choreo_core::ports::{ClockPort, CouncilRegistryPort};
+use choreo_core::ports::{AgentRegistryPort, ClockPort, CouncilRegistryPort};
 use choreo_core::value_objects::{AgentId, CouncilId, Specialty};
 use std::sync::Arc;
 use thiserror::Error;
@@ -32,8 +31,8 @@ pub enum SeedingError {
 /// Read the opt-in env var and apply seeding if present.
 pub async fn apply_env_seeding(
     clock: &dyn ClockPort,
-    agent_registry: &InMemoryAgentRegistry,
-    council_registry: &InMemoryCouncilRegistry,
+    agent_registry: &dyn AgentRegistryPort,
+    council_registry: &dyn CouncilRegistryPort,
 ) -> Result<(), SeedingError> {
     let Ok(raw) = std::env::var(SEED_ENV_VAR) else {
         return Ok(());
@@ -56,8 +55,8 @@ pub async fn apply_env_seeding(
 /// without touching process env.
 pub async fn apply_seeding(
     clock: &dyn ClockPort,
-    agent_registry: &InMemoryAgentRegistry,
-    council_registry: &InMemoryCouncilRegistry,
+    agent_registry: &dyn AgentRegistryPort,
+    council_registry: &dyn CouncilRegistryPort,
     specialties: &[&str],
 ) -> Result<(), SeedingError> {
     for label in specialties {
@@ -66,7 +65,7 @@ pub async fn apply_seeding(
         let agent = Arc::new(NoopAgent::new(agent_id.clone(), specialty.clone()));
         // If the agent is already registered (re-seeding) swallow the
         // AlreadyExists error so restarts stay idempotent.
-        match agent_registry.insert(agent).await {
+        match agent_registry.register(agent).await {
             Ok(()) | Err(DomainError::AlreadyExists { .. }) => {}
             Err(err) => return Err(err.into()),
         }
@@ -84,6 +83,7 @@ pub async fn apply_seeding(
 mod tests {
     use super::*;
     use choreo_adapters::clock::SystemClock;
+    use choreo_adapters::memory::{InMemoryAgentRegistry, InMemoryCouncilRegistry};
     use choreo_core::ports::{AgentResolverPort, CouncilRegistryPort};
 
     #[tokio::test]

--- a/scripts/ci/integration-postgres.sh
+++ b/scripts/ci/integration-postgres.sh
@@ -14,5 +14,7 @@ RUST_TEST_THREADS=1 cargo test \
   -p choreo-tests-integration \
   --features container-tests \
   --test postgres_deliberation_repository \
+  --test postgres_council_registry \
+  --test postgres_agent_registry \
   --locked \
   -- --test-threads=1


### PR DESCRIPTION
## Summary

Extends the Postgres backing to every registry that has a persistent adapter today. When \`CHOREO_POSTGRES_URL\` is set, the composition root wires Postgres for deliberations, councils, **and** agents atomically — no split source of truth across replicas.

## What changed

- \`choreo-core\`: \`AgentDescriptor\` gains \`Serialize\`/\`Deserialize\`
- \`choreo-adapters/postgres\`:
  - \`PostgresCouncilRegistry\` — register / replace / get / list / delete / contains. Council stored as JSONB keyed by specialty. Migration 0002.
  - \`PostgresAgentRegistry\` — implements both \`AgentRegistryPort\` (write) and \`AgentResolverPort\` (read). Persists \`AgentDescriptor\`; \`resolve\` rehydrates a live \`AgentPort\` via the injected \`AgentFactoryPort\` so no pickled provider state crosses the DB boundary. Migration 0003.
  - Honest caveat documented on the adapter: \`register(agent)\` projects to \`kind = \"noop\"\` until a dispatching factory lands.
- \`choreo\` binary:
  - \`compose.rs\` refactored around a single \`Persistence\` helper — all four handles travel together; choosing Postgres flips every registry in lockstep (no half-Postgres/half-memory footguns)
  - \`Application\` widened to port-trait handles (\`Arc<dyn ...>\`); no behaviour change
  - \`seeding.rs\` takes \`AgentRegistryPort\` / \`CouncilRegistryPort\` so seeding works identically on Postgres
- CI: \`integration-postgres\` job now runs all three Postgres suites

## Integration tests (12 total, all green locally via podman + testcontainers)

- **Council registry (4)**: register-roundtrip + list, duplicate → \`AlreadyExists\`, \`replace\` NotFound/update, delete+contains
- **Agent registry (5)**: insert_descriptor roundtrip, duplicate → \`AlreadyExists\`, port-trait register+unregister, unregister missing → \`NotFound\`, \`resolve\` for an unsupported kind surfaces the factory's \`InvariantViolated\`
- **Deliberation repository (3)** (unchanged logic; migrated to shared fixture): completed-aggregate roundtrip, upsert overwrite, exists/not-found

## Design notes

- **Shared fixture**: \`postgres_fixture::start()\` in the integration crate's library centralises container setup. \`container-tests\` feature now pulls \`testcontainers\` + \`tokio\` as optional deps (not just dev-deps) so the lib target builds with the fixture.
- **Atomic persistence choice**: the \`Persistence\` struct in \`compose.rs\` means you can't accidentally ship one Postgres-backed registry with two in-memory ones. Either all Postgres, or all in-memory.

## Test plan
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\`
- [x] \`cargo test --workspace\`
- [x] 12 Postgres integration tests locally (testcontainers + podman)
- [ ] CI green on all 12 checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)