### PR TITLE
feat(transport): gRPC server TLS/mTLS wiring (Epic 8 server side)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2693,6 +2693,7 @@ version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3733,8 +3734,11 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-native-certs 0.8.3",
+ "rustls-pemfile",
  "socket2 0.5.10",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ opentelemetry-semantic-conventions = "0.27"
 tracing-opentelemetry = "0.28"
 
 # gRPC
-tonic = "0.12"
+tonic = { version = "0.12", features = ["tls", "tls-roots"] }
 tonic-build = "0.12"
 prost = "0.13"
 prost-types = "0.13"

--- a/charts/choreographer/templates/deployment.yaml
+++ b/charts/choreographer/templates/deployment.yaml
@@ -29,12 +29,24 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if .Values.tmpVolume.enabled }}
+      {{- $tlsMode := .Values.tls.mode | default "none" }}
+      {{- if or .Values.tmpVolume.enabled (ne $tlsMode "none") }}
       volumes:
+        {{- if .Values.tmpVolume.enabled }}
         - name: tmp
           emptyDir:
             medium: Memory
             sizeLimit: {{ .Values.tmpVolume.sizeLimit }}
+        {{- end }}
+        {{- if ne $tlsMode "none" }}
+        {{- if not .Values.tls.existingSecret }}
+        {{- fail "tls.mode is not 'none' but tls.existingSecret is empty; provide a Kubernetes secret with tls.crt and tls.key (plus ca.crt for mutual mode)" }}
+        {{- end }}
+        - name: grpc-tls
+          secret:
+            secretName: {{ .Values.tls.existingSecret | quote }}
+            defaultMode: 0400
+        {{- end }}
       {{- end }}
       containers:
         - name: choreo
@@ -42,10 +54,17 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          {{- if .Values.tmpVolume.enabled }}
+          {{- if or .Values.tmpVolume.enabled (ne $tlsMode "none") }}
           volumeMounts:
+            {{- if .Values.tmpVolume.enabled }}
             - name: tmp
               mountPath: /tmp
+            {{- end }}
+            {{- if ne $tlsMode "none" }}
+            - name: grpc-tls
+              mountPath: /etc/choreographer/tls
+              readOnly: true
+            {{- end }}
           {{- end }}
           ports:
             - name: grpc
@@ -77,6 +96,18 @@ spec:
             {{- if .Values.config.seedSpecialties }}
             - name: CHOREO_SEED_SPECIALTIES
               value: {{ .Values.config.seedSpecialties | quote }}
+            {{- end }}
+            {{- if ne $tlsMode "none" }}
+            - name: CHOREO_GRPC_TLS_MODE
+              value: {{ $tlsMode | quote }}
+            - name: CHOREO_GRPC_TLS_CERT_PATH
+              value: "/etc/choreographer/tls/tls.crt"
+            - name: CHOREO_GRPC_TLS_KEY_PATH
+              value: "/etc/choreographer/tls/tls.key"
+            {{- if eq $tlsMode "mutual" }}
+            - name: CHOREO_GRPC_TLS_CLIENT_CA_PATH
+              value: "/etc/choreographer/tls/ca.crt"
+            {{- end }}
             {{- end }}
             {{- if .Values.persistence.postgres.enabled }}
             {{- if and .Values.persistence.postgres.urlFromSecret.name .Values.persistence.postgres.urlFromSecret.key }}

--- a/charts/choreographer/values.yaml
+++ b/charts/choreographer/values.yaml
@@ -121,6 +121,18 @@ persistence:
 tls:
   # Transport security mode for the gRPC service.
   # One of: "none" | "server" | "mutual".
+  #   - "none":   plain HTTP/2 over TCP (private mesh only)
+  #   - "server": one-way TLS; the server presents an identity, the
+  #               client verifies it via a trust anchor it already has
+  #   - "mutual": both server and client present identities; the server
+  #               validates the client cert against the CA bundle
+  # When non-"none", `existingSecret` must reference a Kubernetes
+  # `kubernetes.io/tls` (or similar) secret containing:
+  #   tls.crt  — server certificate PEM
+  #   tls.key  — server private key PEM
+  #   ca.crt   — client CA bundle PEM (required only for `mutual`)
+  # The secret is mounted read-only at /etc/choreographer/tls and the
+  # binary picks up the paths via CHOREO_GRPC_TLS_* env vars.
   mode: none
   existingSecret: ""
 

