### PR TITLE
test(e2e): assert causal metadata propagates over NATS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,9 +460,13 @@ name = "choreo-e2e-runner"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-nats",
  "choreo-adapters",
  "choreo-core",
  "choreo-proto",
+ "futures",
+ "serde_json",
+ "time",
  "tokio",
  "tonic",
  "tracing",

--- a/crates/choreo-e2e-runner/Cargo.toml
+++ b/crates/choreo-e2e-runner/Cargo.toml
@@ -33,3 +33,7 @@ tonic = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+async-nats = { workspace = true }
+serde_json = { workspace = true }
+time = { workspace = true }
+futures = { workspace = true }

--- a/crates/choreo-e2e-runner/src/main.rs
+++ b/crates/choreo-e2e-runner/src/main.rs
@@ -195,9 +195,7 @@ async fn verify_causal_metadata_propagates_over_nats(specialty: &str) -> Result<
                 );
             }
             Ok(None) => {
-                bail!(
-                    "NATS subscription closed before a matching DeliberationCompleted arrived"
-                );
+                bail!("NATS subscription closed before a matching DeliberationCompleted arrived");
             }
             Err(_) => {}
         }

--- a/crates/choreo-e2e-runner/src/main.rs
+++ b/crates/choreo-e2e-runner/src/main.rs
@@ -13,6 +13,9 @@ use std::time::Duration;
 use anyhow::{anyhow, bail, Context, Result};
 use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
 use choreo_proto::v1::{DeleteCouncilRequest, DeliberateRequest, ListCouncilsRequest, Task};
+use futures::StreamExt;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
 use tonic::transport::{Channel, Endpoint};
 use tracing::{info, warn};
 use tracing_subscriber::EnvFilter;
@@ -110,8 +113,97 @@ async fn main() -> Result<()> {
         bail!("DeleteCouncil on an unknown specialty must return deleted=false");
     }
 
+    info!("scenario 4: causal metadata propagates from inbound trigger to outbound bus event");
+    verify_causal_metadata_propagates_over_nats(&seed_specialty)
+        .await
+        .context("scenario 4 failed")?;
+
     info!("E2E scenarios passed");
     Ok(())
