### PR TITLE
feat(observability): phase 12 — instrumented tracing spans with domain fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,6 +411,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 

--- a/README.md
+++ b/README.md
@@ -118,5 +118,14 @@ gate in this repository):
   slice.
 - `StreamDeliberation` streams phase transitions only; per-proposal,
   per-critique, and per-revision streaming arrives in a later slice.
+- Distributed tracing: the core use cases, gRPC handlers, NATS
+  inbound subscriber, and `AutoDispatchService` emit `#[tracing::
+  instrument]` spans with domain fields (`task_id`, `specialty`,
+  `event_id`, `agent_id`, `kind`). A regression test pins the
+  `deliberate` span name and fields. **OTLP export** and **W3C
+  tracecontext propagation** across NATS / gRPC boundaries land in
+  a follow-up slice; today spans are observable in-process via the
+  binary's structured JSON subscriber and whatever collector is
+  pointed at stdout.
 
 See `docs/experiments/` for anything beyond these bullet points.

--- a/crates/choreo-adapters/src/grpc/service.rs
+++ b/crates/choreo-adapters/src/grpc/service.rs
@@ -172,6 +172,7 @@ impl ChoreographerService for ChoreographerGrpcService {
         std::result::Result<pb::StreamDeliberationResponse, Status>,
     >;
 
+    #[tracing::instrument(name = "rpc.deliberate", skip_all)]
     async fn deliberate(
         &self,
         request: Request<pb::DeliberateRequest>,
@@ -194,6 +195,7 @@ impl ChoreographerService for ChoreographerGrpcService {
         Ok(Response::new(deliberate_response_from(&out)))
     }
 
+    #[tracing::instrument(name = "rpc.stream_deliberation", skip_all)]
     async fn stream_deliberation(
         &self,
         request: Request<pb::StreamDeliberationRequest>,
@@ -242,6 +244,7 @@ impl ChoreographerService for ChoreographerGrpcService {
         )))
     }
 
+    #[tracing::instrument(name = "rpc.get_deliberation_result", skip_all)]
     async fn get_deliberation_result(
         &self,
         request: Request<pb::GetDeliberationResultRequest>,
@@ -272,6 +275,7 @@ impl ChoreographerService for ChoreographerGrpcService {
         }
     }
 
+    #[tracing::instrument(name = "rpc.orchestrate", skip_all)]
     async fn orchestrate(
         &self,
         request: Request<pb::OrchestrateRequest>,
@@ -292,6 +296,7 @@ impl ChoreographerService for ChoreographerGrpcService {
         Ok(Response::new(orchestrate_response_from(&out)))
     }
 
+    #[tracing::instrument(name = "rpc.create_council", skip_all)]
     async fn create_council(
         &self,
         request: Request<pb::CreateCouncilRequest>,
@@ -330,6 +335,7 @@ impl ChoreographerService for ChoreographerGrpcService {
         }))
     }
 
+    #[tracing::instrument(name = "rpc.list_councils", skip_all)]
     async fn list_councils(
         &self,
         _request: Request<pb::ListCouncilsRequest>,
@@ -348,6 +354,7 @@ impl ChoreographerService for ChoreographerGrpcService {
         }))
     }
 
+    #[tracing::instrument(name = "rpc.delete_council", skip_all)]
     async fn delete_council(
         &self,
         request: Request<pb::DeleteCouncilRequest>,
@@ -363,6 +370,7 @@ impl ChoreographerService for ChoreographerGrpcService {
         }
     }
 
+    #[tracing::instrument(name = "rpc.register_agent", skip_all)]
     async fn register_agent(
         &self,
         request: Request<pb::RegisterAgentRequest>,
@@ -384,6 +392,7 @@ impl ChoreographerService for ChoreographerGrpcService {
         }))
     }
 
+    #[tracing::instrument(name = "rpc.unregister_agent", skip_all)]
     async fn unregister_agent(
         &self,
         request: Request<pb::UnregisterAgentRequest>,
@@ -400,6 +409,7 @@ impl ChoreographerService for ChoreographerGrpcService {
         }
     }
 
