### PR TITLE
chore(ci): make e2e workflow manual-dispatch only

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,10 +1,12 @@
 name: e2e
 
+# E2E runs on demand only. The per-PR fast-feedback gates
+# (clippy, test, contract, integration-nats, integration-postgres,
+# container-image, helm-chart) already cover the compile-and-unit
+# surface; full E2E (docker compose + kind) is expensive and kept
+# as a manual check before cutting a release. Trigger from the
+# Actions tab or via `gh workflow run e2e.yml`.
 on:
-  pull_request:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 concurrency:

--- a/README.md
+++ b/README.md
@@ -78,8 +78,13 @@ This project follows the same discipline as its siblings
 - Integration tests: **testcontainers-backed**, real services per run
   (no mocks at the integration boundary).
 - End-to-end tests: a runner container drives scenarios either via
-  `docker compose` (fast feedback) or as a Kubernetes `Job` against a
-  kind cluster with the Helm chart installed (contract-true path).
+  `docker compose` or as a Kubernetes `Job` against a kind cluster
+  with the Helm chart installed (contract-true path). Both paths
+  are **manual-dispatch only** — the per-PR gates
+  (`clippy`, `test`, `contract`, `integration-nats`,
+  `integration-postgres`, `container-image`, `helm-chart`) already
+  cover the compile-and-unit surface; E2E is reserved for pre-
+  release validation. Trigger via `gh workflow run e2e.yml`.
 
 ## Status
 


### PR DESCRIPTION
## Summary

E2E suites (docker compose + kind) were running on every PR and every push to main. They're expensive (~4–5 min each) and the per-PR gates already cover the compile-and-unit surface. Move E2E to \`workflow_dispatch\` so it's available on demand for pre-release validation but no longer blocks PR feedback.

## Effect

- PR checks on future PRs drop from 12 → 10 (e2e-compose + e2e-kubernetes no longer auto-run)
- \`gh workflow run e2e.yml\` still works whenever a human wants the full path
- README updated to describe the new cadence and name the manual trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)