### PR TITLE
feat(bench): phase 15 — criterion harness + experiment 001

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -144,6 +144,29 @@ jobs:
       - name: Lint Helm chart
         run: bash scripts/ci/helm-lint.sh
 
+  benches-compile:
+    # Criterion benches don't run on every PR (too noisy, wrong
+    # signal/noise ratio) but they must keep compiling — a stale
+    # bench silently breaks every experiment's reproducer.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    needs: [contract]
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
+        with:
+          toolchain: 1.90.0
+      - name: Install protoc
+        run: bash scripts/ci/install-protoc.sh
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+      - name: Compile benches
+        run: bash scripts/ci/bench-compile.sh
+
   sonarcloud:
     runs-on: ubuntu-24.04
     timeout-minutes: 25

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,6 +328,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +425,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "choreo-core",
+ "criterion",
  "mockall",
  "serde",
  "thiserror 1.0.69",
@@ -429,6 +442,7 @@ name = "choreo-core"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "criterion",
  "mockall",
  "serde",
  "serde_json",
@@ -489,6 +503,58 @@ dependencies = [
  "serde",
  "windows-link",
 ]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "concurrent-queue"
@@ -556,6 +622,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "futures",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,6 +692,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1071,6 +1200,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1481,6 +1621,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1771,6 +1931,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2015,6 +2181,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2119,7 +2313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -2139,7 +2333,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -2287,6 +2481,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2556,6 +2770,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -3307,6 +3530,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3794,6 +4027,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3984,6 +4227,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,9 @@ figment = { version = "0.10", features = ["env", "toml"] }
 mockall = "0.13"
 tokio-test = "0.4"
 
+# benchmarking
+criterion = { version = "0.5", features = ["async_tokio"] }
+
 # internal
 choreo-core = { path = "crates/choreo-core" }
 choreo-app = { path = "crates/choreo-app" }

--- a/crates/choreo-app/Cargo.toml
+++ b/crates/choreo-app/Cargo.toml
@@ -25,3 +25,8 @@ serde = { workspace = true }
 mockall = { workspace = true }
 tokio-test = { workspace = true }
 tracing-subscriber = { workspace = true }
+criterion = { workspace = true }
+
+[[bench]]
+name = "deliberate"
+harness = false