+    #[tracing::instrument(name = "rpc.process_trigger_event", skip_all)]
     async fn process_trigger_event(
         &self,
         request: Request<pb::ProcessTriggerEventRequest>,
@@ -435,6 +445,7 @@ impl ChoreographerService for ChoreographerGrpcService {
         }))
     }
 
+    #[tracing::instrument(name = "rpc.get_status", skip_all)]
     async fn get_status(
         &self,
         request: Request<pb::GetStatusRequest>,
@@ -459,6 +470,7 @@ impl ChoreographerService for ChoreographerGrpcService {
         }))
     }
 
+    #[tracing::instrument(name = "rpc.get_metrics", skip_all)]
     async fn get_metrics(
         &self,
         _request: Request<pb::GetMetricsRequest>,

--- a/crates/choreo-adapters/src/nats/subscriber.rs
+++ b/crates/choreo-adapters/src/nats/subscriber.rs
@@ -83,6 +83,7 @@ impl NatsTriggerSubscriber {
     }
 }
 
+#[tracing::instrument(name = "nats.trigger.inbound", skip_all)]
 async fn handle_message(dispatch: &AutoDispatchService, payload: &[u8]) {
     let trigger: TriggerEvent = match serde_json::from_slice(payload) {
         Ok(t) => t,

--- a/crates/choreo-app/Cargo.toml
+++ b/crates/choreo-app/Cargo.toml
@@ -24,3 +24,4 @@ serde = { workspace = true }
 [dev-dependencies]
 mockall = { workspace = true }
 tokio-test = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/crates/choreo-app/src/services/auto_dispatch.rs
+++ b/crates/choreo-app/src/services/auto_dispatch.rs
@@ -75,6 +75,15 @@ impl AutoDispatchService {
         })
     }
 
+    #[tracing::instrument(
+        name = "auto_dispatch",
+        skip_all,
+        fields(
+            event_id = %event.envelope().event_id(),
+            kind = event.kind(),
+            source = event.envelope().source(),
+        )
+    )]
     pub async fn dispatch(&self, event: &TriggerEvent) -> Result<AutoDispatchOutcome, DomainError> {
         let mut outcome = AutoDispatchOutcome::default();
 

--- a/crates/choreo-app/src/usecases/create_council.rs
+++ b/crates/choreo-app/src/usecases/create_council.rs
@@ -46,6 +46,15 @@ impl CreateCouncilUseCase {
         }
     }
 
+    #[tracing::instrument(
+        name = "create_council",
+        skip_all,
+        fields(
+            specialty = %input.specialty,
+            council_id = %input.council_id,
+            size = input.agents.len(),
+        )
+    )]
     pub async fn execute(&self, input: CreateCouncilInput) -> Result<Council, DomainError> {
         // Eagerly check that every agent is resolvable. This fails fast
         // before inserting a council that cannot deliberate.

--- a/crates/choreo-app/src/usecases/delete_council.rs
+++ b/crates/choreo-app/src/usecases/delete_council.rs
@@ -23,6 +23,11 @@ impl DeleteCouncilUseCase {
         Self { registry }
     }
 
+    #[tracing::instrument(
+        name = "delete_council",
+        skip_all,
+        fields(specialty = %specialty)
+    )]
     pub async fn execute(&self, specialty: &Specialty) -> Result<(), DomainError> {
         self.registry.delete(specialty).await?;
         info!(specialty = specialty.as_str(), "council removed");

--- a/crates/choreo-app/src/usecases/deliberate.rs
+++ b/crates/choreo-app/src/usecases/deliberate.rs
@@ -101,6 +101,15 @@ impl DeliberateUseCase {
     /// `observer`. The observer is call-scoped: nothing is retained
     /// by the use case and the observer sees exactly one sequence of
     /// phase transitions per invocation.
+    #[tracing::instrument(
+        name = "deliberate",
+        skip_all,
+        fields(
+            task_id = %task.id(),
+            specialty = %task.specialty(),
+            rounds = task.constraints().rounds().get(),
+        )
+    )]
     pub async fn execute_with_observer(
         &self,
         task: Task,

--- a/crates/choreo-app/src/usecases/get_deliberation.rs
+++ b/crates/choreo-app/src/usecases/get_deliberation.rs
@@ -23,6 +23,11 @@ impl GetDeliberationUseCase {
         Self { repository }
     }
 
+    #[tracing::instrument(
+        name = "get_deliberation",
+        skip_all,
+        fields(task_id = %task_id)
+    )]
     pub async fn execute(&self, task_id: &TaskId) -> Result<Deliberation, DomainError> {
         self.repository.get(task_id).await
     }