+}
+
+/// Publishes a `TriggerEvent` on NATS with known `correlation_id` and
+/// `causation_id`, then asserts that the resulting
+/// `DeliberationCompleted` envelope on the outbound bus carries the
+/// same causal ids. Closes the stack-E2E loose end of Epic 5.
+async fn verify_causal_metadata_propagates_over_nats(specialty: &str) -> Result<()> {
+    let nats_url =
+        std::env::var("CHOREO_NATS_URL").unwrap_or_else(|_| "nats://nats:4222".to_owned());
+    let client = async_nats::connect(&nats_url)
+        .await
+        .with_context(|| format!("connect NATS at {nats_url}"))?;
+    info!(nats_url, "connected to NATS for causal metadata assertion");
+
+    let mut subscription = client
+        .subscribe("choreo.deliberation.completed".to_owned())
+        .await
+        .context("subscribe choreo.deliberation.completed")?;
+    // Flush so the SUB is acked by the server before we publish the
+    // trigger that should fan out into the event we're waiting for.
+    client.flush().await.context("flush NATS subscribe")?;
+
+    let event_id = "stack-e2e-trigger-1";
+    let correlation_id = "stack-e2e-corr";
+    let causation_id = "stack-e2e-cause";
+    let emitted_at = OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .context("format emitted_at as RFC 3339")?;
+    let trigger = serde_json::json!({
+        "event_id": event_id,
+        "emitted_at": emitted_at,
+        "source": "stack-e2e-runner",
+        "correlation_id": correlation_id,
+        "causation_id": causation_id,
+        "kind": "stack.e2e.trigger",
+        "requested_specialties": [specialty],
+    });
+    let subject = format!("choreo.trigger.{specialty}");
+    let payload = serde_json::to_vec(&trigger).context("serialize trigger payload")?;
+    client
+        .publish(subject.clone(), payload.into())
+        .await
+        .with_context(|| format!("publish trigger to {subject}"))?;
+    client.flush().await.context("flush NATS publish")?;
+    info!(subject, correlation_id, causation_id, "trigger published");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    while std::time::Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        let chunk = remaining.min(Duration::from_secs(2));
+        match tokio::time::timeout(chunk, subscription.next()).await {
+            Ok(Some(msg)) => {
+                let payload: serde_json::Value = serde_json::from_slice(&msg.payload)
+                    .context("DeliberationCompleted payload not JSON")?;
+                let got_corr = payload.get("correlation_id").and_then(|v| v.as_str());
+                let got_cause = payload.get("causation_id").and_then(|v| v.as_str());
+                if got_corr == Some(correlation_id) && got_cause == Some(causation_id) {
+                    info!(
+                        out_event_id = payload
+                            .get("event_id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or(""),
+                        correlation_id,
+                        causation_id,
+                        "DeliberationCompleted carried our causal ids"
+                    );
+                    return Ok(());
+                }
+                warn!(
+                    ?got_corr,
+                    ?got_cause,
+                    "DeliberationCompleted seen but causal ids did not match; continuing"
+                );
+            }
+            Ok(None) => {
+                bail!(
+                    "NATS subscription closed before a matching DeliberationCompleted arrived"
+                );
+            }
+            Err(_) => {}
+        }
+    }
+
+    bail!("no DeliberationCompleted with the expected causal ids arrived within 15s")
 }
 
 async fn connect_with_retry(

--- a/docs/stack-gap-analysis.md
+++ b/docs/stack-gap-analysis.md
@@ -94,13 +94,17 @@ plane.
 
 ## Medium-Severity Gaps
 
-### 2. Event correlation is partially improved
+### 2. Event correlation is closed end-to-end
 
-As of 2026-04-26, `EventEnvelope` carries both `correlation_id` and
+As of 2026-05-11, `EventEnvelope` carries both `correlation_id` and
 `causation_id`, and `TaskMetadata` preserves causal ids from inbound
 triggers through deliberation and orchestration lifecycle events.
 `TaskDispatchedEvent` now records the source trigger id when the task
-was built from an inbound trigger.
+was built from an inbound trigger. The e2e-runner publishes a
+`TriggerEvent` on NATS with known causal ids and asserts the resulting
+`DeliberationCompleted` envelope on the outbound bus carries the same
+ids, proving the loop closes over a real stack (not only in unit
+tests).
 
 Relevant files:
 
@@ -108,9 +112,7 @@ Relevant files:
 - [`crates/choreo-app/src/usecases/deliberate.rs`](../crates/choreo-app/src/usecases/deliberate.rs)
 - [`crates/choreo-app/src/usecases/orchestrate.rs`](../crates/choreo-app/src/usecases/orchestrate.rs)
 - [`crates/choreo-adapters/src/grpc/mappers/event.rs`](../crates/choreo-adapters/src/grpc/mappers/event.rs)
-
-Remaining gap: stack E2E coverage should assert causal metadata on the
-event bus.
+- [`crates/choreo-e2e-runner/src/main.rs`](../crates/choreo-e2e-runner/src/main.rs)
 
 ### 3. TLS appears in the chart surface but not in the server wiring
 


### PR DESCRIPTION
## Summary

Closes the stack-E2E sub-gap that PR #44's commit (`501581e`) left explicitly open and that `docs/stack-gap-analysis.md` §2 tracked as remaining.

Adds **scenario 4** to the e2e-runner:

1. publishes a `TriggerEvent` JSON on `choreo.trigger.<specialty>` with known `correlation_id` and `causation_id`
2. subscribes to `choreo.deliberation.completed`
3. asserts the resulting envelope carries the same causal ids

Exercises the full inbound-NATS → AutoDispatchService → DeliberateUseCase → outbound-NATS path — the loop that unit tests cannot prove.

## Test plan

- [x] `cargo clippy -p choreo-e2e-runner --all-targets --locked -- -D warnings` (rust 1.90 container)
- [x] `cargo clippy --workspace --all-targets --locked $PROVIDER_FEATURES -- -D warnings` (no regression elsewhere)
- [x] `cargo test --workspace --locked $PROVIDER_FEATURES` — 406 passed, 0 failed, 0 ignored
- [x] `CONTAINER_RUNTIME=podman-compose make e2e-compose` — full stack with all 4 scenarios passes; the new assertion saw the propagated ids:
  ```
  [e2e-runner] trigger published correlation_id="stack-e2e-corr" causation_id="stack-e2e-cause"
  [e2e-runner] DeliberationCompleted carried our causal ids correlation_id="stack-e2e-corr" causation_id="stack-e2e-cause"
  [e2e-runner] E2E scenarios passed
  ```
- [ ] Per-PR CI gates

## Files

- `crates/choreo-e2e-runner/Cargo.toml` — adds async-nats, serde_json, time, futures
- `crates/choreo-e2e-runner/src/main.rs` — scenario 4 + helper `verify_causal_metadata_propagates_over_nats`
- `Cargo.lock` — lockfile bump for the new deps
- `docs/stack-gap-analysis.md` — §2 retitled "closed end-to-end" with the runner file appended to the references

🤖 Generated with [Claude Code](https://claude.com/claude-code)