--- a/crates/choreo-adapters/src/config.rs
+++ b/crates/choreo-adapters/src/config.rs
@@ -5,7 +5,7 @@
 
 use async_trait::async_trait;
 use choreo_core::error::DomainError;
-use choreo_core::ports::{ConfigurationPort, ServiceConfig};
+use choreo_core::ports::{ConfigurationPort, GrpcTlsConfig, ServiceConfig};
 use figment::{
     providers::{Env, Serialized},
     Figment,
@@ -17,14 +17,24 @@ use tracing::debug;
 ///
 /// Recognised variables (prefixed with `CHOREO_`):
 ///
-/// | Var                        | Default               |
-/// |----------------------------|-----------------------|
-/// | `CHOREO_GRPC_PORT`         | `50055`               |
-/// | `CHOREO_NATS_ENABLED`      | `true`                |
-/// | `CHOREO_NATS_URL`          | `nats://nats:4222`    |
-/// | `CHOREO_TRIGGER_SUBJECT`   | `choreo.trigger.>`    |
-/// | `CHOREO_PUBLISH_PREFIX`    | `choreo`              |
-/// | `CHOREO_POSTGRES_URL`      | (unset)               |
+/// | Var                              | Default               |
+/// |----------------------------------|-----------------------|
+/// | `CHOREO_GRPC_PORT`               | `50055`               |
+/// | `CHOREO_NATS_ENABLED`            | `true`                |
+/// | `CHOREO_NATS_URL`                | `nats://nats:4222`    |
+/// | `CHOREO_TRIGGER_SUBJECT`         | `choreo.trigger.>`    |
+/// | `CHOREO_PUBLISH_PREFIX`          | `choreo`              |
+/// | `CHOREO_POSTGRES_URL`            | (unset)               |
+/// | `CHOREO_GRPC_TLS_MODE`           | `none`                |
+/// | `CHOREO_GRPC_TLS_CERT_PATH`      | (unset)               |
+/// | `CHOREO_GRPC_TLS_KEY_PATH`       | (unset)               |
+/// | `CHOREO_GRPC_TLS_CLIENT_CA_PATH` | (unset)               |
+///
+/// `CHOREO_GRPC_TLS_MODE` accepts `none`, `server`, or `mutual`.
+/// `server` requires both `_CERT_PATH` and `_KEY_PATH`; `mutual`
+/// additionally requires `_CLIENT_CA_PATH`. Validation runs at load
+/// time so the adapter never produces an internally inconsistent
+/// snapshot.
 ///
 /// The adapter performs no IO at construction; `load` returns a
 /// snapshot of the current environment.
@@ -47,6 +57,10 @@ struct Defaults {
     trigger_subject: String,
     publish_prefix: String,
     postgres_url: String,
+    grpc_tls_mode: String,
+    grpc_tls_cert_path: String,
+    grpc_tls_key_path: String,
+    grpc_tls_client_ca_path: String,
 }
 
 impl Default for Defaults {
@@ -59,6 +73,10 @@ impl Default for Defaults {
             trigger_subject: "choreo.trigger.>".to_owned(),
             publish_prefix: "choreo".to_owned(),
             postgres_url: String::new(),
+            grpc_tls_mode: "none".to_owned(),
+            grpc_tls_cert_path: String::new(),
+            grpc_tls_key_path: String::new(),
+            grpc_tls_client_ca_path: String::new(),
         }
     }
 }
@@ -82,6 +100,13 @@ impl ConfigurationPort for EnvConfiguration {
             Some(loaded.postgres_url)
         };
 
