### PR TITLE
feat(core): first-class causal task metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/target-*/
 **/*.rs.bk
 Cargo.lock.bak
 .env
@@ -9,3 +10,5 @@ Cargo.lock.bak
 *.swo
 .DS_Store
 .claude/
+.codex
+tests/e2e/compose.log

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ help:
 		'Available targets:' \
 		'  make check                  # contract + fmt-check + clippy + test + bench-compile' \
 		'  make integration            # integration-nats + integration-postgres' \
-		'  make e2e-compose            # manual E2E via docker/podman compose' \
+		'  make e2e-compose            # manual E2E via docker/podman compose or podman-compose' \
 		'  make e2e-kubernetes         # manual E2E via Kubernetes Job' \
 		'  make e2e-provider-vllm      # provider-level vLLM E2E' \
 		'  make helm-lint              # helm lint + hardened render assertions' \

--- a/crates/choreo-adapters/src/grpc/mappers/event.rs
+++ b/crates/choreo-adapters/src/grpc/mappers/event.rs
@@ -28,7 +28,15 @@ pub fn trigger_event_from_proto(
         EventId::new(ev.event_id)?
     };
     let emitted_at = ev.emitted_at.map_or(fallback_now, timestamp_to_offset);
-    let envelope = EventEnvelope::new(event_id, emitted_at, ev.source, None)?;
+    let correlation_id = optional_event_id(&ev.correlation_id)?;
+    let causation_id = optional_event_id(&ev.causation_id)?;
+    let envelope = EventEnvelope::new_with_causation(
+        event_id,
+        emitted_at,
+        ev.source,
+        correlation_id,
+        causation_id,
+    )?;
 
     let specialties: Vec<Specialty> = ev
         .requested_specialties
@@ -89,6 +97,15 @@ fn timestamp_to_offset(ts: Timestamp) -> OffsetDateTime {
     OffsetDateTime::from_unix_timestamp_nanos(nanos).unwrap_or(OffsetDateTime::UNIX_EPOCH)
 }
 
+fn optional_event_id(value: &str) -> Result<Option<EventId>, DomainError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        Ok(None)
+    } else {
+        EventId::new(trimmed.to_owned()).map(Some)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -110,6 +127,8 @@ mod tests {
             constraints: None,
             payload: Some(PbStruct::default()),
             external_context: None,
+            correlation_id: String::new(),
+            causation_id: String::new(),
         }
     }
 
@@ -125,6 +144,18 @@ mod tests {
         assert_eq!(ev.envelope().source(), "grafana");
         assert_eq!(ev.envelope().emitted_at(), now());
         assert!(!ev.envelope().event_id().as_str().is_empty());
+    }
+
+    #[test]
+    fn supplied_causal_ids_are_preserved() {
+        let mut t = proto_trigger("k", vec!["s"]);
+        t.correlation_id = "corr-1".to_owned();
+        t.causation_id = "cause-1".to_owned();
+
+        let ev = trigger_event_from_proto(t, now()).unwrap();
+
+        assert_eq!(ev.envelope().correlation_id().unwrap().as_str(), "corr-1");
+        assert_eq!(ev.envelope().causation_id().unwrap().as_str(), "cause-1");
     }
 
     #[test]

--- a/crates/choreo-adapters/src/grpc/mappers/task.rs
+++ b/crates/choreo-adapters/src/grpc/mappers/task.rs
@@ -1,9 +1,9 @@
 //! Task & constraints proto → domain conversion.
 
-use choreo_core::entities::{Task, TaskConstraints};
+use choreo_core::entities::{Task, TaskConstraints, TaskMetadata};
 use choreo_core::error::DomainError;
 use choreo_core::value_objects::{
-    DurationMs, NumAgents, Rounds, Specialty, TaskDescription, TaskId,
+    DurationMs, EventId, NumAgents, Rounds, Specialty, TaskDescription, TaskId,
 };
 use choreo_proto::v1 as pb;
 
@@ -20,13 +20,15 @@ pub fn task_from_proto(t: pb::Task) -> Result<Task, DomainError> {
     let constraints = constraints_from_proto(t.constraints)?;
     let attributes = attributes_from_struct(t.attributes)?;
     let external_context = external_context_from_proto(t.external_context)?;
-    Ok(Task::new_with_context(
+    let metadata = metadata_from_proto(t.metadata)?;
+    Ok(Task::new_with_metadata(
         id,
         specialty,
         description,
         constraints,
         attributes,
         external_context,
+        metadata,
     ))
 }
 
@@ -57,6 +59,36 @@ fn constraints_from_proto(c: Option<pb::Constraints>) -> Result<TaskConstraints,
     Ok(constraints)
 }
 
+pub(crate) fn metadata_from_proto(
+    metadata: Option<pb::TaskMetadata>,
+) -> Result<TaskMetadata, DomainError> {
+    let Some(metadata) = metadata else {
+        return Ok(TaskMetadata::default());
+    };
+
+    TaskMetadata::new(
+        optional_event_id(&metadata.source_event_id)?,
+        optional_event_id(&metadata.causation_id)?,
+        optional_event_id(&metadata.correlation_id)?,
+        optional_text(&metadata.council_contract_id),
+        optional_text(&metadata.output_contract_id),
+        attributes_from_struct(metadata.execution_profile)?,
+    )
+}
+
+fn optional_event_id(value: &str) -> Result<Option<EventId>, DomainError> {
+    optional_text(value).map(EventId::new).transpose()
+}
+
+fn optional_text(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_owned())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -76,6 +108,7 @@ mod tests {
             }),
             attributes: Some(PbStruct::default()),
             external_context: None,
+            metadata: None,
         }
     }
 
@@ -117,6 +150,7 @@ mod tests {
             }),
             attributes: None,
             external_context: None,
+            metadata: None,
         };
         let task = task_from_proto(t).unwrap();
         assert_eq!(task.constraints().rounds(), Rounds::default());
@@ -133,6 +167,7 @@ mod tests {
             constraints: None,
             attributes: None,
             external_context: None,
+            metadata: None,
         };
         let err = task_from_proto(t).unwrap_err();
         assert!(matches!(err, DomainError::EmptyField { field: "task_id" }));
@@ -174,5 +209,35 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn task_metadata_maps_to_domain() {
+        let mut t = sample_proto("t1", "triage", "describe alert");
+        t.metadata = Some(pb::TaskMetadata {
+            source_event_id: "source-1".to_owned(),
+            causation_id: "cause-1".to_owned(),
+            correlation_id: "corr-1".to_owned(),
+            council_contract_id: "council-contract".to_owned(),
+            output_contract_id: "output-contract".to_owned(),
+            execution_profile: Some(PbStruct::default()),
+        });
+
+        let task = task_from_proto(t).unwrap();
+
+        assert_eq!(
+            task.metadata().source_event_id().unwrap().as_str(),
+            "source-1"
+        );
+        assert_eq!(task.metadata().causation_id().unwrap().as_str(), "cause-1");
+        assert_eq!(task.metadata().correlation_id().unwrap().as_str(), "corr-1");
+        assert_eq!(
+            task.metadata().council_contract_id(),
+            Some("council-contract")
+        );
+        assert_eq!(
+            task.metadata().output_contract_id(),
+            Some("output-contract")
+        );
     }
 }

--- a/crates/choreo-app/src/services/auto_dispatch.rs
+++ b/crates/choreo-app/src/services/auto_dispatch.rs
@@ -11,7 +11,9 @@
 
 use std::sync::Arc;
 
-use choreo_core::entities::{Deliberation, ExternalContextBundle, Task, TaskConstraints};
+use choreo_core::entities::{
+    Deliberation, ExternalContextBundle, Task, TaskConstraints, TaskMetadata,
+};
 use choreo_core::error::DomainError;
 use choreo_core::events::TriggerEvent;
 use choreo_core::value_objects::{Attributes, Specialty, TaskDescription, TaskId};
@@ -100,6 +102,7 @@ impl AutoDispatchService {
                 event.constraints().clone(),
                 event.payload().clone(),
                 event.external_context().cloned(),
+                TaskMetadata::from_trigger_envelope(event.envelope()),
             )?;
             match self.deliberate.execute(task).await {
                 Ok(out) => {
@@ -133,14 +136,16 @@ impl AutoDispatchService {
         constraints: TaskConstraints,
         attributes: Attributes,
         external_context: Option<ExternalContextBundle>,
+        metadata: TaskMetadata,
     ) -> Result<Task, DomainError> {
-        Ok(Task::new_with_context(
+        Ok(Task::new_with_metadata(
             TaskId::new(Uuid::new_v4().to_string())?,
             specialty.clone(),
             description,
             constraints,
             attributes,
             external_context,
+            metadata,
         ))
     }
 }

--- a/crates/choreo-app/src/usecases/deliberate.rs
+++ b/crates/choreo-app/src/usecases/deliberate.rs
@@ -23,7 +23,8 @@
 use std::sync::Arc;
 
 use choreo_core::entities::{
-    Council, Deliberation, Proposal, Task, TaskConstraints, ValidationOutcome, ValidatorReport,
+    Council, Deliberation, Proposal, Task, TaskConstraints, TaskMetadata, ValidationOutcome,
+    ValidatorReport,
 };
 use choreo_core::error::DomainError;
 use choreo_core::events::{DeliberationCompletedEvent, EventEnvelope};
@@ -174,7 +175,7 @@ impl DeliberateUseCase {
         let winner = Self::pick_winner(&ranked, task.constraints())?;
 
         let completion_event = DeliberationCompletedEvent::new(
-            self.envelope(completed_at)?,
+            self.envelope(completed_at, task.metadata())?,
             deliberation.task_id().clone(),
             deliberation.specialty().clone(),
             winner.proposal().id().clone(),
@@ -384,8 +385,18 @@ impl DeliberateUseCase {
         Ok(reports)
     }
 
-    fn envelope(&self, emitted_at: OffsetDateTime) -> Result<EventEnvelope, DomainError> {
-        EventEnvelope::new(new_event_id()?, emitted_at, self.source.clone(), None)
+    fn envelope(
+        &self,
+        emitted_at: OffsetDateTime,
+        metadata: &TaskMetadata,
+    ) -> Result<EventEnvelope, DomainError> {
+        EventEnvelope::new_with_causation(
+            new_event_id()?,
+            emitted_at,
+            self.source.clone(),
+            metadata.correlation_id().cloned(),
+            metadata.causation_id().cloned(),
+        )
     }
 }
 

--- a/crates/choreo-app/src/usecases/orchestrate.rs
+++ b/crates/choreo-app/src/usecases/orchestrate.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Arc;
 
-use choreo_core::entities::{Deliberation, Proposal, Task};
+use choreo_core::entities::{Deliberation, Proposal, Task, TaskMetadata};
 use choreo_core::error::DomainError;
 use choreo_core::events::{
     EventEnvelope, TaskCompletedEvent, TaskDispatchedEvent, TaskFailedEvent,
@@ -79,12 +79,13 @@ impl OrchestrateUseCase {
     ) -> Result<OrchestrateOutput, DomainError> {
         let task_id = task.id().clone();
         let specialty = task.specialty().clone();
+        let metadata = task.metadata().clone();
 
         let out = match self.deliberate.execute(task).await {
             Ok(out) => out,
             Err(err) => {
                 let event = TaskFailedEvent::new(
-                    self.envelope(self.clock.now())?,
+                    self.envelope(self.clock.now(), &metadata)?,
                     task_id.clone(),
                     specialty.clone(),
                     deliberation_error_kind(&err),
@@ -110,12 +111,15 @@ impl OrchestrateUseCase {
 
         self.messaging
             .publish_task_dispatched(&TaskDispatchedEvent::new(
-                self.envelope(self.clock.now())?,
+                self.envelope(self.clock.now(), &metadata)?,
                 task_id.clone(),
                 specialty.clone(),
-                None,
+                metadata.source_event_id().cloned(),
             ))
             .await?;
+
+        let execution_options =
+            merge_execution_options(metadata.execution_profile(), execution_options)?;
 
         match self.executor.execute(&winner, &execution_options).await {
             Ok(execution) => {
@@ -131,7 +135,7 @@ impl OrchestrateUseCase {
                 if execution.succeeded {
                     self.messaging
                         .publish_task_completed(&TaskCompletedEvent::new(
-                            self.envelope(self.clock.now())?,
+                            self.envelope(self.clock.now(), &metadata)?,
                             task_id.clone(),
                             specialty.clone(),
                             Some(winner.author().clone()),
@@ -145,7 +149,7 @@ impl OrchestrateUseCase {
                     );
                 } else {
                     let event = TaskFailedEvent::new(
-                        self.envelope(self.clock.now())?,
+                        self.envelope(self.clock.now(), &metadata)?,
                         task_id.clone(),
                         specialty.clone(),
                         "executor.unsuccessful",
@@ -166,7 +170,7 @@ impl OrchestrateUseCase {
             }
             Err(err) => {
                 let event = TaskFailedEvent::new(
-                    self.envelope(self.clock.now())?,
+                    self.envelope(self.clock.now(), &metadata)?,
                     task_id.clone(),
                     specialty,
                     "executor.error",
@@ -179,12 +183,17 @@ impl OrchestrateUseCase {
         }
     }
 
-    fn envelope(&self, emitted_at: OffsetDateTime) -> Result<EventEnvelope, DomainError> {
-        EventEnvelope::new(
+    fn envelope(
+        &self,
+        emitted_at: OffsetDateTime,
+        metadata: &TaskMetadata,
+    ) -> Result<EventEnvelope, DomainError> {
+        EventEnvelope::new_with_causation(
             EventId::new(Uuid::new_v4().to_string())?,
             emitted_at,
             self.source.clone(),
-            None,
+            metadata.correlation_id().cloned(),
+            metadata.causation_id().cloned(),
         )
     }
 }
@@ -196,6 +205,15 @@ fn deliberation_error_kind(err: &DomainError) -> &'static str {
     }
 }
 
+fn merge_execution_options(
+    profile: &Attributes,
+    explicit: Attributes,
+) -> Result<Attributes, DomainError> {
+    let mut merged = profile.as_map().clone();
+    merged.extend(explicit.into_inner());
+    Attributes::new(merged)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -203,7 +221,8 @@ mod tests {
 
     use async_trait::async_trait;
     use choreo_core::entities::{
-        Council, Deliberation, DeliberationPhase, Task, TaskConstraints, ValidatorReport,
+        Council, Deliberation, DeliberationPhase, Task, TaskConstraints, TaskMetadata,
+        ValidatorReport,
     };
     use choreo_core::events::{DeliberationCompletedEvent, PhaseChangedEvent, TaskDispatchedEvent};
     use choreo_core::ports::{
@@ -211,8 +230,8 @@ mod tests {
         DraftRequest, Revision, ScoringPort, ValidatorPort,
     };
     use choreo_core::value_objects::{
-        AgentId, Attributes, CouncilId, DurationMs, OutputContract, OutputFieldRule, Rounds,
-        Rubric, Score, Specialty, TaskDescription, TaskId,
+        AgentId, Attributes, CouncilId, DurationMs, EventId, OutputContract, OutputFieldRule,
+        Rounds, Rubric, Score, Specialty, TaskDescription, TaskId,
     };
     use time::macros::datetime;
 
@@ -512,6 +531,23 @@ mod tests {
         }
     }
 
+    struct RecordingExecutor {
+        outcome: ExecutionOutcome,
+        seen_options: Mutex<Vec<Attributes>>,
+    }
+
+    #[async_trait]
+    impl ExecutorPort for RecordingExecutor {
+        async fn execute(
+            &self,
+            _winner: &Proposal,
+            options: &Attributes,
+        ) -> Result<ExecutionOutcome, DomainError> {
+            self.seen_options.lock().unwrap().push(options.clone());
+            Ok(self.outcome.clone())
+        }
+    }
+
     fn specialty() -> Specialty {
         Specialty::new("triage").unwrap()
     }
@@ -523,6 +559,18 @@ mod tests {
             TaskDescription::new("decide a remediation").unwrap(),
             TaskConstraints::new(Rubric::empty(), Rounds::new(0).unwrap(), None, None),
             Attributes::empty(),
+        )
+    }
+
+    fn task_with_metadata(metadata: TaskMetadata) -> Task {
+        Task::new_with_metadata(
+            TaskId::new("task-1").unwrap(),
+            specialty(),
+            TaskDescription::new("decide a remediation").unwrap(),
+            TaskConstraints::new(Rubric::empty(), Rounds::new(0).unwrap(), None, None),
+            Attributes::empty(),
+            None,
+            metadata,
         )
     }
 
@@ -660,6 +708,151 @@ mod tests {
         assert_eq!(bus.failed.lock().unwrap().len(), 1);
         assert_eq!(out.deliberation.phase(), DeliberationPhase::Completed);
         assert_eq!(out.winner.author(), &AgentId::new("agent-1").unwrap());
+    }
+
+    #[tokio::test]
+    async fn lifecycle_events_preserve_task_causal_metadata() {
+        let (deliberate, bus) = deliberate_fixture();
+        let executor = Arc::new(StubExecutor {
+            outcome: ExecutionOutcome {
+                execution_id: "exec-1".to_owned(),
+                succeeded: true,
+                duration: DurationMs::from_millis(50),
+                output: Attributes::empty(),
+            },
+        });
+        let clock = Arc::new(FrozenClock {
+            now: datetime!(2026-04-25 12:00:01 UTC),
+        });
+        let stats: Arc<dyn choreo_core::ports::StatisticsPort> = Arc::new(NullStats);
+        let usecase = OrchestrateUseCase::new(
+            deliberate,
+            executor,
+            bus.clone(),
+            clock,
+            stats,
+            "choreographer",
+        );
+        let metadata = TaskMetadata::new(
+            Some(EventId::new("source-1").unwrap()),
+            Some(EventId::new("cause-1").unwrap()),
+            Some(EventId::new("corr-1").unwrap()),
+            None,
+            None,
+            Attributes::empty(),
+        )
+        .unwrap();
+
+        usecase
+            .execute(task_with_metadata(metadata), Attributes::empty())
+            .await
+            .unwrap();
+
+        let dispatched = bus.dispatched.lock().unwrap();
+        assert_eq!(
+            dispatched[0].trigger_event_id().unwrap().as_str(),
+            "source-1"
+        );
+        assert_eq!(
+            dispatched[0].envelope().correlation_id().unwrap().as_str(),
+            "corr-1"
+        );
+        assert_eq!(
+            dispatched[0].envelope().causation_id().unwrap().as_str(),
+            "cause-1"
+        );
+        drop(dispatched);
+
+        let deliberation_completed = bus.deliberation_completed.lock().unwrap();
+        assert_eq!(
+            deliberation_completed[0]
+                .envelope()
+                .correlation_id()
+                .unwrap()
+                .as_str(),
+            "corr-1"
+        );
+        assert_eq!(
+            deliberation_completed[0]
+                .envelope()
+                .causation_id()
+                .unwrap()
+                .as_str(),
+            "cause-1"
+        );
+        drop(deliberation_completed);
+
+        let completed = bus.completed.lock().unwrap();
+        assert_eq!(
+            completed[0].envelope().correlation_id().unwrap().as_str(),
+            "corr-1"
+        );
+        assert_eq!(
+            completed[0].envelope().causation_id().unwrap().as_str(),
+            "cause-1"
+        );
+    }
+
+    #[tokio::test]
+    async fn execution_profile_is_merged_with_explicit_execution_options() {
+        let (deliberate, bus) = deliberate_fixture();
+        let executor = Arc::new(RecordingExecutor {
+            outcome: ExecutionOutcome {
+                execution_id: "exec-1".to_owned(),
+                succeeded: true,
+                duration: DurationMs::from_millis(50),
+                output: Attributes::empty(),
+            },
+            seen_options: Mutex::new(Vec::new()),
+        });
+        let clock = Arc::new(FrozenClock {
+            now: datetime!(2026-04-25 12:00:01 UTC),
+        });
+        let stats: Arc<dyn choreo_core::ports::StatisticsPort> = Arc::new(NullStats);
+        let usecase = OrchestrateUseCase::new(
+            deliberate,
+            executor.clone(),
+            bus,
+            clock,
+            stats,
+            "choreographer",
+        );
+        let metadata = TaskMetadata::new(
+            None,
+            None,
+            None,
+            None,
+            None,
+            Attributes::new(std::collections::BTreeMap::from([
+                (
+                    "runtime.tool_name".to_owned(),
+                    serde_json::json!("profile-tool"),
+                ),
+                ("runtime.approved".to_owned(), serde_json::json!(false)),
+            ]))
+            .unwrap(),
+        )
+        .unwrap();
+        let explicit = Attributes::new(std::collections::BTreeMap::from([(
+            "runtime.approved".to_owned(),
+            serde_json::json!(true),
+        )]))
+        .unwrap();
+
+        usecase
+            .execute(task_with_metadata(metadata), explicit)
+            .await
+            .unwrap();
+
+        let seen = executor.seen_options.lock().unwrap();
+        assert_eq!(
+            seen[0].get("runtime.tool_name"),
+            Some(&serde_json::json!("profile-tool"))
+        );
+        assert_eq!(
+            seen[0].get("runtime.approved"),
+            Some(&serde_json::json!(true))
+        );
     }
 
     #[tokio::test]

--- a/crates/choreo-core/src/entities/deliberation.rs
+++ b/crates/choreo-core/src/entities/deliberation.rs
@@ -219,6 +219,7 @@ impl Deliberation {
     /// - `Proposing -> Revising`: at least one proposal present.
     /// - `Validating -> Scoring`: every proposal has an outcome.
     /// - Other transitions are unconditional.
+    #[allow(unknown_lints, clippy::collapsible_match)] // collapsible_match added in clippy 1.95; rust 1.90 toolchain doesn't know it
     pub fn advance(&mut self) -> Result<DeliberationPhase, DomainError> {
         let next = self.phase.next().ok_or(DomainError::InvalidTransition {
             from: "Completed",

--- a/crates/choreo-core/src/entities/mod.rs
+++ b/crates/choreo-core/src/entities/mod.rs
@@ -17,5 +17,5 @@ pub use deliberation::{Deliberation, DeliberationPhase, RankedOutcome};
 pub use external_context::{ContextItem, ContextReference, ContextSummary, ExternalContextBundle};
 pub use proposal::Proposal;
 pub use statistics::Statistics;
-pub use task::{Task, TaskConstraints};
+pub use task::{Task, TaskConstraints, TaskMetadata};
 pub use validation::{ValidationOutcome, ValidatorReport};

--- a/crates/choreo-core/src/entities/task.rs
+++ b/crates/choreo-core/src/entities/task.rs
@@ -3,10 +3,14 @@
 use serde::{Deserialize, Serialize};
 
 use crate::entities::ExternalContextBundle;
+use crate::error::DomainError;
+use crate::events::EventEnvelope;
 use crate::value_objects::{
-    Attributes, DurationMs, NumAgents, OutputContract, Rounds, Rubric, Specialty, TaskDescription,
-    TaskId,
+    Attributes, DurationMs, EventId, NumAgents, OutputContract, Rounds, Rubric, Specialty,
+    TaskDescription, TaskId,
 };
+
+const MAX_METADATA_TEXT_LEN: usize = 128;
 
 /// The per-task configuration that shapes a deliberation.
 ///
@@ -94,6 +98,107 @@ pub struct Task {
     constraints: TaskConstraints,
     attributes: Attributes,
     external_context: Option<ExternalContextBundle>,
+    #[serde(default)]
+    metadata: TaskMetadata,
+}
+
+/// First-class metadata that travels with a task through deliberation,
+/// execution, and lifecycle events.
+///
+/// The fields are deliberately integration-neutral. Application-owned
+/// identifiers stay in `Task::attributes` or `ExternalContextBundle`
+/// metadata; the core only understands causality and Choreographer
+/// contract/execution hints.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct TaskMetadata {
+    source_event_id: Option<EventId>,
+    causation_id: Option<EventId>,
+    correlation_id: Option<EventId>,
+    council_contract_id: Option<String>,
+    output_contract_id: Option<String>,
+    execution_profile: Attributes,
+}
+
+impl TaskMetadata {
+    pub fn new(
+        source_event_id: Option<EventId>,
+        causation_id: Option<EventId>,
+        correlation_id: Option<EventId>,
+        council_contract_id: Option<String>,
+        output_contract_id: Option<String>,
+        execution_profile: Attributes,
+    ) -> Result<Self, DomainError> {
+        Ok(Self {
+            source_event_id,
+            causation_id,
+            correlation_id,
+            council_contract_id: validate_optional_text(
+                council_contract_id,
+                "task_metadata.council_contract_id",
+            )?,
+            output_contract_id: validate_optional_text(
+                output_contract_id,
+                "task_metadata.output_contract_id",
+            )?,
+            execution_profile,
+        })
+    }
+
+    #[must_use]
+    pub fn from_trigger_envelope(envelope: &EventEnvelope) -> Self {
+        Self::default().with_trigger_envelope(envelope)
+    }
+
+    #[must_use]
+    pub fn with_trigger_envelope(mut self, envelope: &EventEnvelope) -> Self {
+        if self.source_event_id.is_none() {
+            self.source_event_id = Some(envelope.event_id().clone());
+        }
+        if self.causation_id.is_none() {
+            self.causation_id = envelope
+                .causation_id()
+                .cloned()
+                .or_else(|| Some(envelope.event_id().clone()));
+        }
+        if self.correlation_id.is_none() {
+            self.correlation_id = envelope
+                .correlation_id()
+                .cloned()
+                .or_else(|| Some(envelope.event_id().clone()));
+        }
+        self
+    }
+
+    #[must_use]
+    pub fn source_event_id(&self) -> Option<&EventId> {
+        self.source_event_id.as_ref()
+    }
+
+    #[must_use]
+    pub fn causation_id(&self) -> Option<&EventId> {
+        self.causation_id.as_ref()
+    }
+
+    #[must_use]
+    pub fn correlation_id(&self) -> Option<&EventId> {
+        self.correlation_id.as_ref()
+    }
+
+    #[must_use]
+    pub fn council_contract_id(&self) -> Option<&str> {
+        self.council_contract_id.as_deref()
+    }
+
+    #[must_use]
+    pub fn output_contract_id(&self) -> Option<&str> {
+        self.output_contract_id.as_deref()
+    }
+
+    #[must_use]
+    pub fn execution_profile(&self) -> &Attributes {
+        &self.execution_profile
+    }
 }
 
 impl Task {
@@ -117,6 +222,27 @@ impl Task {
         attributes: Attributes,
         external_context: Option<ExternalContextBundle>,
     ) -> Self {
+        Self::new_with_metadata(
+            id,
+            specialty,
+            description,
+            constraints,
+            attributes,
+            external_context,
+            TaskMetadata::default(),
+        )
+    }
+
+    #[must_use]
+    pub fn new_with_metadata(
+        id: TaskId,
+        specialty: Specialty,
+        description: TaskDescription,
+        constraints: TaskConstraints,
+        attributes: Attributes,
+        external_context: Option<ExternalContextBundle>,
+        metadata: TaskMetadata,
+    ) -> Self {
         Self {
             id,
             specialty,
@@ -124,6 +250,7 @@ impl Task {
             constraints,
             attributes,
             external_context,
+            metadata,
         }
     }
 
@@ -152,6 +279,32 @@ impl Task {
     pub fn external_context(&self) -> Option<&ExternalContextBundle> {
         self.external_context.as_ref()
     }
+
+    #[must_use]
+    pub fn metadata(&self) -> &TaskMetadata {
+        &self.metadata
+    }
+}
+
+fn validate_optional_text(
+    value: Option<String>,
+    field: &'static str,
+) -> Result<Option<String>, DomainError> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    if trimmed.len() > MAX_METADATA_TEXT_LEN {
+        return Err(DomainError::FieldTooLong {
+            field,
+            actual: trimmed.len(),
+            max: MAX_METADATA_TEXT_LEN,
+        });
+    }
+    Ok(Some(trimmed.to_owned()))
 }
 
 #[cfg(test)]
@@ -185,6 +338,7 @@ mod tests {
         assert_eq!(t.description().as_str(), "investigate alert");
         assert!(t.attributes().is_empty());
         assert!(t.external_context().is_none());
+        assert_eq!(t.metadata(), &TaskMetadata::default());
     }
 
     #[test]
@@ -236,5 +390,26 @@ mod tests {
             TaskConstraints::default(),
             Attributes::empty(),
         );
+    }
+
+    #[test]
+    fn metadata_can_be_derived_from_trigger_envelope() {
+        use crate::value_objects::EventId;
+        use time::macros::datetime;
+
+        let envelope = EventEnvelope::new_with_causation(
+            EventId::new("trigger-1").unwrap(),
+            datetime!(2026-04-15 12:00:00 UTC),
+            "pir",
+            Some(EventId::new("corr-1").unwrap()),
+            Some(EventId::new("cause-1").unwrap()),
+        )
+        .unwrap();
+
+        let metadata = TaskMetadata::from_trigger_envelope(&envelope);
+
+        assert_eq!(metadata.source_event_id().unwrap().as_str(), "trigger-1");
+        assert_eq!(metadata.causation_id().unwrap().as_str(), "cause-1");
+        assert_eq!(metadata.correlation_id().unwrap().as_str(), "corr-1");
     }
 }

--- a/crates/choreo-core/src/events/envelope.rs
+++ b/crates/choreo-core/src/events/envelope.rs
@@ -18,6 +18,8 @@ pub struct EventEnvelope {
     source: String,
     #[serde(default)]
     correlation_id: Option<EventId>,
+    #[serde(default)]
+    causation_id: Option<EventId>,
 }
 
 impl EventEnvelope {
@@ -26,6 +28,16 @@ impl EventEnvelope {
         emitted_at: OffsetDateTime,
         source: impl Into<String>,
         correlation_id: Option<EventId>,
+    ) -> Result<Self, DomainError> {
+        Self::new_with_causation(event_id, emitted_at, source, correlation_id, None)
+    }
+
+    pub fn new_with_causation(
+        event_id: EventId,
+        emitted_at: OffsetDateTime,
+        source: impl Into<String>,
+        correlation_id: Option<EventId>,
+        causation_id: Option<EventId>,
     ) -> Result<Self, DomainError> {
         let source = source.into();
         let trimmed = source.trim();
@@ -46,6 +58,7 @@ impl EventEnvelope {
             emitted_at,
             source: trimmed.to_owned(),
             correlation_id,
+            causation_id,
         })
     }
 
@@ -64,6 +77,11 @@ impl EventEnvelope {
     #[must_use]
     pub fn correlation_id(&self) -> Option<&EventId> {
         self.correlation_id.as_ref()
+    }
+
+    #[must_use]
+    pub fn causation_id(&self) -> Option<&EventId> {
+        self.causation_id.as_ref()
     }
 }
 
@@ -110,16 +128,25 @@ mod tests {
     fn correlation_id_is_optional() {
         let env = EventEnvelope::new(EventId::new("e").unwrap(), at(), "s", None).unwrap();
         assert!(env.correlation_id().is_none());
+        assert!(env.causation_id().is_none());
     }
 
     #[test]
     fn accessors_return_fields() {
         let corr = EventId::new("c").unwrap();
-        let env = EventEnvelope::new(EventId::new("e").unwrap(), at(), "src", Some(corr.clone()))
-            .unwrap();
+        let cause = EventId::new("cause").unwrap();
+        let env = EventEnvelope::new_with_causation(
+            EventId::new("e").unwrap(),
+            at(),
+            "src",
+            Some(corr.clone()),
+            Some(cause.clone()),
+        )
+        .unwrap();
         assert_eq!(env.event_id().as_str(), "e");
         assert_eq!(env.emitted_at(), at());
         assert_eq!(env.correlation_id(), Some(&corr));
+        assert_eq!(env.causation_id(), Some(&cause));
     }
 
     #[test]
@@ -143,5 +170,6 @@ mod tests {
         assert!(obj.contains_key("emitted_at"));
         assert!(obj.contains_key("source"));
         assert!(obj.contains_key("correlation_id"));
+        assert!(obj.contains_key("causation_id"));
     }
 }

--- a/crates/choreo-e2e-runner/src/main.rs
+++ b/crates/choreo-e2e-runner/src/main.rs
@@ -64,6 +64,7 @@ async fn main() -> Result<()> {
                 constraints: None,
                 attributes: None,
                 external_context: None,
+                metadata: None,
             }),
         })
         .await

--- a/crates/choreo-proto/proto/underpass/choreo/v1/choreo.proto
+++ b/crates/choreo-proto/proto/underpass/choreo/v1/choreo.proto
@@ -114,6 +114,7 @@ message Task {
   Constraints constraints = 4;
   google.protobuf.Struct attributes = 5;
   ExternalContextBundle external_context = 6;
+  TaskMetadata metadata = 7;
 }
 
 // Constraints shape how the council deliberates.
@@ -179,6 +180,19 @@ message ContextReference {
   string title = 3;
   string media_type = 4;
   google.protobuf.Struct attributes = 5;
+}
+
+// Integration-neutral task metadata. Product/domain identifiers
+// belong in Task.attributes or ExternalContextBundle.metadata; the
+// choreographer only interprets causal ids and its own contract /
+// execution hints.
+message TaskMetadata {
+  string source_event_id = 1;
+  string causation_id = 2;
+  string correlation_id = 3;
+  string council_contract_id = 4;
+  string output_contract_id = 5;
+  google.protobuf.Struct execution_profile = 6;
 }
 
 // A single agent's output from one step of deliberation.
@@ -292,6 +306,8 @@ message TriggerEvent {
 
   google.protobuf.Struct payload = 8; // opaque domain data
   ExternalContextBundle external_context = 9;
+  string correlation_id = 10;
+  string causation_id = 11;
 }
 
 message ProcessTriggerEventRequest {

--- a/docs/agentic-conversation-ceremony-evaluation-research.md
+++ b/docs/agentic-conversation-ceremony-evaluation-research.md
@@ -1,0 +1,518 @@
+# Agentic Meeting Ceremony Evaluation Research
+
+Status: research and design proposal. This document is not an implementation
+claim.
+
+Date: 2026-04-26
+
+## Scope
+
+We want to evaluate whether a designed agentic meeting ceremony is a good fit
+for a given problem. The design must use Choreographer as a
+domain-agnostic conversation orchestrator. Product vocabulary, domain facts, and
+application-owned identifiers must stay at the edge through task attributes,
+external context metadata, output contracts, kernel graph data, or runtime
+session metadata.
+
+Code reviewed locally:
+
+- Current repo: `/home/tirso/ai/developents/underpass-orchestrator`.
+- Downloaded runtime repo: `/tmp/underpass-agentic-research/underpass-runtime`.
+- Downloaded kernel repo: `/tmp/underpass-agentic-research/rehydration-kernel`.
+
+Detailed meeting blueprints live in
+`docs/agentic-meeting-ceremony-blueprints.md`.
+
+## Vision: Real-World-Like Agentic Meetings
+
+The target abstraction is closer to a real meeting than to a free-form chat.
+Agents should meet with an agenda, explicit roles, evidence requests, minutes,
+decisions, dissent, assumptions, and action items. Claims made inside the
+meeting should be treated as unverified until they are backed by evidence from
+kernel context, runtime tool results, artifacts, or approved external inputs.
+
+This gives us three complementary planes:
+
+- Choreographer is the neutral meeting facilitator. It controls phases,
+  participants, turn policy, critique/revision/scoring, and trace emission
+  without knowing the product domain.
+- Rehydration Kernel is the scenario memory plane. It can recreate past
+  situations by rendering causally meaningful context from stored graph state.
+  For future planning, the application can materialize hypothetical scenario
+  graphs or branches and ask the kernel to render them with the same evidence
+  discipline.
+- Underpass Runtime, reached through the runtime client, is the governed tool
+  and action plane. It lets the meeting validate claims, inspect systems, run
+  checks, produce artifacts, and record policy denials or approvals as
+  first-class evidence.
+
+The evaluator should therefore judge not only the final answer, but the meeting
+quality: whether the right agenda was selected, whether claims were validated,
+whether past context was reconstructed faithfully, whether future scenarios were
+planned with explicit assumptions, and whether resulting decisions are
+traceable to evidence.
+
+Important distinction: the kernel does not need to predict the future. Future
+planning should be modeled as explicit hypothetical graph construction and
+evaluation. The meeting owns assumptions and scenario branches; the kernel
+renders and preserves them; runtime-client tools validate whatever can be
+validated.
+
+## Design Stance: Adapter-Agnostic, Sibling-Optimized
+
+The medium-term goal is a generic Choreographer that is usable outside the
+Underpass stack. The contracts must therefore stay adapter-agnostic: no kernel
+types, runtime tool names, Kubernetes terms, or product vocabulary should leak
+into the core meeting model.
+
+At the same time, the first meeting designs should be optimized for our sibling
+systems because that is where the strongest evidence loop exists today:
+
+- Rehydration Kernel gives us past-scenario replay, causal context, evidence
+  packs, relation explanations, content hashes, quality metrics, and
+  hypothetical scenario branches supplied by the application.
+- Underpass Runtime gives us governed tool discovery, recommendations,
+  invocations, policy decisions, denials, approvals, logs, artifacts, quality
+  metrics, and learning evidence.
+
+The design rule is:
+
+- Core contracts describe capabilities, not products: `context_provider`,
+  `scenario_provider`, `tool_runtime`, `evidence_source`, `artifact_source`,
+  `policy_evaluator`, and `trace_sink`.
+- Underpass adapters bind those generic capabilities to the kernel and runtime
+  client.
+- Meeting types may require capability classes such as replay, scenario
+  branching, governed invocation, artifact capture, or policy validation, but
+  they must not require a concrete implementation.
+- The first reference implementations should use kernel + runtime client as the
+  default high-power backend.
+
+This keeps the architecture honest: generic by contract, Underpass-native by
+initial deployment.
+
+## Local Evidence
+
+### Choreographer
+
+Choreographer is currently a domain-agnostic deliberation engine.
+
+- `docs/PRINCIPLES.md` states that core/protocol/specs must avoid use-case
+  vocabulary. Domain terms belong in `attributes` or external context.
+- `crates/choreo-core/src/ports/agent.rs` exposes only generic agent actions:
+  `generate`, `critique`, and `revise`.
+- `crates/choreo-app/src/usecases/deliberate.rs` implements a generic ceremony:
+  propose, peer critique, revise, validate, score, complete.
+- `crates/choreo-app/src/usecases/orchestrate.rs` composes deliberation with an
+  executor and carries generic execution options.
+- `crates/choreo-core/src/entities/task.rs` now carries `TaskMetadata` for
+  causal IDs and execution profile, while application-owned IDs remain in
+  `Task.attributes` or `ExternalContextBundle.metadata`.
+- `crates/choreo-core/src/entities/external_context.rs` provides bounded,
+  typed-but-caller-owned context items, references, summaries, and metadata.
+- `crates/choreo-adapters/src/agents/prompts.rs` keeps system prompts neutral
+  and tests against domain-vocabulary leaks.
+
+Implication: meeting ceremonies can be represented as orchestration
+patterns, but not as product workflows embedded in the core.
+
+### Rehydration Kernel
+
+The kernel is the evidence memory and context rehydration plane.
+
+- `crates/rehydration-domain/src/value_objects/relation_semantic_class.rs`
+  defines semantic relation classes: structural, causal, motivational,
+  procedural, evidential, and constraint.
+- `crates/rehydration-domain/src/value_objects/relation_explanation.rs`
+  captures why a relationship exists: rationale, motivation, method, evidence,
+  confidence, sequence, and related decision/cause IDs.
+- `crates/rehydration-domain/src/value_objects/rehydration_mode.rs` defines
+  modes such as `ResumeFocused` and `ReasonPreserving`.
+- `crates/rehydration-domain/src/value_objects/resolution_tier.rs` defines L0,
+  L1, and L2 tiers, which map well to summary, causal spine, and evidence pack.
+- `crates/rehydration-domain/src/value_objects/bundle_quality_metrics.rs`
+  computes raw-equivalent tokens, compression ratio, causal density, noise
+  ratio, and detail coverage.
+- `crates/application/src/queries/get_context.rs` and related renderers return
+  a rendered context with content hash, selected mode, tiers, truncation, and
+  quality metrics.
+- `crates/rehydration-testkit/src/llm_graph.rs` validates `GraphBatch`:
+  unique nodes, reachable root, valid relation endpoints, and richer evidence
+  requirements for non-structural relations.
+- `crates/transport-grpc/src/agentic_reference/basic_context_agent.rs` shows an
+  agent using kernel context to drive runtime actions through a generic
+  runtime contract.
+
+Important caveat: `context.bundle.generated` is documented in the kernel
+AsyncAPI and test fixtures, but `docs/beta-status.md` says it is contract-only
+today and not emitted by the kernel runtime yet. Evaluations should therefore
+prefer explicit `GetContext` calls and captured render metadata until that event
+is implemented.
+
+### Underpass Runtime
+
+The runtime is the governed action and execution-evidence plane.
+
+- `internal/domain/session.go` models sessions with workspace, runtime
+  reference, allowed paths, principal, and metadata.
+- `internal/domain/capability.go` models tools with schemas, scope, side
+  effects, risk, approval requirements, policy metadata, observability, and
+  examples.
+- `internal/domain/invocation.go` models invocation status, correlation ID,
+  timing, output, logs, artifacts, and errors.
+- `internal/app/service.go` implements session creation, tool discovery,
+  invocation, authorization, artifact persistence, event publication, quality
+  observation, and learning telemetry.
+- `internal/app/recommender.go` implements `RecommendTools`, persists
+  recommendation decisions, emits learning events, and tracks cross-agent
+  insight.
+- `internal/domain/quality_metrics.go` gives invocation quality signals such
+  as status, duration, exit code, output size, error code, and latency bucket.
+- `internal/adapters/policy/static_policy.go` enforces roles, risk, approvals,
+  allowed paths, subject/topic/queue/key-prefix constraints, namespaces,
+  registries, and profiles.
+- `specs/underpass/runtime/learning/v1/learning.proto` carries learning
+  evidence facts with correlation and causation IDs.
+- `e2e/tests/10-llm-agent-loop` validates an LLM conversation loop over tool
+  discovery and invocation.
+- `e2e/tests/12-event-driven-agent` validates event-driven activation,
+  governed tool use, and result publication.
+- `e2e/tests/13-multi-agent-pipeline` validates a concrete multi-agent
+  pipeline ceremony over a shared runtime session.
+
+Implication: the runtime gives objective evidence about what the conversation
+actually did, what was denied, what artifacts were produced, and whether tool
+recommendations or policies shaped the trajectory.
+
+## External Patterns
+
+The web/research baseline suggests these reusable ceremony archetypes:
+
+| Ceremony archetype | Shape | External evidence | Local fit |
+| --- | --- | --- | --- |
+| Solo refinement | draft -> self-feedback -> revise -> validate | Self-Refine: <https://arxiv.org/abs/2303.17651>; Reflexion: <https://arxiv.org/abs/2303.11366> | Single-agent Choreographer council or runtime loop with reflection memory from kernel |
+| Peer-review council | parallel proposals -> peer critique -> revision -> score | AutoGen multi-agent conversations: <https://arxiv.org/abs/2308.08155> | Current Choreographer `DeliberateUseCase` |
+| Adversarial debate | independent answers -> debate rounds -> judge | Multiagent debate: <https://arxiv.org/abs/2305.14325> | Add debate phase policy above generic agent ports |
+| Role-play pair | role-constrained assistant/user agents cooperate | CAMEL role playing: <https://arxiv.org/abs/2303.17760> | Role descriptions in council/agent descriptors, still generic |
+| Selector group chat | shared thread, next speaker selected by manager/model | AutoGen conversation patterns: <https://autogenhub.github.io/autogen/docs/tutorial/conversation-patterns/> | Requires turn-level trace and speaker-selection policy |
+| Supervisor/router | central supervisor delegates to specialists | LangChain multi-agent docs: <https://docs.langchain.com/oss/python/langchain/multi-agent/index> | App-layer shell can route between Choreographer, kernel, and runtime |
+| SOP pipeline | ordered roles with structured handoffs | MetaGPT SOPs: <https://arxiv.org/abs/2308.00352>; ChatDev chat chain: <https://arxiv.org/abs/2307.07924> | Runtime e2e `13-multi-agent-pipeline`, but domain-specific roles stay outside Choreographer |
+| Social/memory simulation | agents remember, reflect, plan, and interact over time | Generative Agents: <https://arxiv.org/abs/2304.03442> | Kernel provides durable context; runtime provides action evidence |
+| Governed execution board | agents must acquire evidence before conclusions/actions | AgentBench interactive evals: <https://arxiv.org/abs/2308.03688>; GAIA tool-use tasks: <https://arxiv.org/abs/2311.12983> | Kernel + runtime evidence gates before scoring |
+| Agent-as-judge | evaluator inspects intermediate trajectory, not only output | Agent-as-a-Judge: <https://arxiv.org/abs/2410.10934>; MT-Bench LLM judge caveats: <https://arxiv.org/abs/2306.05685> | Evaluator should combine deterministic checks with bounded LLM judging |
+
+## Agentic Meeting Types
+
+Meeting types are product-agnostic templates. They should define the shape of
+the meeting, not the vocabulary of the application that uses it. A consuming
+application can bind domain data into `ProblemSpec`, `ExternalContextBundle`,
+`Task.attributes`, runtime session metadata, or kernel graph nodes without
+changing these contracts.
+
+### Meeting Type Contract
+
+Every meeting type should be describable with the same neutral contract:
+
+- `meeting_type`: stable generic identifier.
+- `purpose`: why this meeting exists.
+- `agenda_template`: ordered generic agenda items.
+- `role_slots`: facilitator, proposer, challenger, evidence reviewer,
+  operator, recorder, judge, or observer.
+- `context_policy`: required context capability, max detail tier, focus
+  strategy, replay requirements, and scenario-branch requirements. Underpass
+  binds this to the kernel.
+- `tool_policy`: allowed tool capability families, recommendation use,
+  approval mode, max risk, side-effect budget, and artifact requirements.
+  Underpass binds this to the runtime client.
+- `claim_policy`: which claims require evidence, which may remain assumptions,
+  and what hard gates apply to unsupported claims.
+- `decision_policy`: how decisions are accepted, rejected, deferred,
+  escalated, or split into action items.
+- `output_contracts`: required generic outputs such as `MeetingMinutes`,
+  `ClaimLedger`, `DecisionRecord`, `ScenarioBranch`, `ActionItem`, and
+  `EvaluationScorecard`.
+- `evaluation_focus`: which scoring dimensions matter most for this meeting.
+
+### Catalog
+
+| Meeting type | Purpose | Kernel leverage | Runtime client leverage | Required outputs |
+| --- | --- | --- | --- | --- |
+| Intake meeting | Frame an ambiguous problem and decide the next ceremony | Retrieve compact context and prior related state with L0/L1 focus | Discover available evidence tools and low-risk read-only checks | `MeetingMinutes`, `ProblemFrame`, `EvidenceRequest`, `NextCeremonyDecision` |
+| Evidence review meeting | Verify or reject important claims before a decision | Render evidence packs, relation explanations, provenance, and content hashes | Run validation tools, collect artifacts, record denials and failures | `ClaimLedger`, `EvidenceBundleRef`, `UnresolvedQuestion`, `ValidationReport` |
+| Past replay meeting | Reconstruct what happened in a previous scenario | Use reason-preserving replay, causal spine, temporal context, and known evidence | Pull logs, metrics, files, prior outputs, or other read-only artifacts | `ReplayTimeline`, `CausalPath`, `ClaimLedger`, `KnownUnknowns` |
+| Future scenario planning meeting | Plan possible future branches with explicit assumptions | Render hypothetical scenario graphs or branches supplied by the application | Run simulations, dry runs, policy checks, cost checks, or feasibility probes | `ScenarioBranch`, `AssumptionLedger`, `RiskRegister`, `DecisionOptions` |
+| Decision council | Choose among competing options under evidence and constraints | Compare context bundles for each option and preserve rationale/evidence | Validate feasibility and side effects for candidate actions | `DecisionRecord`, `DissentRecord`, `TradeoffMatrix`, `ActionItem` |
+| Design review meeting | Challenge a proposed plan before implementation or execution | Retrieve prior decisions, constraints, causal dependencies, and evidence | Run static checks, compatibility checks, test probes, or policy checks | `ReviewFinding`, `ClaimLedger`, `RevisionRequest`, `ApprovalDecision` |
+| Red-team meeting | Stress-test assumptions, safety, and failure modes | Retrieve similar failures, constraints, weak signals, and distractors | Execute safe probes and policy simulations; record blocked actions | `RiskRegister`, `AttackPath`, `MitigationPlan`, `DeniedActionRecord` |
+| Production incident resolution meeting | Investigate a production software incident and decide a safe corrective path | Replay recent context, causal spine, prior similar scenarios, and candidate remediation branches | Run governed diagnostics, read-only inspection, tests, policy checks, dry runs, and artifact capture | `IncidentAnalysis`, `ReplayTimeline`, `ClaimLedger`, `RemediationOption`, `DecisionRecord`, `RollbackPlanRef` |
+| Execution readiness meeting | Decide go/no-go before a governed action | Render current state, blockers, dependencies, and required evidence | Verify approvals, environment state, tool availability, and dry-run artifacts | `ReadinessChecklist`, `GoNoGoDecision`, `ActionPlan`, `RollbackPlanRef` |
+| Live coordination meeting | Coordinate multi-step work while evidence changes | Refresh focused context between phases and preserve causal continuity | Invoke governed tools, capture artifacts, update claim status after each step | `PhaseLog`, `ClaimLedger`, `ArtifactIndex`, `ActionItem` |
+| Post-action learning meeting | Learn from an executed action and update future behavior | Rehydrate before/after context and preserve causal deltas | Analyze invocation quality, artifacts, recommendation decisions, and failures | `LearningRecord`, `OutcomeAssessment`, `UpdatedAssumption`, `FollowupAction` |
+| Escalation/handoff meeting | Transfer context and decisions to another actor or system | Render resume-focused context with causal spine and unresolved evidence | Package artifacts, invocation refs, policy state, and pending approvals | `HandoffBrief`, `OpenDecision`, `EvidenceBundleRef`, `ResponsibilityMap` |
+
+### Type Selection Heuristics
+
+The evaluator should also judge whether the selected meeting type fits the
+problem:
+
+- Choose `Intake meeting` when the problem is under-specified or the right
+  evidence path is unknown.
+- Choose `Evidence review meeting` when the risk is mainly unsupported claims.
+- Choose `Past replay meeting` when correctness depends on reconstructing a
+  prior scenario.
+- Choose `Future scenario planning meeting` when the task is about options,
+  branches, assumptions, and consequences.
+- Choose `Decision council` when there are multiple viable options and
+  tradeoffs matter.
+- Choose `Design review meeting` when there is already a proposal that needs
+  critique before action.
+- Choose `Red-team meeting` when safety, adversarial behavior, or hidden
+  failure modes dominate.
+- Choose `Production incident resolution meeting` when a production software
+  incident needs evidence-backed diagnosis, remediation choice, and risk-aware
+  action planning.
+- Choose `Execution readiness meeting` when a governed action is imminent.
+- Choose `Live coordination meeting` when the meeting must interleave reasoning
+  and runtime actions.
+- Choose `Post-action learning meeting` after action completion or failure.
+- Choose `Escalation/handoff meeting` when responsibility moves across
+  boundaries.
+
+### Why Kernel And Runtime Client Matter
+
+Without the kernel, these meetings degrade into short-context discussion. They
+can still deliberate, but they cannot reliably recreate prior scenarios,
+preserve causal paths, compare branches, or prove what evidence was available
+at decision time.
+
+Without the runtime client, these meetings degrade into unsupported reasoning.
+They can make hypotheses, but they cannot validate claims through governed
+tools, produce artifacts, observe denials, or prove that an action was feasible
+and policy-compliant.
+
+The intended product is the combination: a meeting ceremony that can replay
+past context, construct future scenario branches, validate claims with tools,
+and emit an auditable decision trail.
+
+## Proposed Evaluation Model
+
+### ProblemSpec
+
+`ProblemSpec` describes the problem without assuming a particular ceremony:
+
+- `problem_id`: stable identifier.
+- `prompt`: the problem statement.
+- `constraints`: budget, latency, safety, tool, and output constraints.
+- `success_criteria`: objective assertions and qualitative rubrics.
+- `required_evidence`: kernel nodes, relation classes, runtime artifacts, or
+  external references that must support the final answer.
+- `risk_budget`: maximum allowed side effects, approval requirements, and
+  policy-denial expectations.
+- `ground_truth`: optional expected answer, expected failure point, expected
+  causal path, or known distractors.
+- `domain_metadata`: application-owned data passed through generic metadata.
+
+### CeremonySpec
+
+`CeremonySpec` describes how agents should talk and act:
+
+- `ceremony_id`: stable identifier.
+- `roles`: generic participant descriptors, specialties, tool permissions, and
+  context needs.
+- `phases`: ordered or dynamic phases.
+- `turn_policy`: parallel, round-robin, selector, supervisor, debate,
+  pipeline, or bounded reflection.
+- `evidence_policy`: when kernel context is mandatory, which rehydration mode
+  to request, max tier, and required provenance.
+- `runtime_policy`: which tool families are allowed, approval stance, risk
+  ceiling, and artifact requirements.
+- `output_contract`: schema and contract ID for final answer.
+- `stop_criteria`: convergence, validator pass, token budget, time budget, max
+  rounds, or judge confidence.
+
+### PhaseSpec
+
+Each phase should be inspectable:
+
+- `phase_id`: stable generic phase name.
+- `mode`: parallel, gated, pipeline, debate, reflection, or selector.
+- `participants`: roles allowed in the phase.
+- `inputs`: previous phase outputs, kernel context bundles, runtime artifacts,
+  and external context.
+- `allowed_actions`: generate, critique, revise, validate, score, query
+  context, recommend tools, invoke tool.
+- `validators`: deterministic contract validators and optional judge rubrics.
+- `exit_conditions`: completion, revision required, escalation, or abort.
+
+### RunTrace
+
+The evaluator needs a full trace, not only the final answer:
+
+- Choreographer events: event ID, correlation ID, causation ID, task ID,
+  phase transitions, proposals, critiques, revisions, validations, scores, and
+  final output.
+- Kernel context: root/focus node IDs, rendered content hash, mode, tiers,
+  token count, truncation, quality metrics, relation classes, and references.
+- Runtime evidence: session ID, capability discovery, recommendations,
+  invocations, policy denials, approvals, artifacts, logs, outputs, errors, and
+  quality metrics.
+- Conversation transcript: speaker, phase, input references, output references,
+  evidence references, tool references, and timestamp.
+- Claim ledger: every important claim, its status, supporting evidence,
+  opposing evidence, assumptions, validation method, and owner.
+- Meeting minutes: agenda, attendees/roles, decisions, dissent, unresolved
+  questions, action items, deadlines, and escalation points.
+- Scenario branches: reconstructed past scenario IDs, hypothetical future
+  scenario IDs, assumptions, confidence, and validation status.
+- Evaluation artifacts: deterministic check results, judge prompts, judge
+  outputs, score components, failure taxonomy, and baselines compared.
+
+Current gap: Choreographer has domain events and proposals, but it does not yet
+persist an explicit turn-level transcript, claim ledger, meeting minutes, or
+scenario branch references. That is the main instrumentation gap before serious
+ceremony evaluation.
+
+## Evaluation Dimensions
+
+| Dimension | What it checks | Evidence source |
+| --- | --- | --- |
+| Problem fit | Ceremony matches problem uncertainty, decomposition, risk, and need for evidence | `ProblemSpec`, `CeremonySpec`, baseline comparisons |
+| Meeting fidelity | Agenda, roles, minutes, dissent, decisions, and action items are explicit | Transcript, meeting minutes, phase trace |
+| Evidence fidelity | Final output cites required evidence and avoids unsupported claims | Kernel rendered context, content hash, relation explanations, references |
+| Claim validation | Important claims are verified, rejected, or marked as assumptions | Claim ledger, runtime tool results, kernel references |
+| Past replay | Reconstructed context preserves causal path, evidence, and known history | Kernel context, relation explanations, ground truth |
+| Future planning | Future scenarios include explicit assumptions, branches, risks, and validation steps | Scenario branches, runtime checks, evaluator rubrics |
+| Process integrity | Phases, turn policy, critique/revision loops, and stop criteria were followed | Choreographer events and transcript |
+| Runtime governance | Tool use respected policies, approvals, side-effect budget, and denials | Runtime invocations, policy decisions, artifacts |
+| Output correctness | Final output satisfies contract, task constraints, and success criteria | Validators, ground truth, LLM judge when needed |
+| Traceability | Claims map to proposal, context, invocation, artifact, or validation evidence | Correlation/causation IDs, references, artifacts |
+| Efficiency | Token, latency, tool count, cost, context compression, and retries are acceptable | Choreographer timing, kernel metrics, runtime quality metrics |
+| Robustness | Ceremony survives noise, missing context, alternate budgets, and ablations | Re-run matrix and perturbation tests |
+| Safety | No fabricated evidence, unauthorized actions, hidden side effects, or ignored denials | Runtime policy, kernel provenance, evaluator checks |
+
+## Scoring Proposal
+
+Default score: 100 points.
+
+| Component | Weight |
+| --- | ---: |
+| Evidence fidelity and claim validation | 20 |
+| Output correctness and contract validity | 15 |
+| Meeting fidelity and process integrity | 15 |
+| Past replay and future scenario quality | 15 |
+| Runtime governance | 15 |
+| Traceability | 10 |
+| Robustness and ablation performance | 5 |
+| Efficiency | 5 |
+
+Hard gates:
+
+- Invalid final output contract caps score at 40.
+- Missing required evidence caps score at 60.
+- Hallucinated evidence caps score at 50.
+- High-impact claim left unverified and unmarked as an assumption caps score at
+  60.
+- Future plan without explicit assumptions caps score at 70.
+- Past replay that omits known causal evidence caps score at 70.
+- Policy-denied action treated as success caps score at 30.
+- Unauthorized high-risk side effect fails the run.
+- Unavailable or unverifiable trace fails the evaluation, not necessarily the
+  ceremony. The evaluator must distinguish product failure from observability
+  failure.
+
+## Evaluation Algorithm
+
+1. Load or generate a `ProblemSpec`.
+2. Materialize known evidence into the kernel using projection events or
+   `GraphBatch` fixtures.
+3. Create a runtime session with explicit principal, allowed paths, tool
+   profile, and metadata.
+4. Run the candidate `CeremonySpec` through an app-layer shell that calls
+   Choreographer, kernel, and runtime through adapters.
+5. Capture `RunTrace` with Choreographer events, kernel render metadata,
+   runtime invocations, artifacts, transcript entries, and correlation IDs.
+6. Extract the meeting minutes, claim ledger, decisions, unresolved questions,
+   action items, and scenario branches.
+7. Run deterministic validators first: schema, required evidence, phase order,
+   allowed tools, policy compliance, artifact presence, claim evidence status,
+   and scenario assumption completeness.
+8. Run bounded LLM judging only for qualitative deltas: critique usefulness,
+   meeting quality, reasoning quality, completeness, and problem-fit rationale.
+   Judge prompts must include the evidence bundle and must not see unsupported
+   hidden data.
+9. Compare against baselines: direct single agent, Choreographer peer-review
+   without kernel, peer-review with kernel, debate, and SOP pipeline.
+10. Emit a scorecard, hard-gate status, failure taxonomy, and ceremony
+   improvement recommendations.
+
+## Architecture Implications
+
+- Choreographer remains the ceremony orchestrator. It should not know kernel
+  graph semantics, runtime tool catalogs, Kubernetes, or product nouns.
+- A thin app-layer integration shell should map concrete provider evidence into
+  `ExternalContextBundle`, `Task.attributes`, and generic output contracts.
+- In the Underpass deployment, that shell should bind context/scenario
+  capabilities to the kernel and tool/action capabilities to the runtime
+  client.
+- The kernel is our first context/evidence provider. It should not decide which
+  ceremony is correct.
+- The runtime client is our first governed action provider. It should not
+  become hidden memory or unrestricted tool access.
+- Evaluation should be a separate bounded component that consumes traces from
+  all three systems.
+- Kubernetes jobs in namespace `underpass-runtime` are the right place for
+  end-to-end evaluator runs once the offline evaluator is stable.
+
+## Recommended Implementation Slices
+
+1. Freeze the initial meeting-type catalog as documentation: intake, evidence
+   review, past replay, future scenario planning, decision council, design
+   review, red-team, production incident resolution, execution readiness, live
+   coordination, post-action learning, and handoff.
+2. Add schema docs for `ProblemSpec`, `CeremonySpec`, `RunTrace`, and
+   `EvaluationSpec`.
+3. Add meeting-oriented schema docs for agenda, minutes, claim ledger,
+   decisions, action items, and scenario branches.
+4. Add turn-level trace/evidence-reference instrumentation to Choreographer
+   using domain-agnostic names only.
+5. Build an offline evaluator over fixtures from `rehydration-kernel` testkit
+   and `underpass-runtime` e2e artifacts.
+6. Add deterministic validators for contract validity, phase order, required
+   evidence, claim validation, scenario assumptions, runtime policy compliance,
+   and trace completeness.
+7. Add a bounded LLM judge only after deterministic checks exist.
+8. Add baseline ceremony runners: direct, peer-review, peer-review+kernel,
+   debate, and SOP pipeline.
+9. Promote the evaluator to a Kubernetes Job in namespace `underpass-runtime`
+   after offline fixtures are stable.
+
+## Open Design Questions
+
+- Should `CeremonySpec` live as a versioned YAML/JSON schema first, or as Rust
+  value objects in Choreographer with adapters later?
+- Do we need a new Choreographer `ConversationTrace` aggregate, or should trace
+  be an observer/adaptor concern?
+- How strict should evidence citation be: every final claim, every decision,
+  or only claims marked as high risk by the problem spec?
+- Should runtime recommendation decisions count as evidence of process quality,
+  or only as explanatory metadata?
+- Should kernel `context.bundle.generated` be implemented before the evaluator
+  leaves offline mode?
+
+## Source Links
+
+- AutoGen multi-agent conversation framework: <https://arxiv.org/abs/2308.08155>
+- AutoGen conversation patterns docs: <https://autogenhub.github.io/autogen/docs/tutorial/conversation-patterns/>
+- CAMEL role-playing communicative agents: <https://arxiv.org/abs/2303.17760>
+- MetaGPT SOP-based multi-agent collaboration: <https://arxiv.org/abs/2308.00352>
+- ChatDev chat-chain software development agents: <https://arxiv.org/abs/2307.07924>
+- Multiagent debate: <https://arxiv.org/abs/2305.14325>
+- Self-Refine: <https://arxiv.org/abs/2303.17651>
+- Reflexion: <https://arxiv.org/abs/2303.11366>
+- Generative Agents: <https://arxiv.org/abs/2304.03442>
+- AgentBench: <https://arxiv.org/abs/2308.03688>
+- GAIA: <https://arxiv.org/abs/2311.12983>
+- LLM-as-a-judge with MT-Bench and Chatbot Arena: <https://arxiv.org/abs/2306.05685>
+- Agent-as-a-Judge: <https://arxiv.org/abs/2410.10934>
+- LangChain multi-agent docs: <https://docs.langchain.com/oss/python/langchain/multi-agent/index>
+- CrewAI process docs: <https://docs.crewai.com/en/concepts/processes>

--- a/docs/agentic-meeting-ceremony-blueprints.md
+++ b/docs/agentic-meeting-ceremony-blueprints.md
@@ -1,0 +1,743 @@
+# Agentic Meeting Ceremony Blueprints
+
+Status: initial blueprint catalog. These are product-agnostic meeting designs
+optimized for the Underpass sibling capabilities: rehydration kernel as the
+context/scenario provider and runtime client as the governed tool runtime.
+
+Date: 2026-04-26
+
+Related research: `docs/agentic-conversation-ceremony-evaluation-research.md`.
+
+## Design Goal
+
+A meeting should produce a better result than a single agent by forcing the
+system to:
+
+- reconstruct relevant past context before deciding;
+- state assumptions before planning future scenarios;
+- validate important claims with evidence;
+- use governed tools instead of unsupported reasoning;
+- preserve dissent and unresolved questions;
+- emit auditable decisions and action items.
+
+Contracts stay generic. A meeting may require `context.replay`,
+`context.evidence_pack`, `scenario.branching`, `tool.discovery`,
+`tool.invocation`, `artifact.capture`, or `policy.validation`, but it must not
+require concrete kernel or runtime types. Underpass adapters bind those
+capabilities to the kernel and runtime client.
+
+## Common Output Objects
+
+These names are generic and can be represented as JSON/YAML contracts later.
+
+- `MeetingMinutes`: agenda, participants, phase log, decisions, dissent,
+  unresolved questions, action items, and timestamps.
+- `ClaimLedger`: claim ID, speaker, status, evidence refs, opposing evidence,
+  assumptions, validation method, confidence, and owner.
+- `EvidenceBundleRef`: provider, query/focus, content hash, rendered mode,
+  tier, token count, references, and quality metrics.
+- `DecisionRecord`: options considered, selected option, rationale, evidence
+  refs, dissent, constraints, risks, and follow-up actions.
+- `ScenarioBranch`: branch ID, parent scenario, assumptions, expected effects,
+  risks, validation status, and evidence refs.
+- `ActionItem`: owner, action, preconditions, tool/action refs, due state,
+  approval state, and rollback or escalation hint.
+- `EvaluationScorecard`: hard gates, weighted scores, missing evidence,
+  process violations, and improvement recommendations.
+
+## Shared Meeting Phases
+
+Meeting blueprints compose these generic phases:
+
+- `prepare`: load problem, constraints, prior context, and output contracts.
+- `frame`: agree what question the meeting must answer.
+- `rehydrate`: request past/context evidence from a context provider.
+- `branch`: construct future or alternative scenario branches.
+- `propose`: produce candidate answers, options, or plans.
+- `challenge`: critique claims, assumptions, omissions, and risks.
+- `validate`: call governed tools through a tool runtime and attach artifacts.
+- `revise`: update proposals and claim status based on evidence.
+- `decide`: accept, reject, defer, escalate, or split decisions.
+- `record`: emit minutes, ledgers, decisions, artifacts, and next actions.
+- `evaluate`: score meeting quality and identify missing evidence.
+
+## Meeting Blueprints
+
+### 1. Intake Meeting
+
+Purpose: turn an ambiguous request into a framed problem and select the next
+meeting type.
+
+Best when: the input is under-specified, evidence paths are unclear, or the
+system must avoid jumping into execution.
+
+Quality hypothesis: result quality improves when the system first separates
+the problem, missing evidence, constraints, risk level, and suitable ceremony.
+
+Roles:
+
+- `facilitator`: keeps the agenda bounded.
+- `problem-framer`: rewrites the problem in neutral terms.
+- `evidence-scout`: identifies missing context and evidence needs.
+- `operator`: discovers available tool capabilities.
+- `recorder`: emits the frame and next meeting recommendation.
+
+Phases:
+
+1. `prepare`: load prompt, constraints, and any provided external context.
+2. `rehydrate`: request compact related context using L0/L1 focus.
+3. `validate`: discover low-risk read-only tool families through the tool
+   runtime.
+4. `frame`: produce `ProblemFrame`, open questions, and risk budget.
+5. `decide`: choose the next meeting type and required evidence.
+6. `record`: emit minutes and evidence requests.
+
+Context policy:
+
+- Requires `context.summary` and optional `context.causal_spine`.
+- Prefer compact mode; do not request full evidence packs unless risk is high.
+
+Tool policy:
+
+- Allows `tool.discovery` and low-risk read-only probes only.
+- No side-effecting actions.
+
+Required outputs:
+
+- `MeetingMinutes`
+- `ProblemFrame`
+- `EvidenceRequest`
+- `NextCeremonyDecision`
+
+Hard gates:
+
+- Fails if it recommends an execution meeting while high-impact claims are
+  still unframed.
+- Caps score at 70 if no evidence path is proposed.
+
+### 2. Evidence Review Meeting
+
+Purpose: verify, reject, or mark as assumption the claims that matter for a
+decision.
+
+Best when: the main risk is hallucination, weak evidence, or hidden
+unsupported assumptions.
+
+Quality hypothesis: result quality improves when every high-impact claim has
+evidence status before decisions are made.
+
+Roles:
+
+- `claim-owner`: states candidate claims.
+- `evidence-reviewer`: maps claims to evidence.
+- `challenger`: searches for contradictions and missing context.
+- `operator`: validates claims with governed tools.
+- `judge`: decides claim status.
+- `recorder`: maintains the claim ledger.
+
+Phases:
+
+1. `prepare`: load claims, criteria, and risk budget.
+2. `rehydrate`: request evidence packs and relation explanations.
+3. `challenge`: identify unsupported, ambiguous, or conflicting claims.
+4. `validate`: run governed checks and attach artifacts.
+5. `revise`: update claim wording and confidence.
+6. `decide`: mark each claim as verified, rejected, assumption, or unresolved.
+7. `record`: emit claim ledger and validation report.
+
+Context policy:
+
+- Requires `context.evidence_pack`, provenance, content hash, and relation
+  explanations.
+- Prefer reason-preserving mode for high-risk claims.
+
+Tool policy:
+
+- Allows read-only validation and bounded diagnostic tools.
+- Requires artifacts for successful validation.
+- Policy denials must be recorded as evidence, not hidden.
+
+Required outputs:
+
+- `ClaimLedger`
+- `EvidenceBundleRef`
+- `ValidationReport`
+- `UnresolvedQuestion`
+
+Hard gates:
+
+- Fails if a high-impact claim is accepted without evidence.
+- Caps score at 50 if evidence refs cannot be traced to a provider output.
+
+### 3. Past Replay Meeting
+
+Purpose: reconstruct a past scenario with causal continuity and known evidence.
+
+Best when: correctness depends on understanding what happened before, why it
+happened, and what evidence was available at the time.
+
+Quality hypothesis: result quality improves when the meeting starts from a
+replayed causal context rather than a fresh short-context summary.
+
+Roles:
+
+- `timeline-builder`: reconstructs sequence.
+- `causal-analyst`: identifies causal and constraint relations.
+- `evidence-reviewer`: checks provenance and missing facts.
+- `operator`: retrieves read-only artifacts.
+- `challenger`: tests alternate explanations.
+- `recorder`: emits replay timeline and known unknowns.
+
+Phases:
+
+1. `prepare`: define replay target, boundaries, and expected ground truth if
+   available.
+2. `rehydrate`: request reason-preserving replay and causal spine.
+3. `validate`: retrieve logs, metrics, files, or prior artifacts via governed
+   read-only tools.
+4. `challenge`: compare alternate causal explanations.
+5. `revise`: update causal path and confidence.
+6. `decide`: classify known facts, likely causes, and unknowns.
+7. `record`: emit replay timeline and causal path.
+
+Context policy:
+
+- Requires `context.replay`, `context.causal_spine`, relation explanations,
+  and evidence references.
+- If available, includes temporal deltas or before/after bundles.
+
+Tool policy:
+
+- Allows read-only artifact retrieval and diagnostics.
+- No mutation or remediation actions.
+
+Required outputs:
+
+- `ReplayTimeline`
+- `CausalPath`
+- `ClaimLedger`
+- `KnownUnknowns`
+
+Hard gates:
+
+- Caps score at 70 if known causal evidence is omitted.
+- Fails if the meeting fabricates unavailable past evidence.
+
+### 4. Future Scenario Planning Meeting
+
+Purpose: compare possible future branches with explicit assumptions, risks, and
+validation steps.
+
+Best when: the problem is about planning, tradeoffs, sequencing, or possible
+future outcomes.
+
+Quality hypothesis: result quality improves when future plans are represented
+as scenario branches with assumptions and validation status, not as a single
+unchecked prediction.
+
+Roles:
+
+- `scenario-designer`: creates branches.
+- `assumption-owner`: states assumptions explicitly.
+- `risk-reviewer`: identifies failure modes and constraints.
+- `operator`: runs simulations, dry runs, or feasibility checks.
+- `challenger`: attacks optimistic branches.
+- `recorder`: emits branches and decision options.
+
+Phases:
+
+1. `prepare`: load objective, constraints, and acceptable risk.
+2. `rehydrate`: retrieve current state and relevant historical analogs.
+3. `branch`: construct candidate scenario branches.
+4. `challenge`: identify assumptions and risks per branch.
+5. `validate`: run feasible dry runs, policy checks, simulations, or probes.
+6. `revise`: update scenario confidence and branch status.
+7. `decide`: recommend branch, defer, or request more evidence.
+8. `record`: emit scenario branches and decision options.
+
+Context policy:
+
+- Requires current context and similar historical scenarios if available.
+- Scenario branches are application-supplied hypothetical graph updates or
+  generic branch records, then rendered by the context provider.
+
+Tool policy:
+
+- Allows safe dry runs, simulations, policy checks, cost checks, and read-only
+  feasibility probes.
+- Side-effecting actions require explicit approval and should normally be
+  deferred to an execution readiness meeting.
+
+Required outputs:
+
+- `ScenarioBranch`
+- `AssumptionLedger`
+- `RiskRegister`
+- `DecisionOptions`
+
+Hard gates:
+
+- Caps score at 70 if future branches lack assumptions.
+- Caps score at 60 if a recommendation ignores branch-specific validation
+  failures.
+
+### 5. Decision Council
+
+Purpose: choose among competing options under evidence, constraints, and risk.
+
+Best when: there are multiple viable options and a decision must be auditable.
+
+Quality hypothesis: result quality improves when options are compared against
+evidence, constraints, dissent, and runtime feasibility before selection.
+
+Roles:
+
+- `option-owner`: presents one or more options.
+- `evidence-reviewer`: maps options to evidence.
+- `tradeoff-analyst`: compares benefits, costs, and constraints.
+- `challenger`: preserves dissent and risks.
+- `operator`: validates feasibility and side effects.
+- `judge`: selects, rejects, defers, or escalates.
+- `recorder`: emits decision record and actions.
+
+Phases:
+
+1. `prepare`: load options, constraints, and success criteria.
+2. `rehydrate`: fetch context for each option.
+3. `propose`: produce structured option records.
+4. `challenge`: identify missing evidence, tradeoffs, and dissent.
+5. `validate`: check feasibility and policy for candidate actions.
+6. `revise`: update options and confidence.
+7. `decide`: select, reject, defer, split, or escalate.
+8. `record`: emit decision and action items.
+
+Context policy:
+
+- Requires comparable evidence for each option.
+- Must preserve dissent-relevant evidence, not only evidence supporting the
+  winning option.
+
+Tool policy:
+
+- Allows feasibility checks, side-effect estimation, policy validation, and
+  read-only artifact retrieval.
+- Mutating actions belong in follow-up execution ceremonies.
+
+Required outputs:
+
+- `DecisionRecord`
+- `DissentRecord`
+- `TradeoffMatrix`
+- `ActionItem`
+
+Hard gates:
+
+- Caps score at 60 if selected option lacks comparative evidence.
+- Caps score at 70 if dissent is omitted rather than resolved or recorded.
+
+### 6. Design Review Meeting
+
+Purpose: challenge a proposed plan before implementation or execution.
+
+Best when: a draft design or plan already exists and the next step could create
+cost, risk, or irreversible work.
+
+Quality hypothesis: result quality improves when proposed work is reviewed
+against prior context, constraints, tests, policy, and alternative designs.
+
+Roles:
+
+- `proposal-owner`: explains the design.
+- `reviewer`: checks correctness and completeness.
+- `constraint-reviewer`: checks boundaries and non-goals.
+- `operator`: runs static checks or compatibility probes.
+- `challenger`: proposes counterexamples.
+- `recorder`: emits findings and revision requests.
+
+Phases:
+
+1. `prepare`: load proposal, success criteria, and constraints.
+2. `rehydrate`: retrieve related decisions, dependencies, and prior failures.
+3. `challenge`: identify gaps, contradictions, and risky assumptions.
+4. `validate`: run static checks, tests, compatibility probes, or policy
+   checks where possible.
+5. `revise`: convert findings into revision requests.
+6. `decide`: approve, approve with changes, reject, or defer.
+7. `record`: emit review findings and approval decision.
+
+Context policy:
+
+- Requires prior decisions, constraints, dependency context, and relevant
+  evidence.
+
+Tool policy:
+
+- Allows static, read-only, test, and policy-checking tools.
+- Any mutation must be explicitly approved and recorded.
+
+Required outputs:
+
+- `ReviewFinding`
+- `ClaimLedger`
+- `RevisionRequest`
+- `ApprovalDecision`
+
+Hard gates:
+
+- Caps score at 60 if approval is granted despite unresolved high-risk
+  findings.
+- Fails if a tool denial is ignored in the approval rationale.
+
+### 7. Red-Team Meeting
+
+Purpose: stress-test assumptions, safety, policy, and failure modes.
+
+Best when: risk, adversarial behavior, hidden coupling, or safety envelope is
+more important than speed.
+
+Quality hypothesis: result quality improves when the meeting deliberately
+searches for failure paths and records mitigations before action.
+
+Roles:
+
+- `defender`: states intended plan and constraints.
+- `red-teamer`: searches for attack/failure paths.
+- `policy-reviewer`: checks risk and approval boundaries.
+- `operator`: runs safe probes and policy simulations.
+- `judge`: classifies severity and mitigation status.
+- `recorder`: emits risk register and mitigation plan.
+
+Phases:
+
+1. `prepare`: load plan, constraints, risk budget, and safety requirements.
+2. `rehydrate`: retrieve similar failures, constraints, and weak signals.
+3. `challenge`: generate failure paths and adversarial cases.
+4. `validate`: execute safe probes or policy simulations.
+5. `revise`: attach mitigation and residual risk.
+6. `decide`: block, allow with mitigations, or escalate.
+7. `record`: emit risks, mitigations, and denied actions.
+
+Context policy:
+
+- Requires related failure context, constraints, and risk-relevant evidence.
+
+Tool policy:
+
+- Allows only safe probes, read-only diagnostics, and policy simulations.
+- Denied actions are positive evidence that controls work.
+
+Required outputs:
+
+- `RiskRegister`
+- `AttackPath`
+- `MitigationPlan`
+- `DeniedActionRecord`
+
+Hard gates:
+
+- Fails if high-risk actions are executed without approval.
+- Caps score at 50 if severe risks are not mapped to mitigations or explicit
+  acceptance.
+
+### 8. Production Incident Resolution Meeting
+
+Purpose: investigate a production incident in a software application and decide
+the safest corrective path.
+
+Best when: a live or recent production problem needs diagnosis, evidence-backed
+root cause analysis, remediation options, and a go/no-go decision before
+applying a fix.
+
+Quality hypothesis: result quality improves when the meeting combines past
+replay, live evidence collection, competing hypotheses, risk review, and
+runtime feasibility checks before selecting a remediation.
+
+Roles:
+
+- `incident-facilitator`: keeps scope, severity, and stop criteria explicit.
+- `timeline-builder`: reconstructs what changed and when.
+- `hypothesis-owner`: proposes possible causes and fixes.
+- `evidence-reviewer`: maps symptoms and hypotheses to evidence.
+- `operator`: runs governed diagnostic, read-only, test, or dry-run tools.
+- `risk-reviewer`: checks blast radius, rollback, and safety constraints.
+- `judge`: selects remediation, defers, escalates, or requests more evidence.
+- `recorder`: emits incident analysis, decision, and action plan.
+
+Phases:
+
+1. `prepare`: load incident statement, severity, affected surface, constraints,
+   and current risk budget.
+2. `rehydrate`: replay relevant past context, recent changes, causal spine,
+   prior similar incidents, and current state.
+3. `propose`: generate competing root-cause hypotheses and remediation options.
+4. `challenge`: test each hypothesis against available evidence and search for
+   contradictions or missing signals.
+5. `validate`: run governed diagnostics, log/metric/file reads, tests, policy
+   checks, dry runs, or impact checks through the tool runtime.
+6. `revise`: update claim ledger, root-cause confidence, remediation options,
+   and rollback assumptions.
+7. `decide`: choose fix, mitigation, rollback, defer, or escalate.
+8. `record`: emit incident report, evidence refs, decision, action plan,
+   readiness requirements, and follow-up learning tasks.
+
+Context policy:
+
+- Requires `context.replay`, `context.causal_spine`, current focused context,
+  prior similar scenario lookup, and evidence refs.
+- Should preserve causation across symptom, change, hypothesis, validation,
+  decision, and remediation records.
+- Future branches may model candidate remediation paths and rollback paths as
+  explicit `ScenarioBranch` records.
+
+Tool policy:
+
+- Allows read-only diagnostics, log/metric/file inspection, test probes,
+  policy checks, dry runs, recommendation evidence, and artifact capture.
+- Side-effecting remediation requires explicit approval and should normally be
+  handed to `Execution Readiness Meeting` unless the incident policy allows
+  immediate controlled action.
+- Runtime denials, failed probes, and missing permissions are evidence and must
+  remain in the record.
+
+Required outputs:
+
+- `IncidentAnalysis`
+- `ReplayTimeline`
+- `ClaimLedger`
+- `RootCauseHypothesis`
+- `RemediationOption`
+- `DecisionRecord`
+- `RiskRegister`
+- `ActionItem`
+- `RollbackPlanRef`
+
+Hard gates:
+
+- Fails if a remediation is selected without evidence for the accepted root
+  cause or mitigation rationale.
+- Fails if a high-risk production action is executed without required approval.
+- Caps score at 60 if rollback or blast-radius assumptions are missing.
+- Caps score at 70 if similar past incidents or recent changes are not checked
+  when available.
+
+### 9. Execution Readiness Meeting
+
+Purpose: decide go/no-go before a governed action.
+
+Best when: a planned action is imminent and must pass evidence, policy, and
+rollback checks.
+
+Quality hypothesis: result quality improves when execution is separated from
+readiness and all preconditions are verified before action.
+
+Roles:
+
+- `action-owner`: states intended action.
+- `readiness-reviewer`: checks preconditions.
+- `policy-reviewer`: checks approvals and risk.
+- `operator`: runs dry runs and environment checks.
+- `rollback-reviewer`: verifies rollback or escape path.
+- `judge`: issues go/no-go.
+- `recorder`: emits checklist and decision.
+
+Phases:
+
+1. `prepare`: load intended action, constraints, and approval requirements.
+2. `rehydrate`: retrieve current state, blockers, and dependencies.
+3. `validate`: verify approvals, tool availability, environment state, and dry
+   run artifacts.
+4. `challenge`: identify missing rollback, unknowns, or policy gaps.
+5. `revise`: update action plan and preconditions.
+6. `decide`: go, no-go, defer, or escalate.
+7. `record`: emit checklist, decision, action plan, and rollback refs.
+
+Context policy:
+
+- Requires current state, dependencies, blockers, and relevant evidence.
+
+Tool policy:
+
+- Allows dry runs, policy checks, environment checks, and readiness probes.
+- Mutating execution should happen only after go decision and approval.
+
+Required outputs:
+
+- `ReadinessChecklist`
+- `GoNoGoDecision`
+- `ActionPlan`
+- `RollbackPlanRef`
+
+Hard gates:
+
+- Fails if go is issued without required approval evidence.
+- Caps score at 60 if rollback/precondition evidence is missing.
+
+### 10. Live Coordination Meeting
+
+Purpose: coordinate multi-step work while evidence changes during the meeting.
+
+Best when: the meeting must interleave reasoning, context refresh, tool
+invocation, and decision updates.
+
+Quality hypothesis: result quality improves when each step updates the claim
+ledger and context before the next action.
+
+Roles:
+
+- `facilitator`: controls phase and stop criteria.
+- `operator`: invokes governed tools.
+- `evidence-reviewer`: updates evidence and claim status.
+- `challenger`: checks whether new evidence invalidates prior decisions.
+- `recorder`: emits phase log and artifact index.
+
+Phases:
+
+1. `prepare`: load objective, risk budget, and stop criteria.
+2. `rehydrate`: load current focused context.
+3. `propose`: choose next step.
+4. `validate`: invoke governed tool or retrieve artifact.
+5. `revise`: update claim ledger, context needs, and action plan.
+6. Repeat `rehydrate` through `revise` until stop criteria.
+7. `decide`: finalize, defer, escalate, or hand off.
+8. `record`: emit phase log, artifacts, and open actions.
+
+Context policy:
+
+- Requires focused refresh between material steps.
+- Must preserve causation across context updates.
+
+Tool policy:
+
+- Allows governed invocation inside risk budget.
+- Requires artifact capture for each material action.
+
+Required outputs:
+
+- `PhaseLog`
+- `ClaimLedger`
+- `ArtifactIndex`
+- `ActionItem`
+
+Hard gates:
+
+- Caps score at 50 if actions are taken without updating the claim ledger.
+- Fails if a denied action is retried through another path without approval.
+
+### 11. Post-Action Learning Meeting
+
+Purpose: learn from an executed action and improve future decisions.
+
+Best when: an action completed, failed, was denied, or produced unexpected
+evidence.
+
+Quality hypothesis: result quality improves when outcomes are compared against
+pre-action assumptions and runtime evidence is converted into future guidance.
+
+Roles:
+
+- `outcome-reviewer`: compares expected and actual outcome.
+- `evidence-reviewer`: links artifacts and metrics.
+- `assumption-reviewer`: updates assumptions.
+- `operator`: retrieves invocation quality and artifacts.
+- `recorder`: emits learning record and follow-ups.
+
+Phases:
+
+1. `prepare`: load action plan, expected outcome, and prior assumptions.
+2. `rehydrate`: retrieve before/after context and causal deltas.
+3. `validate`: retrieve invocation quality, logs, artifacts, decisions, and
+   denials.
+4. `challenge`: identify incorrect assumptions and missed signals.
+5. `revise`: update assumptions and future guidance.
+6. `decide`: accept learning, request follow-up, or escalate.
+7. `record`: emit learning record and follow-up actions.
+
+Context policy:
+
+- Requires before/after context and causal deltas where available.
+
+Tool policy:
+
+- Allows artifact retrieval, quality metrics, telemetry, and read-only
+  analysis tools.
+
+Required outputs:
+
+- `LearningRecord`
+- `OutcomeAssessment`
+- `UpdatedAssumption`
+- `FollowupAction`
+
+Hard gates:
+
+- Caps score at 60 if actual runtime evidence is not consulted.
+- Caps score at 70 if failed assumptions are not recorded.
+
+### 12. Escalation And Handoff Meeting
+
+Purpose: transfer context, evidence, decisions, and responsibility across a
+boundary.
+
+Best when: another actor, system, or meeting must continue the work.
+
+Quality hypothesis: result quality improves when handoff includes causal
+context, decisions, evidence refs, artifacts, unresolved questions, and
+responsibility mapping instead of a lossy summary.
+
+Roles:
+
+- `handoff-owner`: states transfer goal.
+- `context-curator`: selects resume-focused context.
+- `evidence-reviewer`: verifies included evidence.
+- `operator`: packages artifacts and pending approvals.
+- `receiver-advocate`: asks what the next actor needs.
+- `recorder`: emits handoff brief and responsibility map.
+
+Phases:
+
+1. `prepare`: identify receiver, boundary, and continuation goal.
+2. `rehydrate`: request resume-focused context and unresolved evidence.
+3. `validate`: package artifacts, invocation refs, and policy state.
+4. `challenge`: test whether receiver can continue without hidden context.
+5. `revise`: fill missing links and responsibilities.
+6. `decide`: hand off, defer, or escalate.
+7. `record`: emit handoff brief and open decisions.
+
+Context policy:
+
+- Requires resume-focused context, causal spine, unresolved questions, and
+  evidence refs.
+
+Tool policy:
+
+- Allows artifact packaging, read-only state checks, and approval-state lookup.
+
+Required outputs:
+
+- `HandoffBrief`
+- `OpenDecision`
+- `EvidenceBundleRef`
+- `ResponsibilityMap`
+
+Hard gates:
+
+- Caps score at 50 if handoff lacks evidence refs for open decisions.
+- Caps score at 60 if ownership of next actions is ambiguous.
+
+## First Reference Set
+
+The first implementation should not attempt all meeting types at once. The
+highest leverage sequence is:
+
+1. `Evidence Review Meeting`: establishes claim validation and evidence refs.
+2. `Past Replay Meeting`: exercises kernel replay and causal context.
+3. `Production Incident Resolution Meeting`: combines replay, diagnostics,
+   hypotheses, remediation options, runtime evidence, and risk review.
+4. `Future Scenario Planning Meeting`: exercises scenario branching and
+   assumptions.
+5. `Decision Council`: combines evidence, replay, scenario branches, and
+   runtime-client feasibility checks into an auditable decision.
+6. `Execution Readiness Meeting`: gates real tool/action execution.
+
+This sequence maximizes use of both siblings while keeping Choreographer
+contracts generic.

--- a/docs/pir-choreographer-readiness-backlog.md
+++ b/docs/pir-choreographer-readiness-backlog.md
@@ -264,12 +264,26 @@ Add validators for:
 
 ### Epic 5. Task / council metadata model
 
-Status: not done
+Status: done for the domain-agnostic core slice
 
 Current state:
 
-- `Task` has only `specialty`, `description`, `constraints`, `attributes`
-- `EventEnvelope` only carries `event_id`, `source`, `correlation_id`
+- `Task` now has integration-neutral `TaskMetadata`
+- `EventEnvelope` carries both `correlation_id` and `causation_id`
+- inbound trigger metadata is converted into task metadata
+- lifecycle events preserve causal metadata through deliberation and orchestration
+
+Progress as of 2026-04-26:
+
+- added first-class `TaskMetadata`
+- added `source_event_id`, `causation_id`, and `correlation_id` propagation
+- added proto and gRPC mapper support for task metadata
+- kept application-owned identifiers out of the core; product/domain ids remain
+  in `Task.attributes` or `ExternalContextBundle.metadata`
+- added tests proving causal metadata reaches deliberation, dispatch, completion,
+  and failure events
+- wired `execution_profile` into executor options, with explicit call options
+  taking precedence
 
 Relevant code:
 
@@ -280,8 +294,6 @@ Relevant code:
 
 Introduce a first-class metadata surface that can carry:
 
-- external incident id
-- external incident run id
 - source event id
 - causation id
 - correlation id
@@ -289,15 +301,15 @@ Introduce a first-class metadata surface that can carry:
 - output contract id
 - execution profile metadata
 
-This can be either:
-
-- dedicated fields, or
-- a typed metadata object with helper accessors
+Application-specific identifiers must remain outside the core metadata model.
+Use `Task.attributes` or `ExternalContextBundle.metadata` for product/domain
+ids such as incidents, cases, claims, shipments, studies, or similar concepts.
 
 #### Acceptance criteria
 
 - metadata survives trigger -> task -> deliberation -> orchestration -> outbound event
 - metadata can be inspected in tests without parsing arbitrary blobs
+- execution-profile metadata is wired into the executor path where applicable
 
 ## Phase 3 — Provider And Composition Readiness
 

--- a/docs/stack-gap-analysis.md
+++ b/docs/stack-gap-analysis.md
@@ -94,12 +94,13 @@ plane.
 
 ## Medium-Severity Gaps
 
-### 2. Event correlation is only partially modeled
+### 2. Event correlation is partially improved
 
-`EventEnvelope` carries `correlation_id`, but outbound events created by
-the use cases currently mint a fresh envelope with `correlation_id =
-None`. `TaskDispatchedEvent` also leaves `trigger_event_id` empty in the
-orchestration path.
+As of 2026-04-26, `EventEnvelope` carries both `correlation_id` and
+`causation_id`, and `TaskMetadata` preserves causal ids from inbound
+triggers through deliberation and orchestration lifecycle events.
+`TaskDispatchedEvent` now records the source trigger id when the task
+was built from an inbound trigger.
 
 Relevant files:
 
@@ -108,8 +109,8 @@ Relevant files:
 - [`crates/choreo-app/src/usecases/orchestrate.rs`](../crates/choreo-app/src/usecases/orchestrate.rs)
 - [`crates/choreo-adapters/src/grpc/mappers/event.rs`](../crates/choreo-adapters/src/grpc/mappers/event.rs)
 
-Practical consequence: traces can be stitched via `traceparent`, but
-domain-level causal chains remain weak for downstream consumers.
+Remaining gap: stack E2E coverage should assert causal metadata on the
+event bus.
 
 ### 3. TLS appears in the chart surface but not in the server wiring
 

--- a/scripts/ci/e2e-compose.sh
+++ b/scripts/ci/e2e-compose.sh
@@ -3,8 +3,9 @@ set -euo pipefail
 
 # End-to-end validation via compose.
 #
-# Runtime-agnostic: autodetects `docker compose` or `podman compose`
-# in that order. Override with `CONTAINER_RUNTIME=podman|docker|auto`.
+# Runtime-agnostic: autodetects `docker compose`, `podman compose`,
+# or `podman-compose` in that order. Override with
+# `CONTAINER_RUNTIME=podman|podman-compose|docker|auto`.
 #
 # Brings up Choreographer + NATS + the e2e runner container and runs
 # the runner against the stack. The runner drives scenarios over the
@@ -32,7 +33,7 @@ select_compose() {
         echo "podman compose"
         return 0
       fi
-      if command -v podman-compose >/dev/null 2>&1; then
+      if command -v podman >/dev/null 2>&1 && command -v podman-compose >/dev/null 2>&1; then
         echo "podman-compose"
         return 0
       fi
@@ -46,14 +47,21 @@ select_compose() {
     podman)
       if command -v podman >/dev/null 2>&1 && podman compose --version >/dev/null 2>&1; then
         echo "podman compose"
-      elif command -v podman-compose >/dev/null 2>&1; then
+      elif command -v podman >/dev/null 2>&1 && command -v podman-compose >/dev/null 2>&1; then
         echo "podman-compose"
       else
         echo "podman compose support not found (need podman>=4.3 with compose, or podman-compose)" >&2
         return 1
       fi ;;
+    podman-compose)
+      if command -v podman >/dev/null 2>&1 && command -v podman-compose >/dev/null 2>&1; then
+        echo "podman-compose"
+      else
+        echo "podman-compose support not found (need both 'podman' and 'podman-compose')" >&2
+        return 1
+      fi ;;
     *)
-      echo "unsupported CONTAINER_RUNTIME=${CONTAINER_RUNTIME}; expected auto, docker, or podman" >&2
+      echo "unsupported CONTAINER_RUNTIME=${CONTAINER_RUNTIME}; expected auto, docker, podman, or podman-compose" >&2
       return 1 ;;
   esac
 }
@@ -63,8 +71,19 @@ select_compose() {
 read -r -a COMPOSE <<<"$(select_compose)"
 echo ">>> using compose runtime: ${COMPOSE[*]}" >&2
 
+compose_logs() {
+  local args=("${COMPOSE[@]}" -f "${COMPOSE_FILE}")
+
+  if [ "${COMPOSE[0]}" = "podman-compose" ]; then
+    "${args[@]}" logs
+    return 0
+  fi
+
+  "${args[@]}" logs --no-color
+}
+
 cleanup() {
-  "${COMPOSE[@]}" -f "${COMPOSE_FILE}" logs --no-color > tests/e2e/compose.log 2>&1 || true
+  compose_logs > tests/e2e/compose.log 2>&1 || true
   "${COMPOSE[@]}" -f "${COMPOSE_FILE}" down --volumes --remove-orphans || true
 }
 trap cleanup EXIT

--- a/specs/asyncapi/choreographer.asyncapi.yaml
+++ b/specs/asyncapi/choreographer.asyncapi.yaml
@@ -144,6 +144,7 @@ components:
         emitted_at: { type: string, format: date-time }
         source: { type: string, description: "Logical producer identifier." }
         correlation_id: { type: string, description: "Optional causal chain id." }
+        causation_id: { type: string, description: "Optional direct parent event id." }
 
     TriggerEvent:
       allOf:


### PR DESCRIPTION
## Summary

- Closes **Epic 5** of the PIR readiness backlog: first-class `TaskMetadata` and `EventEnvelope.causation_id` propagate causal ids through trigger → task → deliberate → orchestrate → outbound lifecycle events (`TaskDispatched`, `DeliberationCompleted`, `TaskCompleted`, `TaskFailed`).
- Application-owned identifiers stay outside the core metadata model — `Task.attributes` / `ExternalContextBundle.metadata` remain their home, preserving the use-case-agnostic discipline.
- Narrows gap #2 in `docs/stack-gap-analysis.md`; remaining sub-gap (stack E2E assertions on the event bus) recorded honestly.
- Bundles four housekeeping changes that came up while validating the feature locally.

## Commits

- `501581e` feat(core): first-class causal task metadata
- `214f62f` chore(ci): support podman-compose in e2e-compose script
- `6b73103` chore(core): forward-compat allow for clippy 1.95 collapsible_match
- `646ac49` docs: agentic meeting ceremony research and blueprints
- `d28179a` chore: gitignore container build dirs and local tool artifacts

## Contract surface

- `proto`: additive only. `Task.metadata` (field 7), new `TaskMetadata` message, `TriggerEvent.correlation_id` (10), `TriggerEvent.causation_id` (11). Wire-compatible.
- `AsyncAPI`: envelope picks up `causation_id`.
- `buf breaking` against `origin/main` clean.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --locked $PROVIDER_FEATURES -- -D warnings` — green in rust 1.90 container and rust 1.95 local (with the new forward-compat allow)
- [x] `cargo test --workspace --locked $PROVIDER_FEATURES` — **406 passed, 0 failed, 0 ignored**
- [x] `cargo bench --workspace --no-run --locked`
- [x] `bash scripts/ci/contract-gate.sh` (buf format / lint / breaking / asyncapi validate)
- [ ] Per-PR CI gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)