### PR TITLE
feat(persistence): phase 11c — Postgres statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,19 +93,21 @@ gate in this repository):
 
 **Persistence**:
 
-- When `CHOREO_POSTGRES_URL` is set, deliberations, councils, and
-  the agent registry persist to Postgres; otherwise the in-memory
-  defaults are wired. Persistence choice is binary: all four backings
-  are either Postgres or in-memory together, so no replica reads from
-  a split source of truth. Migrations apply on startup — a fresh
-  cluster is immediately exercisable. Schema lives under
-  `crates/choreo-adapters/migrations/postgres/`.
+- When `CHOREO_POSTGRES_URL` is set, deliberations, councils, the
+  agent registry, and operational statistics persist to Postgres;
+  otherwise the in-memory defaults are wired. Persistence choice is
+  binary: every backing is either Postgres or in-memory together, so
+  no replica reads from a split source of truth. Migrations apply on
+  startup — a fresh cluster is immediately exercisable. Schema lives
+  under `crates/choreo-adapters/migrations/postgres/`.
 - Agents persist as descriptors (`id`, `specialty`, `kind`,
   `attributes`); live `AgentPort` handles are rehydrated through the
   wired `AgentFactoryPort` on resolve, so no pickled provider state
   crosses the database boundary.
-- Statistics still run in memory; its persistent backing lands in
-  the next sub-slice (11c).
+- Statistics counters use an `INSERT ... ON CONFLICT DO UPDATE
+  ... x = x + 1` protocol so concurrent replicas accumulate into the
+  same row without a read-modify-write race — verified by a 50-
+  concurrent-record integration test.
 
 **What is *not* wired yet**:
 
@@ -116,7 +118,5 @@ gate in this repository):
   slice.
 - `StreamDeliberation` streams phase transitions only; per-proposal,
   per-critique, and per-revision streaming arrives in a later slice.
-- Statistics still live in memory; a persistent backing for the
-  `StatisticsPort` is the last persistence sub-slice (11c).
 
 See `docs/experiments/` for anything beyond these bullet points.

