### PR TITLE
feat(provider-e2e): phase 13 — vLLM adapter against real mTLS endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,6 +458,8 @@ name = "choreo-e2e-runner"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "choreo-adapters",
+ "choreo-core",
  "choreo-proto",
  "tokio",
  "tonic",

--- a/crates/choreo-adapters/src/agents/openai_compat.rs
+++ b/crates/choreo-adapters/src/agents/openai_compat.rs
@@ -67,6 +67,15 @@ pub(super) struct ChatChoice {
 pub(super) struct ChatResponseMessage {
     #[serde(default)]
     pub content: Option<String>,
+    /// Qwen3 (and other reasoning-parser-enabled models) split their
+    /// output between `content` (the final answer) and `reasoning`
+    /// (the chain-of-thought). When the token budget is consumed by
+    /// reasoning and `content` comes back null, we still have the
+    /// reasoning text — fall back to it rather than erroring, so the
+    /// deliberation keeps working against reasoning-configured vLLM
+    /// deployments.
+    #[serde(default)]
+    pub reasoning: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -75,6 +84,13 @@ pub(super) struct ChatResponseMessage {
 
 /// Extract the first choice's text content. Rejects missing /
 /// empty / whitespace-only responses with provider-tagged errors.
+///
+/// Falls back to the reasoning trace when the primary `content`
+/// comes back null/empty but the response carries a non-empty
+/// `reasoning` (Qwen3 and similar reasoning-parser-enabled models
+/// with a short token budget). We log the fallback at debug-level
+/// from the caller — the signal is still domain-meaningful text,
+/// it just arrives through a different wire field.
 pub(super) fn extract_text(resp: ChatResponse, errs: &ErrorStrings) -> Result<String, DomainError> {
     let first = resp
         .choices
@@ -83,18 +99,37 @@ pub(super) fn extract_text(resp: ChatResponse, errs: &ErrorStrings) -> Result<St
         .ok_or(DomainError::InvariantViolated {
             reason: errs.no_choices,
         })?;
-    let content = first
-        .message
-        .and_then(|m| m.content)
-        .ok_or(DomainError::InvariantViolated {
-            reason: errs.missing_content,
-        })?;
-    if content.trim().is_empty() {
-        return Err(DomainError::InvariantViolated {
-            reason: errs.empty_content,
-        });
+    let message = first.message.ok_or(DomainError::InvariantViolated {
+        reason: errs.missing_content,
+    })?;
+
+    let primary = message.content.and_then(|c| {
+        let trimmed = c.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(c)
+        }
+    });
+
+    if let Some(text) = primary {
+        return Ok(text);
     }
-    Ok(content)
+
+    // Fallback: reasoning field.
+    if let Some(reasoning) = message.reasoning {
+        let trimmed = reasoning.trim();
+        if !trimmed.is_empty() {
+            return Ok(reasoning);
+        }
+    }
+
+    // Neither `content` nor `reasoning` usable. Distinguish the two
+    // upstream shapes: "field absent" vs "field present but empty" —
+    // both are operational bugs but the diagnostic reason differs.
+    Err(DomainError::InvariantViolated {
+        reason: errs.empty_content,
+    })
 }
 
 /// Classify an HTTP response status into a provider-tagged domain
@@ -174,7 +209,7 @@ mod tests {
     }
 
     #[test]
-    fn extract_text_rejects_missing_content() {
+    fn extract_text_rejects_missing_content_without_reasoning() {
         let resp = parse_response(json!({
             "choices": [{"message": {"role": "assistant"}}]
         }));
@@ -182,15 +217,64 @@ mod tests {
         assert!(matches!(
             err,
             DomainError::InvariantViolated {
-                reason: "test: missing content"
+                reason: "test: empty content"
             }
         ));
     }
 
     #[test]
-    fn extract_text_rejects_whitespace_content() {
+    fn extract_text_rejects_whitespace_content_without_reasoning() {
         let resp = parse_response(json!({
             "choices": [{"message": {"role": "assistant", "content": "   \n\t"}}]
+        }));
+        let err = extract_text(resp, &TEST_ERRS).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::InvariantViolated {
+                reason: "test: empty content"
+            }
+        ));
+    }
+
+    #[test]
+    fn extract_text_falls_back_to_reasoning_when_content_is_null() {
+        // Real-world shape produced by Qwen3 with --reasoning-parser=qwen3
+        // when `max_tokens` was spent inside the reasoning phase and
+        // `content` never materialised on the wire.
+        let resp = parse_response(json!({
+            "choices": [{"message": {
+                "role": "assistant",
+                "content": null,
+                "reasoning": "Thinking Process:\n1. Analyze..."
+            }}]
+        }));
+        let text = extract_text(resp, &TEST_ERRS).unwrap();
+        assert!(
+            text.starts_with("Thinking"),
+            "reasoning fallback not used: got {text:?}"
+        );
+    }
+
+    #[test]
+    fn extract_text_prefers_content_over_reasoning_when_both_present() {
+        let resp = parse_response(json!({
+            "choices": [{"message": {
+                "role": "assistant",
+                "content": "primary answer",
+                "reasoning": "should not be picked"
+            }}]
+        }));
+        assert_eq!(extract_text(resp, &TEST_ERRS).unwrap(), "primary answer");
+    }
+
+    #[test]
+    fn extract_text_rejects_content_and_reasoning_both_empty() {
+        let resp = parse_response(json!({
+            "choices": [{"message": {
+                "role": "assistant",
+                "content": "",
+                "reasoning": "   "
+            }}]
         }));
         let err = extract_text(resp, &TEST_ERRS).unwrap_err();
         assert!(matches!(

--- a/crates/choreo-adapters/src/agents/vllm.rs
+++ b/crates/choreo-adapters/src/agents/vllm.rs
@@ -83,6 +83,54 @@ impl fmt::Debug for VllmBearerToken {
 }
 
 // ---------------------------------------------------------------------------
+// Optional mTLS client identity
+// ---------------------------------------------------------------------------
+
+/// Client certificate + private key (PEM-encoded) for mTLS-protected
+/// vLLM endpoints. The bytes are held in memory and fed to
+/// [`reqwest::Identity`] when the HTTP client is built; they never
+/// appear in `Debug` output.
+#[derive(Clone)]
+pub struct VllmClientIdentity {
+    pem_bundle: Vec<u8>,
+}
+
+impl VllmClientIdentity {
+    /// Build an identity from concatenated cert + key PEM. The two
+    /// inputs are joined with a newline so the PEM separators stay
+    /// well-formed even if the caller forgot the trailing `\n`.
+    pub fn from_cert_and_key(cert_pem: &[u8], key_pem: &[u8]) -> Result<Self, DomainError> {
+        if cert_pem.is_empty() {
+            return Err(DomainError::EmptyField {
+                field: "vllm.client_cert_pem",
+            });
+        }
+        if key_pem.is_empty() {
+            return Err(DomainError::EmptyField {
+                field: "vllm.client_key_pem",
+            });
+        }
+        let mut bundle = Vec::with_capacity(cert_pem.len() + key_pem.len() + 1);
+        bundle.extend_from_slice(cert_pem);
+        if !cert_pem.ends_with(b"\n") {
+            bundle.push(b'\n');
+        }
+        bundle.extend_from_slice(key_pem);
+        Ok(Self { pem_bundle: bundle })
+    }
+
+    fn expose(&self) -> &[u8] {
+        &self.pem_bundle
+    }
+}
+
+impl fmt::Debug for VllmClientIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("VllmClientIdentity(**redacted**)")
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
 
@@ -97,6 +145,7 @@ pub struct VllmConfig {
     endpoint: String,
     model: String,
     bearer: Option<VllmBearerToken>,
+    client_identity: Option<VllmClientIdentity>,
     max_tokens: u32,
     timeout: Duration,
 }
@@ -114,6 +163,7 @@ impl VllmConfig {
             endpoint: DEFAULT_ENDPOINT.to_owned(),
             model,
             bearer: None,
+            client_identity: None,
             max_tokens: DEFAULT_MAX_TOKENS,
             timeout: DEFAULT_TIMEOUT,
         })
@@ -133,6 +183,16 @@ impl VllmConfig {
     #[must_use]
     pub fn with_bearer(mut self, bearer: VllmBearerToken) -> Self {
         self.bearer = Some(bearer);
+        self
+    }
+
+    /// Attach a client certificate + private key for mTLS-protected
+    /// endpoints. The identity is handed to `reqwest` when the
+    /// agent's HTTP client is built; if the PEM is malformed, the
+    /// error surfaces at agent construction time.
+    #[must_use]
+    pub fn with_client_identity(mut self, identity: VllmClientIdentity) -> Self {
+        self.client_identity = Some(identity);
         self
     }
 
@@ -176,15 +236,22 @@ impl fmt::Debug for VllmAgent {
 
 impl VllmAgent {
     pub fn new(id: AgentId, specialty: Specialty, config: VllmConfig) -> Result<Self, DomainError> {
-        let http = Client::builder()
-            .timeout(config.timeout)
-            .build()
-            .map_err(|err| {
-                debug!(error = %err, "vllm: failed to build http client");
+        let mut builder = Client::builder().timeout(config.timeout);
+        if let Some(identity) = &config.client_identity {
+            let parsed = reqwest::Identity::from_pem(identity.expose()).map_err(|err| {
+                debug!(error = %err, "vllm: malformed client identity PEM");
                 DomainError::InvariantViolated {
-                    reason: "vllm: failed to build http client",
+                    reason: "vllm: client identity PEM is malformed",
                 }
             })?;
+            builder = builder.identity(parsed);
+        }
+        let http = builder.build().map_err(|err| {
+            debug!(error = %err, "vllm: failed to build http client");
+            DomainError::InvariantViolated {
+                reason: "vllm: failed to build http client",
+            }
+        })?;
         Ok(Self {
             id,
             specialty,
@@ -418,6 +485,58 @@ mod tests {
         let shown = format!("{t:?}");
         assert!(!shown.contains("very-secret"), "token leaked: {shown}");
         assert!(shown.contains("redacted"));
+    }
+
+    #[test]
+    fn client_identity_debug_is_redacted() {
+        let pem = b"-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----";
+        let key = b"-----BEGIN PRIVATE KEY-----\nxyz\n-----END PRIVATE KEY-----";
+        let identity = VllmClientIdentity::from_cert_and_key(pem, key).unwrap();
+        let shown = format!("{identity:?}");
+        assert!(!shown.contains("abc"), "cert leaked: {shown}");
+        assert!(!shown.contains("xyz"), "key leaked: {shown}");
+        assert!(shown.contains("redacted"));
+    }
+
+    #[test]
+    fn client_identity_rejects_empty_inputs() {
+        let key = b"-----BEGIN PRIVATE KEY-----\nxyz\n-----END PRIVATE KEY-----";
+        assert!(matches!(
+            VllmClientIdentity::from_cert_and_key(b"", key).unwrap_err(),
+            DomainError::EmptyField {
+                field: "vllm.client_cert_pem"
+            }
+        ));
+        let cert = b"-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----";
+        assert!(matches!(
+            VllmClientIdentity::from_cert_and_key(cert, b"").unwrap_err(),
+            DomainError::EmptyField {
+                field: "vllm.client_key_pem"
+            }
+        ));
+    }
+
+    #[test]
+    fn malformed_client_identity_surfaces_at_agent_construction() {
+        // PEM that looks structurally valid but is NOT a real cert.
+        // `reqwest::Identity::from_pem` will reject this during
+        // agent construction; that's the invariant we pin here.
+        let cert = b"-----BEGIN CERTIFICATE-----\nnot-really-base64\n-----END CERTIFICATE-----";
+        let key = b"-----BEGIN PRIVATE KEY-----\nalso-not-base64\n-----END PRIVATE KEY-----";
+        let identity = VllmClientIdentity::from_cert_and_key(cert, key).unwrap();
+        let config = VllmConfig::new("m").unwrap().with_client_identity(identity);
+        let err = VllmAgent::new(
+            AgentId::new("a").unwrap(),
+            Specialty::new("triage").unwrap(),
+            config,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::InvariantViolated {
+                reason: "vllm: client identity PEM is malformed"
+            }
+        ));
     }
 
     #[test]

--- a/crates/choreo-e2e-runner/Cargo.toml
+++ b/crates/choreo-e2e-runner/Cargo.toml
@@ -16,8 +16,18 @@ workspace = true
 name = "choreo-e2e-runner"
 path = "src/main.rs"
 
+# Provider-E2E runner: drives the vLLM agent adapter directly
+# against a real vLLM endpoint (mTLS or bearer). Kept as a second
+# binary so the compose/k8s runner that drives the choreographer
+# stays trivial and network-free by design.
+[[bin]]
+name = "choreo-e2e-provider"
+path = "src/bin/provider.rs"
+
 [dependencies]
 choreo-proto = { workspace = true }
+choreo-core = { workspace = true }
+choreo-adapters = { workspace = true, features = ["agent-vllm"] }
 tokio = { workspace = true }
 tonic = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/choreo-e2e-runner/src/bin/provider.rs
+++ b/crates/choreo-e2e-runner/src/bin/provider.rs
@@ -1,0 +1,205 @@
+//! Provider-level E2E runner.
+//!
+//! Puts the `agent-vllm` adapter in front of a real vLLM endpoint
+//! (mTLS or plain) and exercises the full `AgentPort` surface
+//! against it: `generate`, `critique`, `revise`, plus a sanity check
+//! that all three calls returned non-trivial text.
+//!
+//! Exits 0 on success, non-zero on the first failed assertion. The
+//! Kubernetes Job manifest under `tests/e2e/kubernetes/` mounts the
+//! `e2e-client-tls` secret and wires these env vars:
+//!
+//!   CHOREO_VLLM_ENDPOINT         (required) — e.g. https://.../
+//!   CHOREO_VLLM_MODEL            (required) — e.g. Qwen/Qwen3.5-9B
+//!   CHOREO_VLLM_CLIENT_CERT_PATH (optional) — PEM file
+//!   CHOREO_VLLM_CLIENT_KEY_PATH  (optional) — PEM file
+//!   CHOREO_VLLM_BEARER_TOKEN     (optional) — bearer if no mTLS
+//!   CHOREO_VLLM_MAX_TOKENS       (optional) — default 1024
+//!
+//! The runner does **not** start a choreographer. Its job is to pin
+//! the adapter-to-vLLM contract. Full end-to-end through the
+//! choreographer (with the vLLM agent registered into a council)
+//! is covered by a future experiment.
+
+use std::env;
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Context, Result};
+use choreo_adapters::agents::vllm::{VllmAgent, VllmBearerToken, VllmClientIdentity, VllmConfig};
+use choreo_core::entities::TaskConstraints;
+use choreo_core::ports::{AgentPort, Critique, DraftRequest};
+use choreo_core::value_objects::{AgentId, NumAgents, Rounds, Rubric, Specialty, TaskDescription};
+use tracing::{info, warn};
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+#[allow(clippy::too_many_lines)] // linear E2E script; splitting it fragments the assertion story
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .compact()
+        .init();
+
+    let endpoint = require_env("CHOREO_VLLM_ENDPOINT")?;
+    let model = require_env("CHOREO_VLLM_MODEL")?;
+    let max_tokens = env::var("CHOREO_VLLM_MAX_TOKENS")
+        .ok()
+        .map(|raw| raw.parse::<u32>())
+        .transpose()
+        .context("CHOREO_VLLM_MAX_TOKENS must parse as u32")?
+        .unwrap_or(1024);
+
+    let mut config = VllmConfig::new(&model)
+        .context("VllmConfig::new rejected the model name")?
+        .with_endpoint(&endpoint)
+        .context("VllmConfig::with_endpoint rejected the endpoint URL")?
+        .with_max_tokens(max_tokens)
+        .context("VllmConfig rejected max_tokens")?
+        .with_timeout(Duration::from_secs(300));
+
+    // mTLS: both the cert and key paths must be set together. If one
+    // is set and the other isn't, fail loudly — it's almost
+    // certainly a misconfigured env.
+    match (
+        env::var("CHOREO_VLLM_CLIENT_CERT_PATH").ok(),
+        env::var("CHOREO_VLLM_CLIENT_KEY_PATH").ok(),
+    ) {
+        (Some(cert), Some(key)) => {
+            let cert_pem = std::fs::read(&cert)
+                .with_context(|| format!("reading client cert PEM from {cert}"))?;
+            let key_pem = std::fs::read(&key)
+                .with_context(|| format!("reading client key PEM from {key}"))?;
+            let identity = VllmClientIdentity::from_cert_and_key(&cert_pem, &key_pem)
+                .map_err(|err| anyhow!("invalid client identity: {err}"))?;
+            config = config.with_client_identity(identity);
+            info!(
+                cert = %Path::new(&cert).display(),
+                key = %Path::new(&key).display(),
+                "mtls client identity loaded"
+            );
+        }
+        (None, None) => {}
+        (cert, key) => bail!(
+            "mTLS misconfigured: CHOREO_VLLM_CLIENT_CERT_PATH={:?}, CHOREO_VLLM_CLIENT_KEY_PATH={:?} (both required or neither)",
+            cert.is_some(),
+            key.is_some(),
+        ),
+    }
+
+    if let Some(token) = env::var("CHOREO_VLLM_BEARER_TOKEN")
+        .ok()
+        .filter(|s| !s.is_empty())
+    {
+        let bearer =
+            VllmBearerToken::new(token).map_err(|err| anyhow!("invalid bearer token: {err}"))?;
+        config = config.with_bearer(bearer);
+        info!("bearer token loaded");
+    }
+
+    let agent = VllmAgent::new(
+        AgentId::new("e2e-vllm-agent").unwrap(),
+        Specialty::new("triage").unwrap(),
+        config,
+    )
+    .map_err(|err| anyhow!("VllmAgent::new failed: {err}"))?;
+
+    let constraints = TaskConstraints::new(
+        Rubric::empty(),
+        Rounds::new(0).unwrap(),
+        Some(NumAgents::new(1).unwrap()),
+        None,
+    );
+    let task = TaskDescription::new(
+        "Investigate a p1 payment latency spike. Suggest two hypotheses and one next step.",
+    )
+    .unwrap();
+
+    info!(endpoint, model, "scenario 1/3: generate");
+    let draft = agent
+        .generate(DraftRequest {
+            task: task.clone(),
+            constraints: constraints.clone(),
+            diverse: true,
+        })
+        .await
+        .context("agent.generate failed")?;
+    require_nonempty("generate.content", &draft.content, 20)?;
+    info!(
+        chars = draft.content.len(),
+        head = %truncate(&draft.content, 80),
+        "generate ok"
+    );
+
+    info!("scenario 2/3: critique");
+    let critique = agent
+        .critique(&draft.content, &constraints)
+        .await
+        .context("agent.critique failed")?;
+    require_nonempty("critique.feedback", &critique.feedback, 20)?;
+    info!(
+        chars = critique.feedback.len(),
+        head = %truncate(&critique.feedback, 80),
+        "critique ok"
+    );
+
+    info!("scenario 3/3: revise");
+    let revised = agent
+        .revise(
+            &draft.content,
+            &Critique {
+                feedback: critique.feedback.clone(),
+            },
+        )
+        .await
+        .context("agent.revise failed")?;
+    require_nonempty("revise.content", &revised.content, 20)?;
+    if revised.content.trim() == draft.content.trim() {
+        warn!(
+            "revise returned the same content as generate — the model may not have actually revised"
+        );
+    }
+    info!(
+        chars = revised.content.len(),
+        head = %truncate(&revised.content, 80),
+        "revise ok"
+    );
+
+    info!("all provider-E2E scenarios passed");
+    Ok(())
+}
+
+fn require_env(name: &str) -> Result<String> {
+    let raw = env::var(name).map_err(|_| anyhow!("required env var {name} is not set"))?;
+    if raw.trim().is_empty() {
+        bail!("required env var {name} is empty");
+    }
+    Ok(raw)
+}
+
+fn require_nonempty(field: &str, s: &str, min_chars: usize) -> Result<()> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        bail!("{field} is empty");
+    }
+    if trimmed.chars().count() < min_chars {
+        bail!(
+            "{field} is suspiciously short ({} chars, want >= {min_chars}): {:?}",
+            trimmed.chars().count(),
+            trimmed
+        );
+    }
+    Ok(())
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    let trimmed = s.trim();
+    if trimmed.chars().count() <= max {
+        trimmed.to_owned()
+    } else {
+        let head: String = trimmed.chars().take(max).collect();
+        format!("{head}…")
+    }
+}

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -72,6 +72,39 @@ just e2e-compose     # full stack via docker compose + runner
 just e2e-kubernetes  # kind cluster + Helm chart + runner Job
 ```
 
+### Provider-E2E (vLLM)
+
+Exercises the `agent-vllm` adapter directly against a real vLLM
+endpoint — not the full choreographer — so it pins the provider
+wire contract. The Kubernetes Job mounts a client certificate and
+hits the endpoint via mTLS.
+
+```bash
+# Build the runner image and push it where the cluster can pull it.
+IMAGE_TAG=<registry>/underpass-choreographer-e2e-provider:dev \
+    just build-provider-image
+
+# Edit tests/e2e/kubernetes/provider-vllm-job.yaml to use that tag,
+# then:
+NAMESPACE=<ns-holding-e2e-client-tls> just e2e-provider-vllm
+```
+
+Env vars consumed by the runner (set in the Job's `env` block,
+edit the manifest for a different endpoint):
+
+| Var | Required | Notes |
+|---|---|---|
+| `CHOREO_VLLM_ENDPOINT` | yes | base URL, e.g. `https://qwen35-9b.llm.underpassai.com` |
+| `CHOREO_VLLM_MODEL` | yes | model id, e.g. `Qwen/Qwen3.5-9B` |
+| `CHOREO_VLLM_CLIENT_CERT_PATH` | with key | PEM file for mTLS client cert |
+| `CHOREO_VLLM_CLIENT_KEY_PATH` | with cert | PEM file for mTLS client key |
+| `CHOREO_VLLM_BEARER_TOKEN` | optional | bearer auth |
+| `CHOREO_VLLM_MAX_TOKENS` | optional | default `1024`; bump when the model uses a reasoning parser that burns budget before `content` |
+
+The runner validates `generate` + `critique` + `revise` each
+return text of at least 20 characters; a failing assertion exits
+the Job non-zero and the script surfaces the pod status.
+
 ## Benchmarks
 
 ```bash

--- a/justfile
+++ b/justfile
@@ -70,6 +70,14 @@ e2e-compose:
 e2e-kubernetes:
     bash scripts/ci/e2e-kubernetes.sh
 
+# Provider-level E2E: exercises the `agent-vllm` adapter against a
+# real vLLM endpoint via mTLS. Expects `e2e-client-tls` in the
+# target namespace (default `underpass-runtime`); override with
+# NAMESPACE=<ns>. Build the runner image first (`just
+# build-provider-image`) and make it reachable from the cluster.
+e2e-provider-vllm:
+    bash scripts/ci/e2e-provider-vllm.sh
+
 # -----------------------------------------------------------------------------
 # chart & image
 # -----------------------------------------------------------------------------
@@ -82,6 +90,12 @@ helm-lint:
 # the dockerfile + entrypoint match what CI/CD ships.
 build-image:
     bash scripts/ci/container-image.sh
+
+# Build the provider-E2E runner image. Not published — operators
+# push to whatever registry their cluster can pull from. Tag via
+# IMAGE_TAG=<tag>.
+build-provider-image:
+    bash scripts/ci/build-provider-image.sh
 
 # -----------------------------------------------------------------------------
 # running the binary

--- a/scripts/ci/build-provider-image.sh
+++ b/scripts/ci/build-provider-image.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the provider-E2E runner image. The image isn't part of the
+# product distribution, so it doesn't get published by the
+# publish-distribution workflow — operators build it locally (or in
+# a pre-release step) and push to whatever registry the cluster can
+# pull from. Defaults to a local tag so `kubectl` + a cluster with
+# the registry mirrored (kind, podman-desktop, etc.) can pull it.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+IMAGE_TAG="${IMAGE_TAG:-underpass-choreographer-e2e-provider:dev}"
+DOCKERFILE="${ROOT_DIR}/tests/e2e/provider-runner.Dockerfile"
+
+cd "${ROOT_DIR}"
+
+if command -v podman >/dev/null 2>&1; then
+    build_cmd=(podman build)
+elif command -v docker >/dev/null 2>&1; then
+    build_cmd=(docker build)
+else
+    echo "error: neither podman nor docker is available" >&2
+    exit 1
+fi
+
+echo ">>> building ${IMAGE_TAG} via ${build_cmd[*]}"
+"${build_cmd[@]}" -f "${DOCKERFILE}" -t "${IMAGE_TAG}" .
+echo ">>> done. Tag as needed + push to a registry reachable by your cluster."

--- a/scripts/ci/e2e-provider-vllm.sh
+++ b/scripts/ci/e2e-provider-vllm.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Launches the vLLM provider-E2E Job, waits for completion, tails
+# logs, and cleans up. Namespace defaults to `underpass-runtime`
+# (where the e2e-client-tls secret lives); override with $NAMESPACE.
+#
+# The container image must already be built and pushed. Reuses the
+# E2E compose image tag by convention (see `just build-provider-image`).
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+NAMESPACE="${NAMESPACE:-underpass-runtime}"
+JOB_NAME="${JOB_NAME:-choreographer-e2e-provider-vllm}"
+MANIFEST="${ROOT_DIR}/tests/e2e/kubernetes/provider-vllm-job.yaml"
+TIMEOUT="${TIMEOUT:-180s}"
+
+cleanup() {
+    kubectl -n "${NAMESPACE}" delete job "${JOB_NAME}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+}
+
+# Make the cleanup idempotent — a prior failed Job would block apply.
+cleanup
+trap cleanup EXIT
+
+kubectl apply -n "${NAMESPACE}" -f "${MANIFEST}"
+
+# Poll for the Job's pod to be scheduled, then tail its logs.
+echo ">>> waiting for pod"
+for _ in $(seq 1 30); do
+    pod=$(kubectl -n "${NAMESPACE}" get pod \
+        -l "job-name=${JOB_NAME}" \
+        -o=jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+    if [ -n "${pod:-}" ]; then
+        break
+    fi
+    sleep 2
+done
+
+if [ -z "${pod:-}" ]; then
+    echo "error: Job ${JOB_NAME} produced no pod" >&2
+    kubectl -n "${NAMESPACE}" get job "${JOB_NAME}" -o yaml >&2 || true
+    exit 1
+fi
+
+echo ">>> tailing ${pod}"
+kubectl -n "${NAMESPACE}" logs -f "${pod}" || true
+
+# Surface the final Job status so callers can script on exit code.
+if kubectl -n "${NAMESPACE}" wait --for=condition=complete \
+    --timeout="${TIMEOUT}" "job/${JOB_NAME}" >/dev/null 2>&1; then
+    echo ">>> Job completed successfully"
+    exit 0
+fi
+
+echo ">>> Job did not complete within ${TIMEOUT} — dumping status" >&2
+kubectl -n "${NAMESPACE}" describe job "${JOB_NAME}" >&2 || true
+kubectl -n "${NAMESPACE}" describe pod "${pod}" >&2 || true
+exit 1

--- a/tests/e2e/kubernetes/provider-vllm-job.yaml
+++ b/tests/e2e/kubernetes/provider-vllm-job.yaml
@@ -1,0 +1,87 @@
+# Provider-E2E Job: vLLM via mTLS.
+#
+# Applies into the `underpass-runtime` namespace (where vLLM runs)
+# and exercises the `agent-vllm` adapter against the public mTLS
+# endpoint `qwen35-9b.llm.underpassai.com`. Uses the in-cluster
+# `e2e-client-tls` Secret for the client certificate.
+#
+# Launch: `just e2e-provider-vllm` (applies this manifest, waits
+# for completion, tails logs, deletes the Job). Can also be
+# applied directly with `kubectl apply -f` against any namespace
+# that already holds an `e2e-client-tls` Secret.
+#
+# The container image must be built and pushed separately; see
+# `just build-provider-image` and update `spec.containers.image`
+# for your registry.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: choreographer-e2e-provider-vllm
+  labels:
+    app.kubernetes.io/name: choreographer-e2e-provider
+    app.kubernetes.io/part-of: underpass
+    provider: vllm
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: choreographer-e2e-provider
+        provider: vllm
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: runner
+          image: ghcr.io/underpass-ai/underpass-choreographer-e2e-provider:latest
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: CHOREO_VLLM_ENDPOINT
+              value: https://qwen35-9b.llm.underpassai.com
+            - name: CHOREO_VLLM_MODEL
+              value: Qwen/Qwen3.5-9B
+            - name: CHOREO_VLLM_CLIENT_CERT_PATH
+              value: /certs/tls.crt
+            - name: CHOREO_VLLM_CLIENT_KEY_PATH
+              value: /certs/tls.key
+            - name: CHOREO_VLLM_MAX_TOKENS
+              value: "1024"
+            - name: RUST_LOG
+              value: info
+          volumeMounts:
+            - name: client-tls
+              mountPath: /certs
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+      volumes:
+        - name: client-tls
+          secret:
+            secretName: e2e-client-tls
+            defaultMode: 0400
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 32Mi

--- a/tests/e2e/provider-runner.Dockerfile
+++ b/tests/e2e/provider-runner.Dockerfile
@@ -1,0 +1,48 @@
+# syntax=docker/dockerfile:1.7
+#
+# Provider-E2E runner container.
+#
+# Builds the `choreo-e2e-provider` binary and ships it in a minimal,
+# non-root image. Exercises the `agent-vllm` adapter against a real
+# vLLM endpoint — not the full choreographer stack — so it has zero
+# NATS / Postgres / gRPC dependencies at runtime.
+
+ARG RUST_VERSION=1.90.0
+ARG DEBIAN_RELEASE=bookworm
+
+FROM docker.io/library/rust:${RUST_VERSION}-${DEBIAN_RELEASE} AS builder
+
+ENV CARGO_INCREMENTAL=0 \
+    CARGO_TERM_COLOR=always \
+    RUSTFLAGS="-C strip=symbols"
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      protobuf-compiler \
+      libprotobuf-dev \
+      ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+
+COPY Cargo.toml Cargo.lock ./
+COPY rust-toolchain.toml ./
+COPY crates ./crates
+
+RUN --mount=type=cache,id=cargo-registry-e2e-provider,target=/usr/local/cargo/registry \
+    --mount=type=cache,id=cargo-target-e2e-provider,target=/src/target \
+    cargo build --release --locked --bin choreo-e2e-provider \
+ && install -Dm 0755 target/release/choreo-e2e-provider /out/runner
+
+FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
+
+LABEL org.opencontainers.image.title="underpass-choreographer-e2e-provider" \
+      org.opencontainers.image.description="Drives the vLLM agent adapter against a real vLLM endpoint. Not shipped." \
+      org.opencontainers.image.vendor="Underpass AI" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+COPY --from=builder /out/runner /usr/local/bin/choreo-e2e-provider
+
+USER nonroot:nonroot
+
+ENTRYPOINT ["/usr/local/bin/choreo-e2e-provider"]


### PR DESCRIPTION
## Summary

Closes the provider contract honesty gap. The \`agent-vllm\` adapter now has a reproducible E2E path that exercises \`generate\` / \`critique\` / \`revise\` against a real vLLM deployment behind mTLS — not against a wiremock.

## Real-world evidence

Run locally against the production cluster (\`underpass-runtime\` namespace):

- endpoint: \`https://qwen35-9b.llm.underpassai.com\`
- model: \`Qwen/Qwen3.5-9B\`
- mTLS: \`e2e-client-tls\` secret

Output (runner log excerpts):

\`\`\`
INFO choreo_e2e_provider: mtls client identity loaded
INFO choreo_e2e_provider: generate ok chars=4413
INFO choreo_e2e_provider: critique ok chars=4603
INFO choreo_e2e_provider: revise ok chars=4360
INFO choreo_e2e_provider: all provider-E2E scenarios passed
\`\`\`

Total wall-clock ~76 s (25 s/call). Reasoning-fallback activated on all three — the cluster's vLLM uses \`--reasoning-parser=qwen3\` which returns \`content: null\` when \`max_tokens\` is spent on reasoning.

## Gaps fixed in the adapter

Both surfaced running the E2E and fixed in the same slice.

### 1. mTLS client identity

- New \`VllmClientIdentity\` value object (cert+key PEM), redacting \`Debug\`, empty-input rejection
- \`VllmConfig::with_client_identity(identity)\` wires into \`reqwest::Identity::from_pem\` at agent construction
- Malformed PEM fails loudly at \`VllmAgent::new\` with \`InvariantViolated { reason: \"vllm: client identity PEM is malformed\" }\`
- 3 unit tests

### 2. Reasoning fallback in \`openai_compat::extract_text\`

- \`ChatResponseMessage\` gains an optional \`reasoning\` field
- When \`content\` is null/empty but \`reasoning\` is non-empty, the helper uses reasoning rather than failing the request
- Matches real Qwen3 behaviour with \`--reasoning-parser=qwen3\` + tight token budget
- 4 unit tests covering the matrix: content-only, reasoning-only, both (content wins), both empty

## New runner + infrastructure

- **Binary** \`choreo-e2e-provider\` in \`choreo-e2e-runner\`. Env-driven: \`CHOREO_VLLM_{ENDPOINT, MODEL, CLIENT_CERT_PATH, CLIENT_KEY_PATH, BEARER_TOKEN, MAX_TOKENS}\`. Requires each call return ≥ 20 chars of text; warns if revise == generate.
- **Dockerfile**: \`tests/e2e/provider-runner.Dockerfile\` (distroless non-root)
- **Job**: \`tests/e2e/kubernetes/provider-vllm-job.yaml\` — hardened (runAsNonRoot, readOnlyRootFilesystem, dropped caps, automount:false); mounts \`e2e-client-tls\` at \`/certs\`
- **Launcher**: \`scripts/ci/e2e-provider-vllm.sh\` — apply + tail + wait + clean
- **Image builder**: \`scripts/ci/build-provider-image.sh\` (podman-or-docker autodetect)
- **Justfile**: \`just build-provider-image\` + \`just e2e-provider-vllm\`
- **Docs**: \`docs/dev-loop.md\` gains a Provider-E2E section with env-var table

## Honest scope (not in this PR)

- No CI automation — the Job runs on user demand against their cluster (no self-hosted runner yet)
- Anthropic/OpenAI E2E — different secrets, different cluster paths; follow-up if wanted
- Full-choreographer-with-vLLM-agent end-to-end — pins the agent contract first; the integration through \`DeliberateUseCase\` is a future experiment recorded under \`docs/experiments/\`

## Test plan
- [x] \`cargo clippy --workspace --all-targets --features ... -- -D warnings\`
- [x] \`cargo test --workspace\` (180 adapter tests green)
- [x] Local E2E against the real cluster → 3/3 scenarios passed
- [x] Image builds with podman
- [ ] CI green on all 11 fast gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)