--- a/crates/choreo-app/src/usecases/list_councils.rs
+++ b/crates/choreo-app/src/usecases/list_councils.rs
@@ -22,6 +22,7 @@ impl ListCouncilsUseCase {
         Self { registry }
     }
 
+    #[tracing::instrument(name = "list_councils", skip_all)]
     pub async fn execute(&self) -> Result<Vec<Council>, DomainError> {
         self.registry.list().await
     }

--- a/crates/choreo-app/src/usecases/orchestrate.rs
+++ b/crates/choreo-app/src/usecases/orchestrate.rs
@@ -64,6 +64,14 @@ impl OrchestrateUseCase {
         }
     }
 
+    #[tracing::instrument(
+        name = "orchestrate",
+        skip_all,
+        fields(
+            task_id = %task.id(),
+            specialty = %task.specialty(),
+        )
+    )]
     pub async fn execute(
         &self,
         task: Task,

--- a/crates/choreo-app/src/usecases/register_agent.rs
+++ b/crates/choreo-app/src/usecases/register_agent.rs
@@ -35,6 +35,15 @@ impl RegisterAgentUseCase {
         Self { factory, registry }
     }
 
+    #[tracing::instrument(
+        name = "register_agent",
+        skip_all,
+        fields(
+            agent_id = %descriptor.id,
+            specialty = %descriptor.specialty,
+            kind = %descriptor.kind,
+        )
+    )]
     pub async fn execute(&self, descriptor: AgentDescriptor) -> Result<AgentId, DomainError> {
         let id = descriptor.id.clone();
         let kind = descriptor.kind.clone();

--- a/crates/choreo-app/src/usecases/unregister_agent.rs
+++ b/crates/choreo-app/src/usecases/unregister_agent.rs
@@ -30,6 +30,11 @@ impl UnregisterAgentUseCase {
         Self { registry }
     }
 
+    #[tracing::instrument(
+        name = "unregister_agent",
+        skip_all,
+        fields(agent_id = %id)
+    )]
     pub async fn execute(&self, id: &AgentId) -> Result<(), DomainError> {
         self.registry.unregister(id).await?;
         info!(agent_id = id.as_str(), "agent unregistered");

--- a/crates/choreo-app/tests/span_instrumentation.rs
+++ b/crates/choreo-app/tests/span_instrumentation.rs
@@ -1,0 +1,320 @@
+//! Regression test: the use-case layer emits the
+//! `#[tracing::instrument]` spans it advertises, with the field
+//! names operators wire dashboards against.
+//!
+//! Kept in its own integration-test binary so the capture subscriber
+//! owns the process-global dispatcher without fighting other unit
+//! tests over thread-local state.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use async_trait::async_trait;
+use choreo_app::usecases::DeliberateUseCase;
+use choreo_core::entities::{Council, Deliberation, TaskConstraints, ValidatorReport};
+use choreo_core::error::DomainError;
+use choreo_core::events::{
+    DeliberationCompletedEvent, PhaseChangedEvent, TaskCompletedEvent, TaskDispatchedEvent,
+    TaskFailedEvent,
+};
+use choreo_core::ports::{
+    AgentPort, AgentResolverPort, ClockPort, CouncilRegistryPort, Critique,
+    DeliberationRepositoryPort, DraftRequest, MessagingPort, Revision, ScoringPort, StatisticsPort,
+    ValidatorPort,
+};
+use choreo_core::value_objects::{
+    AgentId, Attributes, CouncilId, DurationMs, Rounds, Rubric, Score, Specialty, TaskDescription,
+    TaskId,
+};
+use time::macros::datetime;
+use time::OffsetDateTime;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+// --- Capture layer ---------------------------------------------------------
+
+#[derive(Default, Clone)]
+struct CapturedSpan {
+    name: String,
+    fields: BTreeMap<String, String>,
+}
+
+#[derive(Default, Clone)]
+struct CaptureLayer {
+    spans: Arc<Mutex<Vec<CapturedSpan>>>,
+}
+
+#[derive(Default)]
+struct FieldRecorder(BTreeMap<String, String>);
+impl tracing::field::Visit for FieldRecorder {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        self.0.insert(field.name().to_owned(), format!("{value:?}"));
+    }
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        self.0.insert(field.name().to_owned(), value.to_owned());
+    }
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        self.0.insert(field.name().to_owned(), value.to_string());
+    }
+}
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CaptureLayer {
+    fn on_new_span(
+        &self,
+        attrs: &tracing::span::Attributes<'_>,
+        _id: &tracing::Id,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let mut recorder = FieldRecorder::default();
+        attrs.record(&mut recorder);
+        self.spans.lock().unwrap().push(CapturedSpan {
+            name: attrs.metadata().name().to_owned(),
+            fields: recorder.0,
+        });
+    }
+}
+
+fn spans_handle() -> Arc<Mutex<Vec<CapturedSpan>>> {
+    static SPANS: OnceLock<Arc<Mutex<Vec<CapturedSpan>>>> = OnceLock::new();
+    SPANS
+        .get_or_init(|| {
+            let spans = Arc::new(Mutex::new(Vec::new()));
+            let layer = CaptureLayer {
+                spans: spans.clone(),
+            };
+            tracing_subscriber::registry().with(layer).init();
+            spans
+        })
+        .clone()
+}
+
+// --- Fixture ---------------------------------------------------------------
+
+struct FrozenClock;
+impl ClockPort for FrozenClock {
+    fn now(&self) -> OffsetDateTime {
+        datetime!(2026-04-15 12:00:00 UTC)
+    }
+}
+
+#[derive(Debug)]
+struct StubAgent {
+    id: AgentId,
+    specialty: Specialty,
+}
+#[async_trait]
+impl AgentPort for StubAgent {
+    fn id(&self) -> &AgentId {
+        &self.id
+    }
+    fn specialty(&self) -> &Specialty {
+        &self.specialty
+    }
+    async fn generate(&self, _: DraftRequest) -> Result<Revision, DomainError> {
+        Ok(Revision {
+            content: format!("content-{}", self.id.as_str()),
+        })
+    }
+    async fn critique(&self, _: &str, _: &TaskConstraints) -> Result<Critique, DomainError> {
+        Ok(Critique {
+            feedback: String::new(),
+        })
+    }
+    async fn revise(&self, own: &str, _: &Critique) -> Result<Revision, DomainError> {
+        Ok(Revision {
+            content: own.to_owned(),
+        })
+    }
+}
+
+struct StubResolver {
+    agents: BTreeMap<AgentId, Arc<dyn AgentPort>>,
+}
+#[async_trait]
+impl AgentResolverPort for StubResolver {
+    async fn resolve(&self, id: &AgentId) -> Result<Arc<dyn AgentPort>, DomainError> {
+        self.agents
+            .get(id)
+            .cloned()
+            .ok_or(DomainError::NotFound { what: "agent" })
+    }
+}
+
+struct FixedRegistry {
+    council: Council,
+}
+#[async_trait]
+impl CouncilRegistryPort for FixedRegistry {
+    async fn register(&self, _: Council) -> Result<(), DomainError> {
+        Ok(())
+    }
+    async fn replace(&self, _: Council) -> Result<(), DomainError> {
+        Ok(())
+    }
+    async fn get(&self, specialty: &Specialty) -> Result<Council, DomainError> {
+        if specialty == self.council.specialty() {
+            Ok(self.council.clone())
+        } else {
+            Err(DomainError::NotFound { what: "council" })
+        }
+    }
+    async fn list(&self) -> Result<Vec<Council>, DomainError> {
+        Ok(vec![self.council.clone()])
+    }
+    async fn delete(&self, _: &Specialty) -> Result<(), DomainError> {
+        Ok(())
+    }
+    async fn contains(&self, _: &Specialty) -> Result<bool, DomainError> {
+        Ok(true)
+    }
+}
+
+#[derive(Default)]
+struct NullRepo;
+#[async_trait]
+impl DeliberationRepositoryPort for NullRepo {
+    async fn save(&self, _: &Deliberation) -> Result<(), DomainError> {
+        Ok(())
+    }
+    async fn get(&self, _: &TaskId) -> Result<Deliberation, DomainError> {
+        Err(DomainError::NotFound {
+            what: "deliberation",
+        })
+    }
+    async fn exists(&self, _: &TaskId) -> Result<bool, DomainError> {
+        Ok(false)
+    }
+}
+
+#[derive(Default)]
+struct NullBus;
+#[async_trait]
+impl MessagingPort for NullBus {
+    async fn publish_task_dispatched(&self, _: &TaskDispatchedEvent) -> Result<(), DomainError> {
+        Ok(())
+    }
+    async fn publish_task_completed(&self, _: &TaskCompletedEvent) -> Result<(), DomainError> {
+        Ok(())
+    }
+    async fn publish_task_failed(&self, _: &TaskFailedEvent) -> Result<(), DomainError> {
+        Ok(())
+    }
+    async fn publish_deliberation_completed(
+        &self,
+        _: &DeliberationCompletedEvent,
+    ) -> Result<(), DomainError> {
+        Ok(())
+    }
+    async fn publish_phase_changed(&self, _: &PhaseChangedEvent) -> Result<(), DomainError> {
+        Ok(())
+    }
+}
+
+struct PassValidator;
+#[async_trait]
+impl ValidatorPort for PassValidator {
+    fn kind(&self) -> &'static str {
+        "pass"
+    }
+    async fn validate(&self, _: &str, _: &TaskConstraints) -> Result<ValidatorReport, DomainError> {
+        ValidatorReport::new("pass", true, "ok", Attributes::empty())
+    }
+}
+
+struct FullScoring;
+#[async_trait]
+impl ScoringPort for FullScoring {
+    async fn score(&self, _: &[ValidatorReport]) -> Result<Score, DomainError> {
+        Score::new(1.0)
+    }
+}
+
+#[derive(Default)]
+struct NullStats;
+#[async_trait]
+impl StatisticsPort for NullStats {
+    async fn record_deliberation(&self, _: &Specialty, _: DurationMs) -> Result<(), DomainError> {
+        Ok(())
+    }
+    async fn record_orchestration(&self, _: DurationMs) -> Result<(), DomainError> {
+        Ok(())
+    }
+    async fn snapshot(&self) -> Result<choreo_core::entities::Statistics, DomainError> {
+        Ok(choreo_core::entities::Statistics::default())
+    }
+}
+
+fn build_usecase() -> DeliberateUseCase {
+    let sp = Specialty::new("reviewer").unwrap();
+    let a1 = AgentId::new("a1").unwrap();
+    let agent: Arc<dyn AgentPort> = Arc::new(StubAgent {
+        id: a1.clone(),
+        specialty: sp.clone(),
+    });
+    let mut agents_map: BTreeMap<AgentId, Arc<dyn AgentPort>> = BTreeMap::new();
+    agents_map.insert(a1.clone(), agent);
+
+    let council = Council::new(
+        CouncilId::new("c").unwrap(),
+        sp.clone(),
+        vec![a1],
+        datetime!(2026-04-15 12:00:00 UTC),
+    )
+    .unwrap();
+
+    DeliberateUseCase::new(
+        Arc::new(FrozenClock),
+        Arc::new(FixedRegistry { council }),
+        Arc::new(StubResolver { agents: agents_map }),
+        vec![Arc::new(PassValidator)],
+        Arc::new(FullScoring),
+        Arc::new(NullRepo),
+        Arc::new(NullBus),
+        Arc::new(NullStats),
+        "test",
+    )
+}
+
+fn task() -> choreo_core::entities::Task {
+    choreo_core::entities::Task::new(
+        TaskId::new("t-span").unwrap(),
+        Specialty::new("reviewer").unwrap(),
+        TaskDescription::new("x").unwrap(),
+        TaskConstraints::new(Rubric::empty(), Rounds::new(0).unwrap(), None, None),
+        Attributes::empty(),
+    )
+}
+
+// --- The test -------------------------------------------------------------
+
+#[tokio::test]
+async fn deliberate_use_case_emits_instrumented_span_with_task_fields() {
+    // The operator-facing contract: a `deliberate` span MUST be
+    // emitted with the fields `task_id`, `specialty`, and `rounds`.
+    // Dashboards and tracing queries pin those names; a rename here
+    // would break production observability silently.
+    let spans = spans_handle();
+    spans.lock().unwrap().clear();
+
+    let usecase = build_usecase();
+    usecase.execute(task()).await.unwrap();
+
+    let captured = spans.lock().unwrap().clone();
+    let names: Vec<&str> = captured.iter().map(|s| s.name.as_str()).collect();
+    let deliberate = captured
+        .iter()
+        .find(|s| s.name == "deliberate")
+        .unwrap_or_else(|| panic!("deliberate span must be recorded; saw: {names:?}"));
+    assert_eq!(
+        deliberate.fields.get("task_id").map(String::as_str),
+        Some("t-span")
+    );
+    assert_eq!(
+        deliberate.fields.get("specialty").map(String::as_str),
+        Some("reviewer")
+    );
+    assert_eq!(
+        deliberate.fields.get("rounds").map(String::as_str),
+        Some("0")
+    );
+}