--- a/crates/choreo-adapters/migrations/postgres/0004_statistics.sql
+++ b/crates/choreo-adapters/migrations/postgres/0004_statistics.sql
@@ -1,0 +1,27 @@
+-- Phase 11c: statistics persistence.
+--
+-- Two tables so each counter update is a single atomic row write,
+-- and so multi-replica deployments can increment the same counters
+-- concurrently without a read-modify-write race:
+--
+--   statistics_totals        — one row (id = 'singleton'), holds the
+--                              scalar counters shared across specialties.
+--   statistics_by_specialty  — one row per specialty, deliberation count.
+--
+-- Adapter writes use `INSERT ... ON CONFLICT ... DO UPDATE SET
+-- counter = table.counter + excluded.counter` so two replicas
+-- recording concurrently both land on the row's accumulated value.
+
+CREATE TABLE IF NOT EXISTS statistics_totals (
+    id                    TEXT PRIMARY KEY,
+    total_deliberations   BIGINT NOT NULL DEFAULT 0,
+    total_orchestrations  BIGINT NOT NULL DEFAULT 0,
+    total_duration_ms     BIGINT NOT NULL DEFAULT 0,
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS statistics_by_specialty (
+    specialty     TEXT PRIMARY KEY,
+    deliberations BIGINT NOT NULL DEFAULT 0,
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/crates/choreo-adapters/src/postgres/mod.rs
+++ b/crates/choreo-adapters/src/postgres/mod.rs
@@ -15,8 +15,10 @@ mod council_registry;
 mod deliberation_repository;
 mod error;
 mod pool;
+mod statistics;
 
 pub use agent_registry::PostgresAgentRegistry;
 pub use council_registry::PostgresCouncilRegistry;
 pub use deliberation_repository::PostgresDeliberationRepository;
 pub use pool::{PostgresConfig, PostgresPool, PostgresPoolError};
+pub use statistics::PostgresStatistics;

--- a/crates/choreo-adapters/src/postgres/statistics.rs
+++ b/crates/choreo-adapters/src/postgres/statistics.rs
@@ -1,0 +1,199 @@
+//! Postgres implementation of [`StatisticsPort`].
+//!
+//! Storage: running counters split across two tables (see
+//! `migrations/postgres/0004_statistics.sql`). Every record is a
+//! single `INSERT ... ON CONFLICT ... DO UPDATE SET x = table.x + 1`
+//! so concurrent replicas accumulate into the same row without a
+//! read-modify-write race.
+//!
+//! Saturating semantics: Postgres `BIGINT` is `i64`. The in-memory
+//! counters are `u64` so an operator who really sustained 2^63 events
+//! could legally overflow on the wire. We guard by clamping at
+//! read-time on snapshot; writes stay additive and never fail the
+//! port.
+
+use async_trait::async_trait;
+use choreo_core::entities::Statistics;
+use choreo_core::error::DomainError;
+use choreo_core::ports::StatisticsPort;
+use choreo_core::value_objects::{DurationMs, Specialty};
+use sqlx::Row;
+
+use super::error::sqlx_to_domain;
+use super::pool::PostgresPool;
+
+const TOTALS_SINGLETON_ID: &str = "singleton";
+
+#[derive(Clone)]
+pub struct PostgresStatistics {
+    pool: PostgresPool,
+}
+
+impl std::fmt::Debug for PostgresStatistics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PostgresStatistics").finish()
+    }
+}
+
+impl PostgresStatistics {
+    #[must_use]
+    pub fn new(pool: PostgresPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl StatisticsPort for PostgresStatistics {
+    async fn record_deliberation(
+        &self,
+        specialty: &Specialty,
+        duration: DurationMs,
+    ) -> Result<(), DomainError> {
+        let mut tx = self
+            .pool
+            .inner()
+            .begin()
+            .await
+            .map_err(|e| sqlx_to_domain(e, "record_deliberation"))?;
+
+        let duration_ms = i64::try_from(duration.get()).unwrap_or(i64::MAX);
+
+        sqlx::query(
+            "
+            INSERT INTO statistics_totals
+                (id, total_deliberations, total_duration_ms, updated_at)
+            VALUES ($1, 1, $2, NOW())
+            ON CONFLICT (id) DO UPDATE SET
+                total_deliberations = statistics_totals.total_deliberations + 1,
+                total_duration_ms   = statistics_totals.total_duration_ms + EXCLUDED.total_duration_ms,
+                updated_at          = NOW()
+            ",
+        )
+        .bind(TOTALS_SINGLETON_ID)
+        .bind(duration_ms)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| sqlx_to_domain(e, "record_deliberation"))?;
+
+        sqlx::query(
+            "
+            INSERT INTO statistics_by_specialty (specialty, deliberations, updated_at)
+            VALUES ($1, 1, NOW())
+            ON CONFLICT (specialty) DO UPDATE SET
+                deliberations = statistics_by_specialty.deliberations + 1,
+                updated_at    = NOW()
+            ",
+        )
+        .bind(specialty.as_str())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| sqlx_to_domain(e, "record_deliberation"))?;
+
+        tx.commit()
+            .await
+            .map_err(|e| sqlx_to_domain(e, "record_deliberation"))?;
+        Ok(())
+    }
+
+    async fn record_orchestration(&self, duration: DurationMs) -> Result<(), DomainError> {
+        let duration_ms = i64::try_from(duration.get()).unwrap_or(i64::MAX);
+        sqlx::query(
+            "
+            INSERT INTO statistics_totals
+                (id, total_orchestrations, total_duration_ms, updated_at)
+            VALUES ($1, 1, $2, NOW())
+            ON CONFLICT (id) DO UPDATE SET
+                total_orchestrations = statistics_totals.total_orchestrations + 1,
+                total_duration_ms    = statistics_totals.total_duration_ms + EXCLUDED.total_duration_ms,
+                updated_at           = NOW()
+            ",
+        )
+        .bind(TOTALS_SINGLETON_ID)
+        .bind(duration_ms)
+        .execute(self.pool.inner())
+        .await
+        .map_err(|e| sqlx_to_domain(e, "record_orchestration"))?;
+        Ok(())
+    }
+
+    async fn snapshot(&self) -> Result<Statistics, DomainError> {
+        let totals = sqlx::query(
+            "
+            SELECT total_deliberations, total_orchestrations, total_duration_ms
+            FROM statistics_totals WHERE id = $1
+            ",
+        )
+        .bind(TOTALS_SINGLETON_ID)
+        .fetch_optional(self.pool.inner())
+        .await
+        .map_err(|e| sqlx_to_domain(e, "snapshot"))?;
+
+        let (total_deliberations, total_orchestrations, total_duration) = match totals {
+            Some(row) => {
+                let td: i64 = row
+                    .try_get("total_deliberations")
+                    .map_err(|e| sqlx_to_domain(e, "snapshot"))?;
+                let to: i64 = row
+                    .try_get("total_orchestrations")
+                    .map_err(|e| sqlx_to_domain(e, "snapshot"))?;
+                let dur: i64 = row
+                    .try_get("total_duration_ms")
+                    .map_err(|e| sqlx_to_domain(e, "snapshot"))?;
+                (
+                    clamp_nonneg(td),
+                    clamp_nonneg(to),
+                    DurationMs::from_millis(clamp_nonneg(dur)),
+                )
+            }
+            None => (0, 0, DurationMs::ZERO),
+        };
+
+        let specialty_rows =
+            sqlx::query("SELECT specialty, deliberations FROM statistics_by_specialty")
+                .fetch_all(self.pool.inner())
+                .await
+                .map_err(|e| sqlx_to_domain(e, "snapshot"))?;
+
+        let mut per_specialty = std::collections::BTreeMap::new();
+        for row in specialty_rows {
+            let name: String = row
+                .try_get("specialty")
+                .map_err(|e| sqlx_to_domain(e, "snapshot"))?;
+            let count: i64 = row
+                .try_get("deliberations")
+                .map_err(|e| sqlx_to_domain(e, "snapshot"))?;
+            per_specialty.insert(Specialty::new(name)?, clamp_nonneg(count));
+        }
+
+        Ok(Statistics::from_counters(
+            total_deliberations,
+            total_orchestrations,
+            total_duration,
+            per_specialty,
+        ))
+    }
+}
+
+/// Map a signed counter onto the entity's `u64` shape. Negative
+/// values are impossible with the `INSERT ... + 1` protocol but we
+/// clamp defensively rather than panic on a drift.
+fn clamp_nonneg(v: i64) -> u64 {
+    if v < 0 {
+        0
+    } else {
+        v as u64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clamp_maps_negative_to_zero_and_preserves_positive() {
+        assert_eq!(clamp_nonneg(0), 0);
+        assert_eq!(clamp_nonneg(42), 42);
+        assert_eq!(clamp_nonneg(-1), 0);
+        assert_eq!(clamp_nonneg(i64::MAX), i64::MAX as u64);
+    }
+}

--- a/crates/choreo-core/src/entities/statistics.rs
+++ b/crates/choreo-core/src/entities/statistics.rs
@@ -29,6 +29,27 @@ impl Statistics {
         Self::default()
     }
 
+    /// Rehydrate a [`Statistics`] from already-aggregated counters.
+    ///
+    /// Used by persistent adapters whose storage shape keeps running
+    /// sums rather than the stream of individual records. The entity's
+    /// mutators stay the single source of truth for increments; this
+    /// is the matching read path.
+    #[must_use]
+    pub fn from_counters(
+        total_deliberations: u64,
+        total_orchestrations: u64,
+        total_duration: DurationMs,
+        per_specialty: BTreeMap<Specialty, u64>,
+    ) -> Self {
+        Self {
+            total_deliberations,
+            total_orchestrations,
+            total_duration,
+            per_specialty,
+        }
+    }
+
     /// Record that a deliberation for `specialty` completed in `duration`.
     pub fn record_deliberation(&mut self, specialty: &Specialty, duration: DurationMs) {
         self.total_deliberations = self.total_deliberations.saturating_add(1);

--- a/crates/choreo-tests-integration/tests/postgres_statistics.rs
+++ b/crates/choreo-tests-integration/tests/postgres_statistics.rs
@@ -1,0 +1,103 @@
+//! Integration test: [`PostgresStatistics`] against a real Postgres
+//! container. Exercises record / snapshot semantics and the
+//! concurrent-accumulation guarantee the counter-increment UPSERT
+//! protocol is meant to provide.
+//!
+//! Runs only when the `container-tests` feature is enabled (CI).
+
+#![cfg(feature = "container-tests")]
+
+use std::sync::Arc;
+
+use choreo_adapters::postgres::PostgresStatistics;
+use choreo_core::ports::StatisticsPort;
+use choreo_core::value_objects::{DurationMs, Specialty};
+use choreo_tests_integration::postgres_fixture;
+use futures::future::join_all;
+
+#[tokio::test]
+async fn fresh_snapshot_is_empty() {
+    let (pool, _container) = postgres_fixture::start().await;
+    let stats = PostgresStatistics::new(pool);
+    let snap = stats.snapshot().await.unwrap();
+    assert_eq!(snap.total_deliberations(), 0);
+    assert_eq!(snap.total_orchestrations(), 0);
+    assert_eq!(snap.total_duration(), DurationMs::ZERO);
+    assert!(snap.per_specialty().is_empty());
+}
+
+#[tokio::test]
+async fn record_deliberation_populates_totals_and_per_specialty() {
+    let (pool, _container) = postgres_fixture::start().await;
+    let stats = PostgresStatistics::new(pool);
+
+    let triage = Specialty::new("triage").unwrap();
+    let reviewer = Specialty::new("reviewer").unwrap();
+
+    stats
+        .record_deliberation(&triage, DurationMs::from_millis(100))
+        .await
+        .unwrap();
+    stats
+        .record_deliberation(&triage, DurationMs::from_millis(50))
+        .await
+        .unwrap();
+    stats
+        .record_deliberation(&reviewer, DurationMs::from_millis(200))
+        .await
+        .unwrap();
+
+    let snap = stats.snapshot().await.unwrap();
+    assert_eq!(snap.total_deliberations(), 3);
+    assert_eq!(snap.total_orchestrations(), 0);
+    assert_eq!(snap.total_duration(), DurationMs::from_millis(350));
+    assert_eq!(snap.per_specialty().get(&triage).copied(), Some(2));
+    assert_eq!(snap.per_specialty().get(&reviewer).copied(), Some(1));
+}
+
+#[tokio::test]
+async fn record_orchestration_does_not_touch_per_specialty() {
+    let (pool, _container) = postgres_fixture::start().await;
+    let stats = PostgresStatistics::new(pool);
+
+    stats
+        .record_orchestration(DurationMs::from_millis(400))
+        .await
+        .unwrap();
+    let snap = stats.snapshot().await.unwrap();
+    assert_eq!(snap.total_orchestrations(), 1);
+    assert_eq!(snap.total_duration(), DurationMs::from_millis(400));
+    assert!(snap.per_specialty().is_empty());
+}
+
+#[tokio::test]
+async fn concurrent_records_accumulate_without_loss() {
+    // The UPSERT-with-increment protocol is the core design decision
+    // for multi-replica safety. This test exercises it by firing 50
+    // concurrent record_deliberation calls against the same row and
+    // asserting the counter matches the number of requests.
+    let (pool, _container) = postgres_fixture::start().await;
+    let stats = Arc::new(PostgresStatistics::new(pool));
+    let triage = Specialty::new("triage").unwrap();
+
+    let tasks = (0..50).map(|_| {
+        let stats = stats.clone();
+        let triage = triage.clone();
+        async move {
+            stats
+                .record_deliberation(&triage, DurationMs::from_millis(10))
+                .await
+                .unwrap();
+        }
+    });
+    join_all(tasks).await;
+
+    let snap = stats.snapshot().await.unwrap();
+    assert_eq!(
+        snap.total_deliberations(),
+        50,
+        "every concurrent record must be observed"
+    );
+    assert_eq!(snap.per_specialty().get(&triage).copied(), Some(50));
+    assert_eq!(snap.total_duration(), DurationMs::from_millis(500));
+}

--- a/crates/choreo/src/compose.rs
+++ b/crates/choreo/src/compose.rs
@@ -12,7 +12,7 @@ use choreo_adapters::nats::{NatsConfig, NatsMessaging, NatsTriggerSubscriber};
 use choreo_adapters::noop::{NoopAgentFactory, NoopExecutor, NoopMessaging};
 use choreo_adapters::postgres::{
     PostgresAgentRegistry, PostgresConfig, PostgresCouncilRegistry, PostgresDeliberationRepository,
-    PostgresPool, PostgresPoolError,
+    PostgresPool, PostgresPoolError, PostgresStatistics,
 };
 use choreo_adapters::scoring::UniformScoring;
 use choreo_adapters::validators::ContentNonEmptyValidator;
@@ -100,6 +100,7 @@ pub async fn compose() -> Result<Application, ComposeError> {
         council_registry,
         agent_registry,
         agent_resolver,
+        statistics,
     } = wire_persistence(&service_config, agent_factory.clone()).await?;
 
     let MessagingWiring {
@@ -107,8 +108,6 @@ pub async fn compose() -> Result<Application, ComposeError> {
         subscriber_factory: nats_subscriber_factory,
         nats_client,
     } = wire_messaging(&service_config).await?;
-
-    let statistics: Arc<dyn StatisticsPort> = Arc::new(InMemoryStatistics::new());
 
     let deliberate = Arc::new(DeliberateUseCase::new(
         clock.clone(),
@@ -276,7 +275,7 @@ async fn wire_messaging(cfg: &ServiceConfig) -> Result<MessagingWiring, ComposeE
     })
 }
 
-/// Composite of the four persistent handles the app needs. Kept as a
+/// Composite of the persistent handles the app needs. Kept as a
 /// single bag so the composition root wires them together — either
 /// all backed by Postgres, or all in-memory. Splitting the source of
 /// truth across replicas (half Postgres, half in-memory) is not a
@@ -286,6 +285,7 @@ struct Persistence {
     council_registry: Arc<dyn CouncilRegistryPort>,
     agent_registry: Arc<dyn AgentRegistryPort>,
     agent_resolver: Arc<dyn AgentResolverPort>,
+    statistics: Arc<dyn StatisticsPort>,
 }
 
 /// Pick persistent backings based on config. When `CHOREO_POSTGRES_URL`
@@ -300,12 +300,13 @@ async fn wire_persistence(
         let pool = PostgresPool::connect(&PostgresConfig::from_url(url)).await?;
         pool.run_migrations().await?;
         let agents = Arc::new(PostgresAgentRegistry::new(pool.clone(), agent_factory));
-        info!("postgres persistence wired (deliberations, councils, agents)");
+        info!("postgres persistence wired (deliberations, councils, agents, statistics)");
         Ok(Persistence {
             repository: Arc::new(PostgresDeliberationRepository::new(pool.clone())),
-            council_registry: Arc::new(PostgresCouncilRegistry::new(pool)),
+            council_registry: Arc::new(PostgresCouncilRegistry::new(pool.clone())),
             agent_registry: agents.clone(),
             agent_resolver: agents,
+            statistics: Arc::new(PostgresStatistics::new(pool)),
         })
     } else {
         info!("postgres disabled; using in-memory persistence");
@@ -315,6 +316,7 @@ async fn wire_persistence(
             council_registry: Arc::new(InMemoryCouncilRegistry::new()),
             agent_registry: agents.clone(),
             agent_resolver: agents,
+            statistics: Arc::new(InMemoryStatistics::new()),
         })
     }
 }