+        let grpc_tls = build_grpc_tls(
+            &loaded.grpc_tls_mode,
+            &loaded.grpc_tls_cert_path,
+            &loaded.grpc_tls_key_path,
+            &loaded.grpc_tls_client_ca_path,
+        )?;
+
         Ok(ServiceConfig {
             grpc_port: loaded.grpc_port,
             http_port: loaded.http_port,
@@ -90,7 +115,60 @@ impl ConfigurationPort for EnvConfiguration {
             trigger_subject: loaded.trigger_subject,
             publish_prefix: loaded.publish_prefix,
             postgres_url,
+            grpc_tls,
         })
+    }
+}
+
+fn nonempty(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_owned())
+    }
+}
+
+fn build_grpc_tls(
+    mode: &str,
+    cert_path: &str,
+    key_path: &str,
+    client_ca_path: &str,
+) -> Result<GrpcTlsConfig, DomainError> {
+    let mode = mode.trim().to_ascii_lowercase();
+    match mode.as_str() {
+        "" | "none" | "disabled" => Ok(GrpcTlsConfig::Disabled),
+        "server" => {
+            let cert = nonempty(cert_path).ok_or(DomainError::EmptyField {
+                field: "grpc_tls.cert_path",
+            })?;
+            let key = nonempty(key_path).ok_or(DomainError::EmptyField {
+                field: "grpc_tls.key_path",
+            })?;
+            Ok(GrpcTlsConfig::Server {
+                cert_path: cert,
+                key_path: key,
+            })
+        }
+        "mutual" | "mtls" => {
+            let cert = nonempty(cert_path).ok_or(DomainError::EmptyField {
+                field: "grpc_tls.cert_path",
+            })?;
+            let key = nonempty(key_path).ok_or(DomainError::EmptyField {
+                field: "grpc_tls.key_path",
+            })?;
+            let ca = nonempty(client_ca_path).ok_or(DomainError::EmptyField {
+                field: "grpc_tls.client_ca_path",
+            })?;
+            Ok(GrpcTlsConfig::Mutual {
+                cert_path: cert,
+                key_path: key,
+                client_ca_path: ca,
+            })
+        }
+        _ => Err(DomainError::InvariantViolated {
+            reason: "grpc_tls.mode must be one of: none, server, mutual",
+        }),
     }
 }
 
@@ -173,6 +251,109 @@ mod tests {
         let err = EnvConfiguration::new().load().await.unwrap_err();
         assert!(matches!(err, DomainError::InvariantViolated { .. }));
 
+        clear_env();
+    }
+
+    #[tokio::test]
+    async fn grpc_tls_defaults_to_disabled() {
+        let _guard = ENV_LOCK.lock().await;
+        clear_env();
+
+        let cfg = EnvConfiguration::new().load().await.unwrap();
+        assert_eq!(cfg.grpc_tls, GrpcTlsConfig::Disabled);
+        assert_eq!(cfg.grpc_tls.mode_name(), "none");
+    }
+
+    #[tokio::test]
+    async fn grpc_tls_server_mode_requires_cert_and_key() {
+        let _guard = ENV_LOCK.lock().await;
+        clear_env();
+        std::env::set_var("CHOREO_GRPC_TLS_MODE", "server");
+        // cert + key missing
+        let err = EnvConfiguration::new().load().await.unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::EmptyField {
+                field: "grpc_tls.cert_path"
+            }
+        ));
+        clear_env();
+    }
+
+    #[tokio::test]
+    async fn grpc_tls_server_mode_loads_when_both_paths_set() {
+        let _guard = ENV_LOCK.lock().await;
+        clear_env();
+        std::env::set_var("CHOREO_GRPC_TLS_MODE", "server");
+        std::env::set_var("CHOREO_GRPC_TLS_CERT_PATH", "/etc/tls/tls.crt");
+        std::env::set_var("CHOREO_GRPC_TLS_KEY_PATH", "/etc/tls/tls.key");
+
+        let cfg = EnvConfiguration::new().load().await.unwrap();
+        assert_eq!(
+            cfg.grpc_tls,
+            GrpcTlsConfig::Server {
+                cert_path: "/etc/tls/tls.crt".to_owned(),
+                key_path: "/etc/tls/tls.key".to_owned(),
+            }
+        );
+        assert_eq!(cfg.grpc_tls.mode_name(), "server");
+        clear_env();
+    }
+
+    #[tokio::test]
+    async fn grpc_tls_mutual_mode_requires_client_ca() {
+        let _guard = ENV_LOCK.lock().await;
+        clear_env();
+        std::env::set_var("CHOREO_GRPC_TLS_MODE", "mutual");
+        std::env::set_var("CHOREO_GRPC_TLS_CERT_PATH", "/etc/tls/tls.crt");
+        std::env::set_var("CHOREO_GRPC_TLS_KEY_PATH", "/etc/tls/tls.key");
+        // client CA missing
+
+        let err = EnvConfiguration::new().load().await.unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::EmptyField {
+                field: "grpc_tls.client_ca_path"
+            }
+        ));
+        clear_env();
+    }
+
+    #[tokio::test]
+    async fn grpc_tls_mutual_mode_loads_when_all_three_paths_set() {
+        let _guard = ENV_LOCK.lock().await;
+        clear_env();
+        std::env::set_var("CHOREO_GRPC_TLS_MODE", "mutual");
+        std::env::set_var("CHOREO_GRPC_TLS_CERT_PATH", "/etc/tls/tls.crt");
+        std::env::set_var("CHOREO_GRPC_TLS_KEY_PATH", "/etc/tls/tls.key");
+        std::env::set_var("CHOREO_GRPC_TLS_CLIENT_CA_PATH", "/etc/tls/ca.crt");
+
+        let cfg = EnvConfiguration::new().load().await.unwrap();
+        assert_eq!(
+            cfg.grpc_tls,
+            GrpcTlsConfig::Mutual {
+                cert_path: "/etc/tls/tls.crt".to_owned(),
+                key_path: "/etc/tls/tls.key".to_owned(),
+                client_ca_path: "/etc/tls/ca.crt".to_owned(),
+            }
+        );
+        assert_eq!(cfg.grpc_tls.mode_name(), "mutual");
+        clear_env();
+    }
+
+    #[tokio::test]
+    async fn grpc_tls_invalid_mode_is_rejected() {
+        let _guard = ENV_LOCK.lock().await;
+        clear_env();
+        std::env::set_var("CHOREO_GRPC_TLS_MODE", "weird");
+
+        let err = EnvConfiguration::new().load().await.unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::InvariantViolated {
+                reason: "grpc_tls.mode must be one of: none, server, mutual"
+            }
+        ));
         clear_env();
     }
 }