### PR DESCRIPTION
## Summary

Operators now get a named span at every meaningful boundary of the system, carrying the domain fields dashboards and tracing queries are wired against.

**Honest scope**: this slice does **not** wire an OTLP exporter or cross-process W3C tracecontext propagation. Spans are emitted in-process through the existing structured JSON subscriber; a follow-up slice **12b** will add OTLP + propagation across gRPC metadata and NATS headers.

## Spans added

| Layer | Span | Key fields |
|---|---|---|
| app/usecases | \`deliberate\` | task_id, specialty, rounds |
| app/usecases | \`orchestrate\` | task_id, specialty |
| app/usecases | \`create_council\` | specialty, council_id, size |
| app/usecases | \`delete_council\` | specialty |
| app/usecases | \`get_deliberation\` | task_id |
| app/usecases | \`list_councils\` | (span only) |
| app/usecases | \`register_agent\` | agent_id, specialty, kind |
| app/usecases | \`unregister_agent\` | agent_id |
| app/services | \`auto_dispatch\` | event_id, kind, source |
| adapters/grpc | \`rpc.*\` (one per RPC — 12 total) | (tonic provides per-request ctx) |
| adapters/nats | \`nats.trigger.inbound\` | (attached on payload handle) |

The inner use-case span nests under the RPC span so operators see the full request → domain chain in hierarchy.

## Honest gate

New integration test \`crates/choreo-app/tests/span_instrumentation.rs\`:

- Installs a process-global \`tracing\` subscriber via \`OnceLock\`
- Runs a deliberation end-to-end through a stub fixture
- Asserts the \`deliberate\` span is emitted with \`task_id\`, \`specialty\`, and \`rounds\` at the exact names operators will query

Lives in its own integration-test binary so the global subscriber does not race with unit tests' thread-local dispatchers.

## Pending (12b)

- \`opentelemetry-otlp\` exporter behind an \`otel\` feature flag
- \`CHOREO_OTLP_ENDPOINT\` config
- W3C tracecontext extract/inject on gRPC metadata (interceptor)
- W3C tracecontext round-trip on NATS headers (publish + subscribe)
- Testcontainer-backed OTLP collector smoke test

## Test plan
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\`
- [x] \`cargo test --workspace\`
- [x] Stability: 5 consecutive \`cargo test -p choreo-app\` runs all green
- [ ] CI green on all 12 checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)