--- a/crates/choreo-app/benches/deliberate.rs
+++ b/crates/choreo-app/benches/deliberate.rs
@@ -1,0 +1,275 @@
+//! End-to-end bench for [`DeliberateUseCase`].
+//!
+//! Exercises the full deliberation loop (seed → peer-review
+//! rounds → validate → score → rank → save → publish → record
+//! statistics) against a fixture that replaces every port with an
+//! in-process stub. The measurement isolates the use case's own
+//! cost — no DB, no NATS, no gRPC — so regressions stick out from
+//! adapter overhead.
+//!
+//! Two canonical scenarios:
+//! - `deliberate/3-agents-0-rounds`: baseline happy path with no
+//!   revision loop. Closest to a minimal invocation.
+//! - `deliberate/3-agents-2-rounds`: the aggregate's revision
+//!   loop runs twice — stresses the O(rounds · agents) peer review
+//!   pairing.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use choreo_app::usecases::DeliberateUseCase;
+use choreo_core::entities::{Council, Deliberation, TaskConstraints, ValidatorReport};
+use choreo_core::error::DomainError;
+use choreo_core::events::{
+    DeliberationCompletedEvent, PhaseChangedEvent, TaskCompletedEvent, TaskDispatchedEvent,
+    TaskFailedEvent,
+};
+use choreo_core::ports::{
+    AgentPort, AgentResolverPort, ClockPort, CouncilRegistryPort, Critique,
+    DeliberationRepositoryPort, DraftRequest, MessagingPort, Revision, ScoringPort, StatisticsPort,
+    ValidatorPort,
+};
+use choreo_core::value_objects::{
+    AgentId, Attributes, CouncilId, DurationMs, Rounds, Rubric, Score, Specialty, TaskDescription,
+    TaskId,
+};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use time::macros::datetime;
+use time::OffsetDateTime;
+
+// ---- Minimal stub ports -----------------------------------------------------
+
+struct FrozenClock;
+impl ClockPort for FrozenClock {
+    fn now(&self) -> OffsetDateTime {
+        datetime!(2026-04-15 12:00:00 UTC)
+    }
+}
+
+#[derive(Debug)]
+struct StubAgent {
+    id: AgentId,
+    specialty: Specialty,
+}
+#[async_trait]
+impl AgentPort for StubAgent {
+    fn id(&self) -> &AgentId {
+        &self.id
+    }
+    fn specialty(&self) -> &Specialty {
+        &self.specialty
+    }
+    async fn generate(&self, _: DraftRequest) -> Result<Revision, DomainError> {
+        Ok(Revision {
+            content: "bench-content".to_owned(),
+        })
+    }
+    async fn critique(&self, _: &str, _: &TaskConstraints) -> Result<Critique, DomainError> {
+        Ok(Critique {
+            feedback: String::new(),
+        })
+    }
+    async fn revise(&self, own: &str, _: &Critique) -> Result<Revision, DomainError> {
+        Ok(Revision {
+            content: own.to_owned(),
+        })
+    }
+}
+
+struct StubResolver {
+    agents: BTreeMap<AgentId, Arc<dyn AgentPort>>,
+}
+#[async_trait]
+impl AgentResolverPort for StubResolver {
+    async fn resolve(&self, id: &AgentId) -> Result<Arc<dyn AgentPort>, DomainError> {
+        self.agents
+            .get(id)
+            .cloned()
+            .ok_or(DomainError::NotFound { what: "agent" })
+    }
+}
+
+struct FixedRegistry {
+    council: Council,
+}
+#[async_trait]
+impl CouncilRegistryPort for FixedRegistry {
+    async fn register(&self, _: Council) -> Result<(), DomainError> {
+        Ok(())
+    }
+    async fn replace(&self, _: Council) -> Result<(), DomainError> {
+        Ok(())
+    }
+    async fn get(&self, specialty: &Specialty) -> Result<Council, DomainError> {
+        if specialty == self.council.specialty() {
+            Ok(self.council.clone())
+        } else {
+            Err(DomainError::NotFound { what: "council" })
+        }
+    }
+    async fn list(&self) -> Result<Vec<Council>, DomainError> {
+        Ok(vec![self.council.clone()])
+    }
+    async fn delete(&self, _: &Specialty) -> Result<(), DomainError> {
+        Ok(())
+    }
+    async fn contains(&self, _: &Specialty) -> Result<bool, DomainError> {
+        Ok(true)
+    }
+}
+
+#[derive(Default)]
+struct NullRepo;
+#[async_trait]
+impl DeliberationRepositoryPort for NullRepo {
+    async fn save(&self, _: &Deliberation) -> Result<(), DomainError> {
+        Ok(())
+    }
+    async fn get(&self, _: &TaskId) -> Result<Deliberation, DomainError> {
+        Err(DomainError::NotFound {
+            what: "deliberation",
+        })
+    }
+    async fn exists(&self, _: &TaskId) -> Result<bool, DomainError> {
+        Ok(false)
+    }
+}
+
+#[derive(Default)]
+struct NullBus;
+#[async_trait]
+impl MessagingPort for NullBus {
+    async fn publish_task_dispatched(&self, _: &TaskDispatchedEvent) -> Result<(), DomainError> {
+        Ok(())
+    }
+    async fn publish_task_completed(&self, _: &TaskCompletedEvent) -> Result<(), DomainError> {
+        Ok(())
+    }
+    async fn publish_task_failed(&self, _: &TaskFailedEvent) -> Result<(), DomainError> {
+        Ok(())
+    }
+    async fn publish_deliberation_completed(
+        &self,
+        _: &DeliberationCompletedEvent,
+    ) -> Result<(), DomainError> {
+        Ok(())
+    }
+    async fn publish_phase_changed(&self, _: &PhaseChangedEvent) -> Result<(), DomainError> {
+        Ok(())
+    }
+}
+
+struct PassValidator;
+#[async_trait]
+impl ValidatorPort for PassValidator {
+    fn kind(&self) -> &'static str {
+        "pass"
+    }
+    async fn validate(&self, _: &str, _: &TaskConstraints) -> Result<ValidatorReport, DomainError> {
+        ValidatorReport::new("pass", true, "ok", Attributes::empty())
+    }
+}
+
+struct FullScoring;
+#[async_trait]
+impl ScoringPort for FullScoring {
+    async fn score(&self, _: &[ValidatorReport]) -> Result<Score, DomainError> {
+        Score::new(1.0)
+    }
+}
+
+#[derive(Default)]
+struct NullStats;
+#[async_trait]
+impl StatisticsPort for NullStats {
+    async fn record_deliberation(&self, _: &Specialty, _: DurationMs) -> Result<(), DomainError> {
+        Ok(())
+    }
+    async fn record_orchestration(&self, _: DurationMs) -> Result<(), DomainError> {
+        Ok(())
+    }
+    async fn snapshot(&self) -> Result<choreo_core::entities::Statistics, DomainError> {
+        Ok(choreo_core::entities::Statistics::default())
+    }
+}
+
+// ---- Fixture ----------------------------------------------------------------
+
+fn build_usecase(n_agents: usize) -> DeliberateUseCase {
+    let sp = Specialty::new("bench").unwrap();
+
+    let mut agents_map: BTreeMap<AgentId, Arc<dyn AgentPort>> = BTreeMap::new();
+    let mut agent_ids = Vec::new();
+    for i in 0..n_agents {
+        let id = AgentId::new(format!("a{i}")).unwrap();
+        agents_map.insert(
+            id.clone(),
+            Arc::new(StubAgent {
+                id: id.clone(),
+                specialty: sp.clone(),
+            }),
+        );
+        agent_ids.push(id);
+    }
+
+    let council = Council::new(
+        CouncilId::new("c").unwrap(),
+        sp.clone(),
+        agent_ids,
+        datetime!(2026-04-15 12:00:00 UTC),
+    )
+    .unwrap();
+
+    DeliberateUseCase::new(
+        Arc::new(FrozenClock),
+        Arc::new(FixedRegistry { council }),
+        Arc::new(StubResolver { agents: agents_map }),
+        vec![Arc::new(PassValidator)],
+        Arc::new(FullScoring),
+        Arc::new(NullRepo),
+        Arc::new(NullBus),
+        Arc::new(NullStats),
+        "bench",
+    )
+}
+
+fn task(rounds: u32) -> choreo_core::entities::Task {
+    choreo_core::entities::Task::new(
+        TaskId::new("bench-task").unwrap(),
+        Specialty::new("bench").unwrap(),
+        TaskDescription::new("bench").unwrap(),
+        TaskConstraints::new(Rubric::empty(), Rounds::new(rounds).unwrap(), None, None),
+        Attributes::empty(),
+    )
+}
+
+// ---- Benchmarks -------------------------------------------------------------
+
+fn deliberate(c: &mut Criterion) {
+    // Tokio runtime shared across iterations — keeps the per-iter
+    // cost focused on the use case itself rather than runtime spin-
+    // up. `basic_scheduler` (current-thread) mirrors how the real
+    // service runs tasks and avoids work-stealing overhead.
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let mut group = c.benchmark_group("deliberate");
+    for (n_agents, rounds) in [(3usize, 0u32), (3, 2)] {
+        let usecase = build_usecase(n_agents);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("{n_agents}-agents-{rounds}-rounds")),
+            &rounds,
+            |b, &rounds| {
+                b.to_async(&runtime)
+                    .iter(|| async { usecase.execute(task(rounds)).await.unwrap() });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, deliberate);
+criterion_main!(benches);

--- a/crates/choreo-core/Cargo.toml
+++ b/crates/choreo-core/Cargo.toml
@@ -24,3 +24,8 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 mockall = { workspace = true }
 serde_json = { workspace = true }
+criterion = { workspace = true }
+
+[[bench]]
+name = "trace_context"
+harness = false

--- a/crates/choreo-core/benches/trace_context.rs
+++ b/crates/choreo-core/benches/trace_context.rs
@@ -1,0 +1,41 @@
+//! Micro-benchmarks for [`TraceContext`].
+//!
+//! Ran on every publish (inject) and every receive (extract) through
+//! NATS headers. Kept here so any regression in parse/format cost
+//! surfaces against a baseline rather than silently accumulating.
+
+use choreo_core::value_objects::TraceContext;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+const W3C_EXAMPLE: &str = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+
+fn parse(c: &mut Criterion) {
+    c.bench_function("TraceContext::parse(valid)", |b| {
+        b.iter(|| TraceContext::parse(black_box(W3C_EXAMPLE)).unwrap());
+    });
+}
+
+fn format(c: &mut Criterion) {
+    let ctx = TraceContext::parse(W3C_EXAMPLE).unwrap();
+    c.bench_function("TraceContext::to_header", |b| {
+        b.iter(|| black_box(ctx.to_header()));
+    });
+}
+
+fn generate(c: &mut Criterion) {
+    c.bench_function("TraceContext::generate", |b| {
+        b.iter(TraceContext::generate);
+    });
+}
+
+fn roundtrip(c: &mut Criterion) {
+    c.bench_function("TraceContext::parse + to_header", |b| {
+        b.iter(|| {
+            let ctx = TraceContext::parse(black_box(W3C_EXAMPLE)).unwrap();
+            black_box(ctx.to_header())
+        });
+    });
+}
+
+criterion_group!(benches, parse, format, generate, roundtrip);
+criterion_main!(benches);

--- a/docs/experiments/001-baseline-deliberation-latency/README.md
+++ b/docs/experiments/001-baseline-deliberation-latency/README.md
@@ -1,0 +1,120 @@
+# 001 — Baseline deliberation latency
+
+- **Author:** @underpass-ai
+- **Date:** 2026-04-18
+- **Status:** complete
+- **Related code:**
+  - `crates/choreo-app/benches/deliberate.rs`
+  - `crates/choreo-core/benches/trace_context.rs`
+
+## 1. Hypothesis
+
+A single deliberation through `DeliberateUseCase` — with stub agents
+and every port replaced by an in-process no-op — completes in
+**under 10 µs** on commodity hardware for the canonical shape
+(3 agents, 0 or 2 rounds). The hot path the choreographer owns
+(seed → peer-review → validate → score → rank → save → publish →
+record statistics) should not exceed that budget; anything slower
+means the domain loop has acquired accidental overhead rather than
+work.
+
+Supporting micro-hypothesis: the W3C `TraceContext` wire-shape
+helpers (`parse`, `to_header`, `generate`) stay in the sub-µs
+regime; they are on every NATS publish and subscribe path, so a
+regression there becomes a tax on the messaging fast path.
+
+## 2. Experiment design
+
+- **Inputs**: two parameterised shapes of `DeliberateUseCase::execute`:
+  - `3-agents-0-rounds` — minimal loop, no revision.
+  - `3-agents-2-rounds` — exercises the revision loop twice.
+  Plus four `TraceContext` micro-benchmarks.
+- **Fixed variables**: every adapter stubbed in-process, stub agent
+  methods return constant content, `PassValidator` + `FullScoring`
+  (all proposals pass, everyone scores 1.0), no I/O.
+- **Measurement**: criterion 0.5 defaults (3-second measurement
+  window, 100 samples, auto-calibrated iteration count, variance
+  reported as a Tukey-style 95 % confidence interval on the median).
+- **Refutation**: either benchmark's median exceeds 10 µs.
+- **Environment**:
+  - CPU: AMD Ryzen Threadripper PRO 5955WX (16 cores)
+  - Kernel: Linux 6.19.8-arch1-1
+  - Toolchain: rustc 1.90.0 (1159e78c4 2025-09-14)
+  - Profile: `bench` (release-equivalent, LTO thin, codegen-units 1)
+
+## 3. Method
+
+```bash
+bash docs/experiments/001-baseline-deliberation-latency/run.sh
+```
+
+The script runs both benches with criterion defaults and dumps the
+raw output into `results/`. No warmup-time or sample-size overrides
+are used — defaults are the source of truth.
+
+## 4. Results
+
+Medians with 95 % Tukey intervals from criterion's native reporter.
+
+### `DeliberateUseCase::execute`
+
+| Scenario              | Low       | Median   | High      |
+|-----------------------|-----------|----------|-----------|
+| 3-agents-0-rounds     | 3.100 µs  | 3.121 µs | 3.147 µs  |
+| 3-agents-2-rounds     | 3.438 µs  | 3.577 µs | 3.722 µs  |
+
+Raw criterion output: [`results/deliberate.txt`](results/deliberate.txt).
+
+### `TraceContext` helpers
+
+| Operation                        | Low       | Median    | High      |
+|----------------------------------|-----------|-----------|-----------|
+| `parse(valid)`                   | 84.15 ns  | 85.54 ns  | 87.24 ns  |
+| `to_header`                      | 108.49 ns | 109.94 ns | 111.66 ns |
+| `generate`                       | 424.33 ns | 430.15 ns | 436.69 ns |
+| `parse + to_header` (round-trip) | 219.45 ns | 220.95 ns | 222.61 ns |
+
+Raw criterion output: [`results/trace_context.txt`](results/trace_context.txt).
+
+## 5. Conclusion
+
+**Hypothesis supported.** The domain loop lands well under budget:
+
+- `3-agents-0-rounds`: **~3.1 µs**, ~3× below the 10 µs bound.
+- `3-agents-2-rounds`: **~3.6 µs**, still ~3× below; the revision
+  loop adds ~450 ns (≈14 %) for two full agent rounds, which is
+  consistent with doing O(rounds × agents) small stub-agent calls.
+- `TraceContext::generate` at ~430 ns is the only helper above the
+  100 ns band, dominated by two `uuid::v4` generations + hex
+  encoding. Bearable on NATS publish (one per message), and the
+  parse+format round-trip stays at 220 ns.
+
+The supporting micro-hypothesis is also supported: every
+`TraceContext` helper stays sub-µs.
+
+## 6. Threats to validity
+
+- **Stub agents hide the dominant real cost.** In production an
+  agent call is an LLM HTTP round-trip (10–10 000 ms). This bench
+  measures the choreographer's *own* cost only — it is the
+  right question for "how much do we add?" but not the answer to
+  "how long does a deliberation take?". Real-agent latencies will
+  need their own experiment.
+- **Small N of shapes.** We only bench two points (0 and 2 rounds,
+  3 agents). The O(rounds × agents) peer-review loop should scale
+  linearly by construction but we have not measured that.
+- **Single host, single build.** No cross-machine comparison, no
+  cross-compiler (stable only). The absolute numbers are not
+  transferable; the *budget* is.
+- **No memory metric.** Criterion reports wall time only. A leak
+  or allocator regression would not surface here.
+
+## 7. Follow-ups
+
+- **002** — scale experiment: sweep `rounds ∈ {0, 2, 4, 8}` and
+  `agents ∈ {1, 3, 5, 10}` to confirm the linear model.
+- **003** — end-to-end through NATS + gRPC: puts the choreographer's
+  ~3 µs in context next to the adapter + transport layer.
+- **004** — real-agent mix: parameterise with a mock HTTP agent
+  stubbing realistic LLM latencies so the whole-system budget is
+  documented honestly.

--- a/docs/experiments/001-baseline-deliberation-latency/results/deliberate.txt
+++ b/docs/experiments/001-baseline-deliberation-latency/results/deliberate.txt
@@ -1,0 +1,26 @@
+    Finished `bench` profile [optimized] target(s) in 0.09s
+     Running benches/deliberate.rs (target/release/deps/deliberate-4abbffe59e1e448b)
+Gnuplot not found, using plotters backend
+Benchmarking deliberate/3-agents-0-rounds
+Benchmarking deliberate/3-agents-0-rounds: Warming up for 3.0000 s
+Benchmarking deliberate/3-agents-0-rounds: Collecting 100 samples in estimated 5.0079 s (1.6M iterations)
+Benchmarking deliberate/3-agents-0-rounds: Analyzing
+deliberate/3-agents-0-rounds
+                        time:   [3.1001 µs 3.1205 µs 3.1470 µs]
+                        change: [-0.4789% +0.7272% +1.8388%] (p = 0.31 > 0.05)
+                        No change in performance detected.
+Found 12 outliers among 100 measurements (12.00%)
+  4 (4.00%) high mild
+  8 (8.00%) high severe
+Benchmarking deliberate/3-agents-2-rounds
+Benchmarking deliberate/3-agents-2-rounds: Warming up for 3.0000 s
+Benchmarking deliberate/3-agents-2-rounds: Collecting 100 samples in estimated 5.0027 s (1.5M iterations)
+Benchmarking deliberate/3-agents-2-rounds: Analyzing
+deliberate/3-agents-2-rounds
+                        time:   [3.4382 µs 3.5772 µs 3.7221 µs]
+                        change: [+1.2831% +3.6424% +6.3117%] (p = 0.02 < 0.05)
+                        Performance has regressed.
+Found 14 outliers among 100 measurements (14.00%)
+  9 (9.00%) high mild
+  5 (5.00%) high severe
+

--- a/docs/experiments/001-baseline-deliberation-latency/results/trace_context.txt
+++ b/docs/experiments/001-baseline-deliberation-latency/results/trace_context.txt
@@ -1,0 +1,56 @@
+   Compiling regex-automata v0.4.14
+   Compiling tracing-core v0.1.36
+   Compiling tokio v1.52.0
+   Compiling tracing v0.1.44
+   Compiling choreo-core v0.1.0 (/home/tirso/ai/developents/underpass-orchestrator/crates/choreo-core)
+   Compiling regex v1.12.3
+   Compiling criterion v0.5.1
+    Finished `bench` profile [optimized] target(s) in 18.90s
+     Running benches/trace_context.rs (target/release/deps/trace_context-5fbf2a3e609a5b63)
+Gnuplot not found, using plotters backend
+Benchmarking TraceContext::parse(valid)
+Benchmarking TraceContext::parse(valid): Warming up for 3.0000 s
+Benchmarking TraceContext::parse(valid): Collecting 100 samples in estimated 5.0004 s (59M iterations)
+Benchmarking TraceContext::parse(valid): Analyzing
+TraceContext::parse(valid)
+                        time:   [84.147 ns 85.535 ns 87.238 ns]
+                        change: [-7.5686% -5.4626% -3.5890%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 11 outliers among 100 measurements (11.00%)
+  3 (3.00%) high mild
+  8 (8.00%) high severe
+
+Benchmarking TraceContext::to_header
+Benchmarking TraceContext::to_header: Warming up for 3.0000 s
+Benchmarking TraceContext::to_header: Collecting 100 samples in estimated 5.0005 s (46M iterations)
+Benchmarking TraceContext::to_header: Analyzing
+TraceContext::to_header time:   [108.49 ns 109.94 ns 111.66 ns]
+                        change: [-2.7452% -0.3606% +2.1480%] (p = 0.76 > 0.05)
+                        No change in performance detected.
+Found 10 outliers among 100 measurements (10.00%)
+  9 (9.00%) high mild
+  1 (1.00%) high severe
+
+Benchmarking TraceContext::generate
+Benchmarking TraceContext::generate: Warming up for 3.0000 s
+Benchmarking TraceContext::generate: Collecting 100 samples in estimated 5.0013 s (12M iterations)
+Benchmarking TraceContext::generate: Analyzing
+TraceContext::generate  time:   [424.33 ns 430.15 ns 436.69 ns]
+                        change: [-0.6045% +2.0926% +5.1230%] (p = 0.21 > 0.05)
+                        No change in performance detected.
+Found 4 outliers among 100 measurements (4.00%)
+  2 (2.00%) high mild
+  2 (2.00%) high severe
+
+Benchmarking TraceContext::parse + to_header
+Benchmarking TraceContext::parse + to_header: Warming up for 3.0000 s
+Benchmarking TraceContext::parse + to_header: Collecting 100 samples in estimated 5.0001 s (23M iterations)
+Benchmarking TraceContext::parse + to_header: Analyzing
+TraceContext::parse + to_header
+                        time:   [219.45 ns 220.95 ns 222.61 ns]
+                        change: [+2.9683% +5.1092% +7.3279%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 10 outliers among 100 measurements (10.00%)
+  4 (4.00%) high mild
+  6 (6.00%) high severe
+

--- a/docs/experiments/001-baseline-deliberation-latency/run.sh
+++ b/docs/experiments/001-baseline-deliberation-latency/run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reproduces the numbers in this directory's README.md. No overrides
+# on criterion — defaults are the source of truth so the file is
+# comparable across machines.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+OUT_DIR="${ROOT_DIR}/docs/experiments/001-baseline-deliberation-latency/results"
+
+mkdir -p "${OUT_DIR}"
+cd "${ROOT_DIR}"
+
+cargo bench -p choreo-core --bench trace_context | tee "${OUT_DIR}/trace_context.txt"
+cargo bench -p choreo-app  --bench deliberate   | tee "${OUT_DIR}/deliberate.txt"

--- a/docs/experiments/README.md
+++ b/docs/experiments/README.md
@@ -67,4 +67,6 @@ Concrete next experiments (by number or slug).
 
 ## Index
 
-_Empty. The Choreographer has not yet run any experiments._
+| # | Slug | Status | Summary |
+|---|---|---|---|
+| 001 | [baseline-deliberation-latency](001-baseline-deliberation-latency/README.md) | complete | `DeliberateUseCase::execute` runs in ~3.1–3.6 µs (3 agents, 0–2 rounds) on commodity hardware with stubbed ports — domain loop stays well under a 10 µs self-cost budget. |

--- a/scripts/ci/bench-compile.sh
+++ b/scripts/ci/bench-compile.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Criterion benches must keep compiling. Actually *running* them in
+# CI is noisy and would not meet the per-PR time budget, but a
+# refactor that breaks the bench fixture would silently stop the
+# experiment reproducer from working. Compile-only gate on every PR;
+# full runs happen locally via each experiment's run.sh.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT_DIR}"
+
+cargo bench --workspace --no-run --locked


### PR DESCRIPTION
## Summary

First reproducible performance baseline for the choreographer. Lands the scientific-method infrastructure the README has been asking for: benches in the crates they measure, a new CI gate that keeps them compiling, and an append-only lab notebook under \`docs/experiments/\`.

## Benches added

- **\`choreo-core/benches/trace_context.rs\`** — parse / to_header / generate / round-trip. Every helper runs on every NATS publish & subscribe; micro-level accuracy matters.
- **\`choreo-app/benches/deliberate.rs\`** — end-to-end \`DeliberateUseCase\` with every port stubbed. Two shapes: \`3-agents-0-rounds\` (minimal) and \`3-agents-2-rounds\` (revision loop).

## Experiment 001 — baseline-deliberation-latency

Hypothesis: the domain loop stays under **10 µs self-cost** on commodity hardware.

Measured (Ryzen Threadripper PRO 5955WX, Linux 6.19, rustc 1.90):

| Scenario | Median | 95 % CI |
|---|---|---|
| \`deliberate/3-agents-0-rounds\` | **3.12 µs** | 3.10–3.15 |
| \`deliberate/3-agents-2-rounds\` | **3.58 µs** | 3.44–3.72 |
| \`TraceContext::parse\` | 85.5 ns | — |
| \`TraceContext::to_header\` | 109.9 ns | — |
| \`TraceContext::generate\` | 430 ns | — |

Hypothesis supported. Explicit threats to validity documented (stub agents hide LLM-dominated real cost; single-host; no memory metric).

Reproducer: \`bash docs/experiments/001-baseline-deliberation-latency/run.sh\` — criterion defaults, no overrides, so numbers are comparable across machines.

## CI

- **New**: \`scripts/ci/bench-compile.sh\` → \`cargo bench --workspace --no-run --locked\`
- **New job**: \`benches-compile\` in \`quality-gate.yml\`, compile-only gate (running full benches would be too noisy for per-PR signal)

## Follow-ups queued

- 002 — scale sweep: \`rounds ∈ {0,2,4,8}\`, \`agents ∈ {1,3,5,10}\`
- 003 — end-to-end through NATS + gRPC
- 004 — realistic agent latency mock

## Test plan
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace\`
- [x] \`bash scripts/ci/bench-compile.sh\`
- [x] \`bash docs/experiments/001-baseline-deliberation-latency/run.sh\`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)