--- a/scripts/ci/integration-postgres.sh
+++ b/scripts/ci/integration-postgres.sh
@@ -16,5 +16,6 @@ RUST_TEST_THREADS=1 cargo test \
   --test postgres_deliberation_repository \
   --test postgres_council_registry \
   --test postgres_agent_registry \
+  --test postgres_statistics \
   --locked \
   -- --test-threads=1


### PR DESCRIPTION
## Summary

Closes the persistence trilogy. Operational counters now survive restarts and accumulate safely across replicas when \`CHOREO_POSTGRES_URL\` is set.

## What changed

- \`choreo-core\`: \`Statistics::from_counters\` for adapters that store running sums rather than the stream of records
- \`choreo-adapters/postgres\`:
  - Migration \`0004_statistics.sql\`: two tables — \`statistics_totals\` (singleton) + \`statistics_by_specialty\` (per-specialty count)
  - \`PostgresStatistics\`: every record is an \`INSERT ... ON CONFLICT ... DO UPDATE SET x = table.x + EXCLUDED.x\` so concurrent replicas accumulate without a read-modify-write race; \`record_deliberation\` groups both writes in a transaction so totals and per-specialty never drift
- \`choreo\` binary: \`Persistence\` helper grows a \`StatisticsPort\` slot; Postgres/in-memory switch stays binary (all or nothing)
- CI: \`integration-postgres\` job now runs four Postgres suites (deliberations + councils + agents + statistics)

## Integration tests (4 new, all green locally via podman + testcontainers)

- Fresh snapshot is empty
- \`record_deliberation\` populates totals and per-specialty map
- \`record_orchestration\` never touches per-specialty
- **50-concurrent-record race check**: fires 50 concurrent \`record_deliberation\` calls against the same row and asserts every write is observed (the key multi-replica safety guarantee)

## Persistence trilogy complete

- 11a: deliberations
- 11b: councils + agents
- 11c: statistics ← this slice

Everything that had a port now has a persistent adapter. Migrations apply on startup, all handles travel together under the binary switch, and \`cargo test --workspace\` stays fast and network-free (testcontainer suites gated behind the \`container-tests\` feature).

## Test plan
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\`
- [x] \`cargo test --workspace\`
- [x] Four Postgres integration suites locally (testcontainers + podman)
- [ ] CI green on all 12 checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)