--- a/crates/choreo-core/src/ports/configuration.rs
+++ b/crates/choreo-core/src/ports/configuration.rs
@@ -21,6 +21,54 @@ pub struct ServiceConfig {
     /// in-memory repository is wired. Empty-string is treated as
     /// unset so the chart can carry a placeholder default.
     pub postgres_url: Option<String>,
+    /// Transport security for the gRPC server.
+    pub grpc_tls: GrpcTlsConfig,
+}
+
+/// Mode + paths for the gRPC server's transport security. Validated
+/// at load time so the adapter never sees an internally inconsistent
+/// state (e.g. mode=server with no cert path).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum GrpcTlsConfig {
+    /// Plain HTTP/2 over TCP. Acceptable inside a private mesh; not
+    /// for cross-network deployments.
+    Disabled,
+    /// One-way TLS: the server presents an identity, the client
+    /// verifies it via a trust anchor it already has.
+    Server { cert_path: String, key_path: String },
+    /// Mutual TLS: client presents an identity that the server
+    /// validates against `client_ca_path`.
+    Mutual {
+        cert_path: String,
+        key_path: String,
+        client_ca_path: String,
+    },
+}
+
+impl GrpcTlsConfig {
+    /// Disabled by default — every other mode requires explicit
+    /// configuration with file paths the binary can actually read.
+    #[must_use]
+    pub fn disabled() -> Self {
+        Self::Disabled
+    }
+
+    /// Operator-friendly name for the active mode. Useful for
+    /// startup-log honesty so deployments expose what they're doing.
+    #[must_use]
+    pub fn mode_name(&self) -> &'static str {
+        match self {
+            Self::Disabled => "none",
+            Self::Server { .. } => "server",
+            Self::Mutual { .. } => "mutual",
+        }
+    }
+}
+
+impl Default for GrpcTlsConfig {
+    fn default() -> Self {
+        Self::disabled()
+    }
 }
 
 #[async_trait]

--- a/crates/choreo-core/src/ports/mod.rs
+++ b/crates/choreo-core/src/ports/mod.rs
@@ -34,7 +34,7 @@ pub use agent_factory::{AgentDescriptor, AgentFactoryPort};
 pub use agent_registry::AgentRegistryPort;
 pub use agent_resolver::AgentResolverPort;
 pub use clock::ClockPort;
-pub use configuration::{ConfigurationPort, ServiceConfig};
+pub use configuration::{ConfigurationPort, GrpcTlsConfig, ServiceConfig};
 pub use council_registry::CouncilRegistryPort;
 pub use deliberation_observer::{DeliberationObserverPort, NullObserver};
 pub use deliberation_repository::DeliberationRepositoryPort;

--- a/crates/choreo/src/runtime.rs
+++ b/crates/choreo/src/runtime.rs
@@ -15,8 +15,10 @@
 use std::net::SocketAddr;
 
 use anyhow::{Context, Result};
+use choreo_core::ports::GrpcTlsConfig;
 use tokio::signal::unix::{signal, SignalKind};
 use tokio::sync::watch;
+use tonic::transport::{Certificate, Identity, Server, ServerTlsConfig};
 use tracing::{error, info};
 
 use crate::compose::Application;
@@ -62,7 +64,15 @@ pub async fn serve(app: Application) -> Result<()> {
             )
         })?;
 
-    info!(grpc = %grpc_addr, http = %http_addr, "servers starting");
+    let mut server_builder = grpc_server_builder(&service_config.grpc_tls)
+        .context("failed to build grpc server with the configured TLS posture")?;
+
+    info!(
+        grpc = %grpc_addr,
+        http = %http_addr,
+        grpc_tls = service_config.grpc_tls.mode_name(),
+        "servers starting"
+    );
 
     // Driver: one task waits for the OS signal and flips the watch.
     tokio::spawn(async move {
@@ -72,7 +82,7 @@ pub async fn serve(app: Application) -> Result<()> {
 
     let grpc_shutdown = wait_for_shutdown(shutdown_rx.clone());
     let grpc_task = tokio::spawn(async move {
-        tonic::transport::Server::builder()
+        server_builder
             .add_service(grpc_service.into_server())
             .serve_with_shutdown(grpc_addr, grpc_shutdown)
             .await
@@ -117,6 +127,52 @@ async fn wait_for_shutdown(mut rx: watch::Receiver<bool>) {
             break;
         }
     }
+}
+
+/// Build a `Server` builder honouring the operator's TLS posture.
+///
+/// Returns a configured builder ready to receive services. `Disabled`
+/// produces the plain HTTP/2 builder; `Server` attaches a one-way
+/// identity; `Mutual` additionally enforces a client CA. File reads
+/// happen here so a misconfigured deployment fails fast at startup
+/// rather than at the first request.
+fn grpc_server_builder(tls: &GrpcTlsConfig) -> Result<Server> {
+    match tls {
+        GrpcTlsConfig::Disabled => Ok(Server::builder()),
+        GrpcTlsConfig::Server {
+            cert_path,
+            key_path,
+        } => {
+            let identity = load_identity(cert_path, key_path)?;
+            let config = ServerTlsConfig::new().identity(identity);
+            Server::builder()
+                .tls_config(config)
+                .context("failed to apply server TLS configuration")
+        }
+        GrpcTlsConfig::Mutual {
+            cert_path,
+            key_path,
+            client_ca_path,
+        } => {
+            let identity = load_identity(cert_path, key_path)?;
+            let client_ca_pem = std::fs::read(client_ca_path)
+                .with_context(|| format!("failed to read client CA bundle at {client_ca_path}"))?;
+            let config = ServerTlsConfig::new()
+                .identity(identity)
+                .client_ca_root(Certificate::from_pem(client_ca_pem));
+            Server::builder()
+                .tls_config(config)
+                .context("failed to apply mutual TLS configuration")
+        }
+    }
+}
+
+fn load_identity(cert_path: &str, key_path: &str) -> Result<Identity> {
+    let cert = std::fs::read(cert_path)
+        .with_context(|| format!("failed to read server cert at {cert_path}"))?;
+    let key = std::fs::read(key_path)
+        .with_context(|| format!("failed to read server key at {key_path}"))?;
+    Ok(Identity::from_pem(cert, key))
 }
 
 async fn shutdown_signal() {

--- a/docs/pir-choreographer-readiness-backlog.md
+++ b/docs/pir-choreographer-readiness-backlog.md
@@ -29,11 +29,12 @@ As of 2026-05-11 the eight stack-readiness areas resolve as follows:
 | 4 | complete causal metadata propagation | done (Epic 5) |
 | 5 | provider-backed council materialization | done (`DispatchingAgentFactory` wired with `noop`/`anthropic`/`openai`/`vllm` arms) |
 | 6 | honest and durable transport semantics | done (AsyncAPI now declares plain core NATS; JetStream deferred) |
-| 7 | real TLS / mTLS posture | not started (chart surface is dead config; server and client have no TLS wiring) |
+| 7 | real TLS / mTLS posture | mostly done (server-side TLS wired with `none`/`server`/`mutual`; chart honest; Runtime client TLS + handshake-level integration test deferred) |
 | 8 | stack-level end-to-end proofs | partial (E2E covers Noop council + causal metadata; real-council + runtime legs missing) |
 
-What is now genuinely blocking PIR integration: Epics 8, 9, 10
-plus the missing real-council / runtime legs of Epic 11. The execution
+What is now genuinely blocking PIR integration: Epic 8 leg (Runtime
+client TLS), Epics 9 and 10, plus the missing real-council / runtime
+legs of Epic 11. The execution
 and context foundations (Phases 1 and 2 in the original plan) plus
 provider composition are satisfied.
 
@@ -75,7 +76,7 @@ Choreographer is "ready" when all of the following are true:
 
 These items still block PIR integration.
 
-- TLS / mTLS server + client posture (Epic 8)
+- Runtime gRPC client TLS in `RuntimeExecutor::connect` (Epic 8 leg)
 - dedicated PIR-facing RPC surface (Epic 9)
 - structured report artifact support (Epic 10)
 - stack E2E proof with real council + runtime executor (Epic 11 leg)
@@ -84,7 +85,7 @@ Already cleared: Runtime executor adapter (Epic 1), Kernel context
 boundary (Epic 2), structured council output contracts (Epic 3),
 causal metadata model (Epic 5), provider-backed agent factory
 composition (Epic 6), honest transport semantics (Epic 7 — declared
-plain NATS).
+plain NATS), gRPC server TLS/mTLS posture (Epic 8 server side).
 
 ### P1 — required before production
 
@@ -486,26 +487,52 @@ integration on direct gRPC.
 
 ### Epic 8. TLS / mTLS parity
 
-Status: not started
+Status: mostly done (gRPC server side); Runtime client TLS deferred.
 
-Current state:
+Current state (2026-05-11):
 
-- gRPC server in `crates/choreo/src/runtime.rs` is built with
-  `Server::builder().add_service(...)` only — no `ServerTlsConfig`,
-  no identity wiring
-- Runtime gRPC client in `RuntimeExecutor::connect` uses
-  `Endpoint::from_shared(...).connect()` only — no `.tls_config(...)`
-- chart still exposes `tls.mode` / `tls.existingSecret` in
-  `values.yaml`, but no template references those keys; they are dead
-  config
-- Cargo workspace has no `rustls` / `tokio-rustls` / `ServerTlsConfig`
-  usage in the binary or in the gRPC adapters
+- gRPC server in `crates/choreo/src/runtime.rs` builds with
+  `ServerTlsConfig::new().identity(...)` (server mode) or additionally
+  `client_ca_root(...)` (mutual mode), driven by the new
+  `GrpcTlsConfig` enum in `ServiceConfig`. PEM files are read at
+  startup; a misconfigured deployment fails fast.
+- `EnvConfiguration` reads `CHOREO_GRPC_TLS_MODE` (`none`/`server`/`mutual`),
+  `CHOREO_GRPC_TLS_CERT_PATH`, `CHOREO_GRPC_TLS_KEY_PATH`, and (for mutual)
+  `CHOREO_GRPC_TLS_CLIENT_CA_PATH`. Validation surfaces missing-path
+  combinations as `DomainError::EmptyField` and an invalid mode as
+  `InvariantViolated`.
+- Chart template (`charts/choreographer/templates/deployment.yaml`) mounts
+  `tls.existingSecret` read-only at `/etc/choreographer/tls` and passes
+  the matching env vars; rendering with `tls.mode != "none"` but no
+  `existingSecret` fails the helm template with an explicit message.
+- `scripts/ci/helm-lint.sh` gate 4 asserts the rendered manifest for
+  both `server` and `mutual` modes carries the expected env vars and
+  volume mount, and that `server` mode does NOT carry the client-CA
+  env var.
+- `values.yaml` `tls.mode` and `tls.existingSecret` are now honest
+  configuration with documented secret layout.
+
+Remaining work (deferred to a follow-up epic slice):
+
+- Runtime gRPC client TLS in `RuntimeExecutor::connect` — still uses
+  plain `Endpoint::from_shared(...).connect()`. Out-of-process mTLS
+  to the Runtime service requires a coordinated identity rollout with
+  the runtime team.
+- Rust integration test that performs an actual TLS handshake against
+  the choreographer (e.g. with `rcgen` to generate a self-signed cert
+  in the test). Today the wiring is exercised by helm-lint gate 4
+  plus the env-loading unit tests; the handshake itself is implicitly
+  validated by the tonic library's invariants but not asserted
+  end-to-end from this repo.
 
 Relevant code:
 
 - [`crates/choreo/src/runtime.rs`](../crates/choreo/src/runtime.rs)
-- [`crates/choreo-adapters/src/runtime.rs`](../crates/choreo-adapters/src/runtime.rs)
-- [`charts/choreographer/values.yaml`](../charts/choreographer/values.yaml)
+- [`crates/choreo-adapters/src/config.rs`](../crates/choreo-adapters/src/config.rs)
+- [`crates/choreo-core/src/ports/configuration.rs`](../crates/choreo-core/src/ports/configuration.rs)
+- [`charts/choreographer/templates/deployment.yaml`](../charts/choreographer/templates/deployment.yaml)
+- [`scripts/ci/helm-lint.sh`](../scripts/ci/helm-lint.sh)
+- [`crates/choreo-adapters/src/runtime.rs`](../crates/choreo-adapters/src/runtime.rs) (Runtime client — still no TLS)
 
 #### Deliverables
 
@@ -717,8 +744,8 @@ Exit condition:
 
 - composition, transport, and security claims match reality
 
-**Mostly cleared 2026-05-11.** Epics 6 and 7 done; Epic 8 still not
-started.
+**Mostly cleared 2026-05-11.** Epics 6 and 7 done; Epic 8 server side
+done, Runtime client TLS leg deferred.
 
 ### Milestone D — PIR-facing surface
 
@@ -780,11 +807,19 @@ tests via `NoopAgentFactory`).
   retitled accordingly. JetStream remains the upgrade path if the
   bus-coupling requirement later demands durability.
 
-#### Wave 4c — TLS honesty
+#### Wave 4c — TLS honesty — partially done
 
-- wire `ServerTlsConfig` on the gRPC server (and Runtime client) or
-  remove the chart's `tls.*` keys; one integration test for the
-  enabled mode
+- gRPC server: `GrpcTlsConfig` wired through `ServiceConfig`,
+  `EnvConfiguration` validates the mode combinations, `runtime.rs`
+  applies `ServerTlsConfig` (server or mutual). Chart template now
+  mounts the secret and passes env vars; helm-lint gate 4 asserts
+  the rendered manifest for both modes; 6 env-loading unit tests
+  pin the validation paths.
+- Open follow-up: Runtime gRPC client TLS in `RuntimeExecutor::connect`
+  (requires coordinated identity rollout with the runtime team) and
+  a Rust integration test that performs a real TLS handshake against
+  the choreographer (likely with `rcgen` to generate a self-signed
+  cert in-test).
 
 #### Wave 5 — PIR-facing surface
 

--- a/scripts/ci/helm-lint.sh
+++ b/scripts/ci/helm-lint.sh
@@ -62,3 +62,70 @@ for marker in "${required_markers[@]}"; do
     exit 1
   fi
 done
+
+# --- Gate 4: TLS render. `tls.mode=server` with an existingSecret
+# must wire the env vars + volume mount; `tls.mode=mutual` must also
+# carry the client-CA env var; `tls.mode=server` without a secret
+# must fail loudly.
+
+TLS_SERVER_OUT="${TMP_DIR}/choreographer-helm-tls-server.yaml"
+TLS_MUTUAL_OUT="${TMP_DIR}/choreographer-helm-tls-mutual.yaml"
+TLS_MISSING_ERR="${TMP_DIR}/choreographer-helm-tls-missing.err"
+
+if helm template choreographer "${CHART_PATH}" \
+  --set image.tag=v0 \
+  --set tls.mode=server \
+  > /dev/null 2>"${TLS_MISSING_ERR}"; then
+  echo "tls.mode=server with no existingSecret render unexpectedly succeeded" >&2
+  exit 1
+fi
+grep -q "tls.mode is not 'none' but tls.existingSecret is empty" "${TLS_MISSING_ERR}"
+
+helm template choreographer "${CHART_PATH}" \
+  --set image.tag=v0 \
+  --set tls.mode=server \
+  --set tls.existingSecret=choreo-grpc-tls \
+  > "${TLS_SERVER_OUT}"
+
+tls_server_markers=(
+  'name: CHOREO_GRPC_TLS_MODE'
+  'value: "server"'
+  'name: CHOREO_GRPC_TLS_CERT_PATH'
+  'value: "/etc/choreographer/tls/tls.crt"'
+  'name: CHOREO_GRPC_TLS_KEY_PATH'
+  'value: "/etc/choreographer/tls/tls.key"'
+  'name: grpc-tls'
+  'secretName: "choreo-grpc-tls"'
+  'mountPath: /etc/choreographer/tls'
+)
+for marker in "${tls_server_markers[@]}"; do
+  if ! grep -qF -- "${marker}" "${TLS_SERVER_OUT}"; then
+    echo "tls=server chart manifest missing required marker: ${marker}" >&2
+    exit 1
+  fi
+done
+
+if grep -qF 'CHOREO_GRPC_TLS_CLIENT_CA_PATH' "${TLS_SERVER_OUT}"; then
+  echo "tls=server manifest must NOT carry CHOREO_GRPC_TLS_CLIENT_CA_PATH" >&2
+  exit 1
+fi
+
+helm template choreographer "${CHART_PATH}" \
+  --set image.tag=v0 \
+  --set tls.mode=mutual \
+  --set tls.existingSecret=choreo-grpc-mtls \
+  > "${TLS_MUTUAL_OUT}"
+
+tls_mutual_markers=(
+  'name: CHOREO_GRPC_TLS_MODE'
+  'value: "mutual"'
+  'name: CHOREO_GRPC_TLS_CLIENT_CA_PATH'
+  'value: "/etc/choreographer/tls/ca.crt"'
+  'secretName: "choreo-grpc-mtls"'
+)
+for marker in "${tls_mutual_markers[@]}"; do
+  if ! grep -qF -- "${marker}" "${TLS_MUTUAL_OUT}"; then
+    echo "tls=mutual chart manifest missing required marker: ${marker}" >&2
+    exit 1
+  fi
+done


### PR DESCRIPTION
## Summary

Advances **Epic 8** of the PIR readiness backlog. The chart's `tls.mode` / `tls.existingSecret` keys were previously dead config; the gRPC server bound on plain HTTP/2 regardless of the chart's stated posture. This PR closes the **server-side** gap end to end.

## What landed

- `ServiceConfig.grpc_tls: GrpcTlsConfig` enum with `Disabled` / `Server` / `Mutual` variants
- `EnvConfiguration` reads `CHOREO_GRPC_TLS_MODE` + cert/key/client-CA paths, validates the combinations
- `runtime.rs` builds `tonic::transport::Server` with `ServerTlsConfig` honouring the mode; misconfigured deployments fail fast at startup
- `tonic = { features = ["tls", "tls-roots"] }` in workspace deps
- Chart `templates/deployment.yaml` mounts `existingSecret` at `/etc/choreographer/tls` and passes the env vars
- `values.yaml` documents the expected secret keys (`tls.crt`, `tls.key`, `ca.crt` for mutual)
- `scripts/ci/helm-lint.sh` gate 4 asserts the rendered manifest for both `server` and `mutual` modes, plus a negative gate for `server` without a secret

## Honest scope

Two pieces still open (recorded under Epic 8 in the backlog):

1. **Runtime gRPC client TLS** in `RuntimeExecutor::connect` — out-of-process mTLS to the runtime needs a coordinated identity rollout with the runtime team. Today's adapter still uses plain `Endpoint::from_shared(...).connect()`.
2. **Rust integration test for a real TLS handshake** against the choreographer — would need `rcgen` (dev-dep) to generate a self-signed cert at runtime. Today's wiring is exercised by helm-lint gate 4 plus the env-loading unit tests; the handshake itself relies on tonic's library invariants.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --locked $PROVIDER_FEATURES -- -D warnings`
- [x] `cargo test --workspace --locked $PROVIDER_FEATURES` — **422 passed, 0 failed** (+6 new TLS env-loading tests)
- [x] `bash scripts/ci/helm-lint.sh` — gate 4 (TLS) added and passes locally
- [ ] Per-PR CI gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)