### PR TITLE
feat(mcp): hand-rolled stdio MCP adapter for the choreographer API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,6 +474,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "choreo-mcp"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "choreo-proto",
+ "futures",
+ "opentelemetry",
+ "prost-types",
+ "serde_json",
+ "sha2",
+ "time",
+ "tokio",
+ "tonic",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "choreo-proto"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/choreo",
     "crates/choreo-tests-integration",
     "crates/choreo-e2e-runner",
+    "crates/choreo-mcp",
 ]
 
 [workspace.package]
@@ -95,6 +96,9 @@ tokio-test = "0.4"
 
 # benchmarking
 criterion = { version = "0.5", features = ["async_tokio"] }
+
+# crypto / hashing
+sha2 = "0.10"
 
 # internal
 choreo-core = { path = "crates/choreo-core" }

--- a/crates/choreo-mcp/Cargo.toml
+++ b/crates/choreo-mcp/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "choreo-mcp"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Stdio MCP (Model Context Protocol) adapter that exposes the Underpass Choreographer gRPC API to coding agents (Codex, Claude Desktop, …)."
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "choreo-mcp"
+path = "src/main.rs"
+
+[dependencies]
+choreo-proto = { workspace = true }
+async-trait = { workspace = true }
+futures = { workspace = true }
+prost-types = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+time = { workspace = true }
+tokio = { workspace = true }
+tonic = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+opentelemetry = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/choreo-mcp/src/backend.rs
+++ b/crates/choreo-mcp/src/backend.rs
@@ -1,0 +1,298 @@
+//! Backend trait + env-driven TLS configuration for the choreo MCP
+//! server.
+//!
+//! The MCP layer talks to exactly one [`ChoreoMcpToolBackend`]; the
+//! production impl is gRPC against a running choreographer, the
+//! fixture impl reads canned responses for client-wiring smoke tests.
+//! Backend selection happens at startup from
+//! [`CHOREO_MCP_BACKEND`](MCP_BACKEND_ENV) — default `grpc`,
+//! fail-fast when the endpoint env is missing.
+
+use std::future::Future;
+use std::path::PathBuf;
+use std::pin::Pin;
+
+use serde_json::Value;
+
+/// Endpoint URL the MCP gRPC backend should connect to.
+pub const GRPC_ENDPOINT_ENV: &str = "CHOREO_MCP_GRPC_ENDPOINT";
+/// Backend selector: `grpc` (default) or `fixture`.
+pub const MCP_BACKEND_ENV: &str = "CHOREO_MCP_BACKEND";
+/// TLS mode override for the gRPC client: `disabled`/`server`/`mutual`.
+pub const GRPC_TLS_MODE_ENV: &str = "CHOREO_MCP_GRPC_TLS_MODE";
+/// PEM bundle the client should trust as a CA when verifying the
+/// server (server or mutual mode).
+pub const GRPC_TLS_CA_PATH_ENV: &str = "CHOREO_MCP_GRPC_TLS_CA_PATH";
+/// Client certificate PEM the MCP presents to the server (mutual).
+pub const GRPC_TLS_CERT_PATH_ENV: &str = "CHOREO_MCP_GRPC_TLS_CERT_PATH";
+/// Client private key PEM matching `_CERT_PATH` (mutual).
+pub const GRPC_TLS_KEY_PATH_ENV: &str = "CHOREO_MCP_GRPC_TLS_KEY_PATH";
+/// Override the TLS SNI/domain (when the URL host differs from the
+/// cert CN/SAN, e.g. behind a kube Service).
+pub const GRPC_TLS_DOMAIN_NAME_ENV: &str = "CHOREO_MCP_GRPC_TLS_DOMAIN_NAME";
+
+/// Async tool-call future shape. Boxed so the trait stays object-safe.
+pub type ChoreoMcpToolFuture<'a> = Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>>;
+
+/// Single seam between the MCP request dispatcher and any concrete
+/// transport. The MCP server reads only the trait; switching from
+/// fixtures to live gRPC is a single line in `main.rs`.
+pub trait ChoreoMcpToolBackend: Send + Sync {
+    /// Operator-friendly backend label for the `initialize` response
+    /// metadata and structured tracing.
+    fn backend_name(&self) -> &'static str;
+
+    /// Operator-friendly TLS posture label for startup logs and the
+    /// `initialize` response metadata.
+    fn grpc_tls_mode_name(&self) -> &'static str {
+        "disabled"
+    }
+
+    /// Dispatch one MCP tool call.
+    ///
+    /// `arguments` is the raw JSON `arguments` field from
+    /// `tools/call.params`. The backend owns its own argument
+    /// validation, proto mapping, and error taxonomy. Errors come back
+    /// as plain strings; the server wraps them in the MCP-spec
+    /// `isError: true` content block.
+    fn call_tool<'a>(&'a self, name: &'a str, arguments: &'a Value) -> ChoreoMcpToolFuture<'a>;
+}
+
+/// Configured gRPC TLS posture for the MCP client.
+///
+/// Constructed via [`ChoreoMcpGrpcTlsConfig::from_env_for_endpoint`].
+/// The MCP layer never decides TLS by itself — every variant maps to
+/// a tonic `ClientTlsConfig` shape one of the backends knows how to
+/// apply.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChoreoMcpGrpcTlsConfig {
+    pub(crate) mode: ChoreoMcpGrpcTlsMode,
+    pub(crate) ca_path: Option<PathBuf>,
+    pub(crate) cert_path: Option<PathBuf>,
+    pub(crate) key_path: Option<PathBuf>,
+    pub(crate) domain_name: Option<String>,
+}
+
+/// Operator-visible TLS posture options.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ChoreoMcpGrpcTlsMode {
+    /// Plain HTTP/2 over TCP.
+    Disabled,
+    /// One-way TLS: the server presents an identity, the client
+    /// verifies it through a CA bundle (or system roots).
+    Server,
+    /// Mutual TLS: client also presents an identity.
+    Mutual,
+}
+
+impl ChoreoMcpGrpcTlsMode {
+    /// Stable label for logs/metadata. Kept distinct from `Debug` so
+    /// machine consumers can grep for it.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Disabled => "disabled",
+            Self::Server => "server",
+            Self::Mutual => "mutual",
+        }
+    }
+}
+
+impl ChoreoMcpGrpcTlsConfig {
+    /// Explicitly disabled TLS — useful for in-cluster talks behind
+    /// network policies and for unit tests.
+    #[must_use]
+    pub fn disabled() -> Self {
+        Self {
+            mode: ChoreoMcpGrpcTlsMode::Disabled,
+            ca_path: None,
+            cert_path: None,
+            key_path: None,
+            domain_name: None,
+        }
+    }
+
+    /// One-way TLS with a caller-supplied CA bundle. Use system roots
+    /// by passing an `https://` endpoint without setting `_CA_PATH`.
+    #[must_use]
+    pub fn server(ca_path: impl Into<PathBuf>, domain_name: Option<String>) -> Self {
+        Self {
+            mode: ChoreoMcpGrpcTlsMode::Server,
+            ca_path: Some(ca_path.into()),
+            cert_path: None,
+            key_path: None,
+            domain_name,
+        }
+    }
+
+    /// Mutual TLS: caller presents an identity in addition to
+    /// verifying the server.
+    #[must_use]
+    pub fn mutual(
+        ca_path: impl Into<PathBuf>,
+        cert_path: impl Into<PathBuf>,
+        key_path: impl Into<PathBuf>,
+        domain_name: Option<String>,
+    ) -> Self {
+        Self {
+            mode: ChoreoMcpGrpcTlsMode::Mutual,
+            ca_path: Some(ca_path.into()),
+            cert_path: Some(cert_path.into()),
+            key_path: Some(key_path.into()),
+            domain_name,
+        }
+    }
+
+    /// Read the TLS posture from environment, with helpful
+    /// auto-detection so the common cases stay one env var:
+    ///
+    /// - `https://` endpoint OR `_CA_PATH` set OR `_DOMAIN_NAME` set
+    ///   → server TLS (system roots if no CA path);
+    /// - `_CERT_PATH` and/or `_KEY_PATH` set → mutual TLS;
+    /// - explicit `CHOREO_MCP_GRPC_TLS_MODE` always wins.
+    #[must_use]
+    pub fn from_env_for_endpoint(endpoint: Option<&str>) -> Self {
+        let ca_path = optional_env_path(GRPC_TLS_CA_PATH_ENV);
+        let cert_path = optional_env_path(GRPC_TLS_CERT_PATH_ENV);
+        let key_path = optional_env_path(GRPC_TLS_KEY_PATH_ENV);
+        let domain_name = optional_env_string(GRPC_TLS_DOMAIN_NAME_ENV);
+        let server_tls_requested = ca_path.is_some()
+            || domain_name.is_some()
+            || endpoint.is_some_and(|endpoint| endpoint.trim().starts_with("https://"));
+        let mode = optional_env_string(GRPC_TLS_MODE_ENV)
+            .and_then(|value| parse_tls_mode(&value))
+            .unwrap_or_else(|| {
+                if cert_path.is_some() || key_path.is_some() {
+                    ChoreoMcpGrpcTlsMode::Mutual
+                } else if server_tls_requested {
+                    ChoreoMcpGrpcTlsMode::Server
+                } else {
+                    ChoreoMcpGrpcTlsMode::Disabled
+                }
+            });
+
+        Self {
+            mode,
+            ca_path,
+            cert_path,
+            key_path,
+            domain_name,
+        }
+    }
+
+    /// Convenience: read TLS posture from env with no extra context.
+    #[must_use]
+    pub fn from_env() -> Self {
+        Self::from_env_for_endpoint(std::env::var(GRPC_ENDPOINT_ENV).ok().as_deref())
+    }
+
+    /// Active mode.
+    #[must_use]
+    pub fn mode(&self) -> ChoreoMcpGrpcTlsMode {
+        self.mode
+    }
+
+    /// Stable label for logs/metadata.
+    #[must_use]
+    pub fn mode_name(&self) -> &'static str {
+        self.mode.as_str()
+    }
+}
+
+/// When TLS is enabled, automatically rewrite an `http://` endpoint to
+/// `https://` so callers can flip a single env var (the TLS knob)
+/// without having to also change the URL scheme.
+pub(crate) fn endpoint_uri_for_tls_mode(endpoint: &str, mode: ChoreoMcpGrpcTlsMode) -> String {
+    if mode == ChoreoMcpGrpcTlsMode::Disabled {
+        return endpoint.to_string();
+    }
+    endpoint.strip_prefix("http://").map_or_else(
+        || endpoint.to_string(),
+        |without_scheme| format!("https://{without_scheme}"),
+    )
+}
+
+fn parse_tls_mode(value: &str) -> Option<ChoreoMcpGrpcTlsMode> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "disabled" | "disable" | "off" | "false" | "none" => Some(ChoreoMcpGrpcTlsMode::Disabled),
+        "server" | "tls" => Some(ChoreoMcpGrpcTlsMode::Server),
+        "mutual" | "mtls" | "m-tls" => Some(ChoreoMcpGrpcTlsMode::Mutual),
+        _ => None,
+    }
+}
+
+fn optional_env_path(name: &str) -> Option<PathBuf> {
+    optional_env_string(name).map(PathBuf::from)
+}
+
+fn optional_env_string(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tls_mode_labels_are_stable() {
+        assert_eq!(ChoreoMcpGrpcTlsMode::Disabled.as_str(), "disabled");
+        assert_eq!(ChoreoMcpGrpcTlsMode::Server.as_str(), "server");
+        assert_eq!(ChoreoMcpGrpcTlsMode::Mutual.as_str(), "mutual");
+    }
+
+    #[test]
+    fn endpoint_uri_upgrades_http_when_tls_enabled() {
+        assert_eq!(
+            endpoint_uri_for_tls_mode("http://127.0.0.1:50055", ChoreoMcpGrpcTlsMode::Server),
+            "https://127.0.0.1:50055"
+        );
+        assert_eq!(
+            endpoint_uri_for_tls_mode("https://x.example", ChoreoMcpGrpcTlsMode::Mutual),
+            "https://x.example"
+        );
+        assert_eq!(
+            endpoint_uri_for_tls_mode("http://127.0.0.1:50055", ChoreoMcpGrpcTlsMode::Disabled),
+            "http://127.0.0.1:50055"
+        );
+    }
+
+    #[test]
+    fn parse_tls_mode_accepts_aliases() {
+        assert_eq!(
+            parse_tls_mode("disabled"),
+            Some(ChoreoMcpGrpcTlsMode::Disabled)
+        );
+        assert_eq!(parse_tls_mode("none"), Some(ChoreoMcpGrpcTlsMode::Disabled));
+        assert_eq!(parse_tls_mode("server"), Some(ChoreoMcpGrpcTlsMode::Server));
+        assert_eq!(parse_tls_mode("tls"), Some(ChoreoMcpGrpcTlsMode::Server));
+        assert_eq!(parse_tls_mode("mutual"), Some(ChoreoMcpGrpcTlsMode::Mutual));
+        assert_eq!(parse_tls_mode("mtls"), Some(ChoreoMcpGrpcTlsMode::Mutual));
+        assert_eq!(parse_tls_mode("garbage"), None);
+    }
+
+    #[test]
+    fn tls_constructors_preserve_paths() {
+        let server = ChoreoMcpGrpcTlsConfig::server("/tmp/ca.pem", Some("choreo.local".into()));
+        assert_eq!(server.mode(), ChoreoMcpGrpcTlsMode::Server);
+        assert_eq!(
+            server.ca_path.as_deref(),
+            Some(std::path::Path::new("/tmp/ca.pem"))
+        );
+        assert_eq!(server.domain_name.as_deref(), Some("choreo.local"));
+
+        let mutual =
+            ChoreoMcpGrpcTlsConfig::mutual("/tmp/ca.pem", "/tmp/cert.pem", "/tmp/key.pem", None);
+        assert_eq!(mutual.mode(), ChoreoMcpGrpcTlsMode::Mutual);
+        assert_eq!(
+            mutual.cert_path.as_deref(),
+            Some(std::path::Path::new("/tmp/cert.pem"))
+        );
+        assert_eq!(
+            mutual.key_path.as_deref(),
+            Some(std::path::Path::new("/tmp/key.pem"))
+        );
+    }
+}

--- a/crates/choreo-mcp/src/fixture.rs
+++ b/crates/choreo-mcp/src/fixture.rs
@@ -1,0 +1,232 @@
+//! Fixture-backed [`ChoreoMcpToolBackend`].
+//!
+//! Returns canned, deterministic responses for every tool. Useful for:
+//!
+//! - validating client wiring (Claude Desktop / Codex CLI) without a
+//!   running choreographer in reach;
+//! - smoke tests in repos that consume this crate;
+//! - documenting the expected response shape — the fixtures are the
+//!   reference JSON that real gRPC responses will mirror field-for-field.
+
+use async_trait::async_trait;
+use serde_json::{json, Value};
+
+use crate::backend::{ChoreoMcpToolBackend, ChoreoMcpToolFuture};
+
+/// Backend that returns canned JSON for every tool. The shapes are
+/// kept aligned with what [`crate::grpc::GrpcChoreoMcpBackend`] will
+/// emit in live mode so client wiring is identical across modes.
+#[derive(Debug, Default, Clone)]
+pub struct FixtureChoreoMcpBackend;
+
+#[async_trait]
+impl ChoreoMcpToolBackend for FixtureChoreoMcpBackend {
+    fn backend_name(&self) -> &'static str {
+        "fixture"
+    }
+
+    fn call_tool<'a>(&'a self, name: &'a str, _arguments: &'a Value) -> ChoreoMcpToolFuture<'a> {
+        Box::pin(async move {
+            let structured = match name {
+                "choreo_deliberate" => deliberate_fixture(),
+                "choreo_stream_deliberation" => stream_fixture(),
+                "choreo_get_deliberation_result" => get_deliberation_fixture(),
+                "choreo_orchestrate" => orchestrate_fixture(),
+                "choreo_create_council" => create_council_fixture(),
+                "choreo_list_councils" => list_councils_fixture(),
+                "choreo_delete_council" => delete_council_fixture(),
+                "choreo_register_agent" => register_agent_fixture(),
+                "choreo_unregister_agent" => unregister_agent_fixture(),
+                "choreo_process_trigger_event" => process_trigger_fixture(),
+                "choreo_get_status" => get_status_fixture(),
+                "choreo_get_metrics" => get_metrics_fixture(),
+                other => {
+                    return Err(format!(
+                        "fixture backend: unknown tool `{other}` (this is a client-side typo, not a backend error)"
+                    ));
+                }
+            };
+            Ok(crate::protocol::tool_success_result(structured))
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Canned fixtures. Stable across releases so client wiring stays
+// reproducible. New fields appear here first, then in the real
+// adapter; tests in `tests/stdio_protocol.rs` pin the shape.
+// ---------------------------------------------------------------------------
+
+fn deliberate_fixture() -> Value {
+    json!({
+        "task_id": "task-fixture-1",
+        "winner_proposal_id": "proposal-fixture-a",
+        "duration_ms": 42,
+        "results": [
+            {
+                "rank": 0,
+                "proposal": {
+                    "proposal_id": "proposal-fixture-a",
+                    "author_agent_id": "agent-fixture-1",
+                    "content": "fixture answer",
+                    "metadata": {}
+                },
+                "validation": {
+                    "score": 1.0,
+                    "reports": [
+                        { "kind": "content-non-empty", "passed": true, "summary": "ok", "details": {} }
+                    ]
+                }
+            }
+        ],
+        "metadata": { "fixture": true }
+    })
+}
+
+fn stream_fixture() -> Value {
+    json!({
+        "task_id": "task-fixture-1",
+        "frames": [
+            { "phase": "DELIBERATION_PHASE_PROPOSING", "emitted_at": null, "payload": null },
+            { "phase": "DELIBERATION_PHASE_REVISING", "emitted_at": null, "payload": null },
+            { "phase": "DELIBERATION_PHASE_VALIDATING", "emitted_at": null, "payload": null },
+            { "phase": "DELIBERATION_PHASE_SCORING", "emitted_at": null, "payload": null },
+            {
+                "phase": "DELIBERATION_PHASE_COMPLETED",
+                "emitted_at": null,
+                "payload": { "kind": "result", "result": deliberate_fixture()["results"][0].clone() }
+            }
+        ],
+        "winner": deliberate_fixture()["results"][0].clone()
+    })
+}
+
+fn get_deliberation_fixture() -> Value {
+    json!({
+        "found": true,
+        "result": deliberate_fixture()
+    })
+}
+
+fn orchestrate_fixture() -> Value {
+    json!({
+        "task_id": "task-fixture-1",
+        "execution_id": "exec-fixture-1",
+        "duration_ms": 73,
+        "winner": deliberate_fixture()["results"][0].clone(),
+        "candidates": [],
+        "metadata": { "fixture": true }
+    })
+}
+
+fn create_council_fixture() -> Value {
+    json!({
+        "council": {
+            "specialty": "triage",
+            "num_agents": 1,
+            "created_at": null,
+            "agents": []
+        }
+    })
+}
+
+fn list_councils_fixture() -> Value {
+    json!({
+        "councils": [
+            { "specialty": "triage", "num_agents": 1, "created_at": null, "agents": [] }
+        ]
+    })
+}
+
+fn delete_council_fixture() -> Value {
+    json!({ "deleted": true })
+}
+
+fn register_agent_fixture() -> Value {
+    json!({ "agent_id": "agent-fixture-1" })
+}
+
+fn unregister_agent_fixture() -> Value {
+    json!({ "unregistered": true })
+}
+
+fn process_trigger_fixture() -> Value {
+    json!({
+        "ack": {
+            "event_id": "evt-fixture-1",
+            "accepted": true,
+            "dispatched_task_ids": ["task-fixture-1"],
+            "reason": ""
+        }
+    })
+}
+
+fn get_status_fixture() -> Value {
+    json!({
+        "version": "fixture",
+        "uptime_seconds": 0,
+        "health": "healthy",
+        "stats": null
+    })
+}
+
+fn get_metrics_fixture() -> Value {
+    json!({
+        "stats": {
+            "total_deliberations": 0,
+            "total_orchestrations": 0,
+            "total_duration_ms": 0,
+            "average_duration_ms": 0.0,
+            "per_specialty_counts": {}
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn unknown_tool_returns_explicit_error() {
+        let backend = FixtureChoreoMcpBackend;
+        let err = backend.call_tool("nope", &json!({})).await.unwrap_err();
+        assert!(err.contains("unknown tool"));
+    }
+
+    #[tokio::test]
+    async fn deliberate_returns_mcp_success_envelope() {
+        let backend = FixtureChoreoMcpBackend;
+        let v = backend
+            .call_tool("choreo_deliberate", &json!({}))
+            .await
+            .unwrap();
+        assert_eq!(v["isError"], false);
+        assert_eq!(
+            v["structuredContent"]["winner_proposal_id"],
+            "proposal-fixture-a"
+        );
+    }
+
+    #[tokio::test]
+    async fn every_tool_has_a_fixture() {
+        let backend = FixtureChoreoMcpBackend;
+        for tool in [
+            "choreo_deliberate",
+            "choreo_stream_deliberation",
+            "choreo_get_deliberation_result",
+            "choreo_orchestrate",
+            "choreo_create_council",
+            "choreo_list_councils",
+            "choreo_delete_council",
+            "choreo_register_agent",
+            "choreo_unregister_agent",
+            "choreo_process_trigger_event",
+            "choreo_get_status",
+            "choreo_get_metrics",
+        ] {
+            let v = backend.call_tool(tool, &json!({})).await.unwrap();
+            assert_eq!(v["isError"], false, "{tool} fixture must be a success");
+        }
+    }
+}

--- a/crates/choreo-mcp/src/grpc.rs
+++ b/crates/choreo-mcp/src/grpc.rs
@@ -1,0 +1,72 @@
+//! Live-gRPC backend for the choreo MCP adapter.
+//!
+//! Talks to a running choreographer via the `underpass.choreo.v1`
+//! gRPC contract. Every tool maps 1:1 to one RPC; JSON arguments and
+//! responses are translated field-for-field by `json_to_proto` and
+//! `proto_to_json`, so the MCP layer never drops or flattens fields.
+
+mod channel;
+mod json_to_proto;
+mod proto_to_json;
+mod streaming;
+mod tools;
+
+use async_trait::async_trait;
+use serde_json::Value;
+use tonic::transport::Channel;
+use tracing::debug;
+
+use crate::backend::{
+    endpoint_uri_for_tls_mode, ChoreoMcpGrpcTlsConfig, ChoreoMcpToolBackend, ChoreoMcpToolFuture,
+};
+
+/// gRPC-backed implementation of [`ChoreoMcpToolBackend`].
+///
+/// Holds a lazily-connected tonic `Channel` (resolved on the first
+/// call) and the negotiated TLS posture. The endpoint URI is rewritten
+/// to `https://` when TLS is enabled so callers can flip one env var
+/// without having to also change the URL scheme.
+#[derive(Debug, Clone)]
+pub struct GrpcChoreoMcpBackend {
+    endpoint: String,
+    tls: ChoreoMcpGrpcTlsConfig,
+}
+
+impl GrpcChoreoMcpBackend {
+    /// Build a backend pointed at `endpoint` with the given TLS posture.
+    /// No network call happens here — the connection is opened on the
+    /// first tool call so `--help`-style probes don't block on DNS.
+    pub fn new(endpoint: impl Into<String>, tls: ChoreoMcpGrpcTlsConfig) -> Self {
+        let endpoint = endpoint_uri_for_tls_mode(&endpoint.into(), tls.mode());
+        Self { endpoint, tls }
+    }
+
+    async fn channel(&self) -> Result<Channel, String> {
+        channel::open_channel(&self.endpoint, &self.tls).await
+    }
+}
+
+#[async_trait]
+impl ChoreoMcpToolBackend for GrpcChoreoMcpBackend {
+    fn backend_name(&self) -> &'static str {
+        "grpc"
+    }
+
+    fn grpc_tls_mode_name(&self) -> &'static str {
+        self.tls.mode_name()
+    }
+
+    fn call_tool<'a>(&'a self, name: &'a str, arguments: &'a Value) -> ChoreoMcpToolFuture<'a> {
+        Box::pin(async move {
+            debug!(
+                tool = name,
+                tls = self.tls.mode_name(),
+                endpoint = self.endpoint.as_str(),
+                "choreo_mcp: dispatching live tool call"
+            );
+            let channel = self.channel().await?;
+            let structured = tools::dispatch(channel, name, arguments).await?;
+            Ok(crate::protocol::tool_success_result(structured))
+        })
+    }
+}

--- a/crates/choreo-mcp/src/grpc/channel.rs
+++ b/crates/choreo-mcp/src/grpc/channel.rs
@@ -1,0 +1,67 @@
+//! Tonic channel construction + TLS configuration.
+
+use tonic::transport::{Certificate, Channel, ClientTlsConfig, Endpoint, Identity};
+
+use crate::backend::{ChoreoMcpGrpcTlsConfig, ChoreoMcpGrpcTlsMode};
+
+/// Open a tonic channel honouring the configured TLS posture.
+///
+/// Mistakes surface as plain strings so the MCP tool result can carry
+/// them straight to the agent without leaking tonic internals.
+pub(crate) async fn open_channel(
+    endpoint: &str,
+    tls: &ChoreoMcpGrpcTlsConfig,
+) -> Result<Channel, String> {
+    let mut endpoint_builder = Endpoint::from_shared(endpoint.to_string())
+        .map_err(|err| format!("invalid gRPC endpoint `{endpoint}`: {err}"))?;
+
+    if tls.mode() != ChoreoMcpGrpcTlsMode::Disabled {
+        let tls_config = build_client_tls_config(tls).await?;
+        endpoint_builder = endpoint_builder
+            .tls_config(tls_config)
+            .map_err(|err| format!("failed to apply client TLS config: {err}"))?;
+    }
+
+    endpoint_builder
+        .connect()
+        .await
+        .map_err(|err| format!("gRPC connect to {endpoint} failed: {err}"))
+}
+
+async fn build_client_tls_config(tls: &ChoreoMcpGrpcTlsConfig) -> Result<ClientTlsConfig, String> {
+    let mut config = ClientTlsConfig::new();
+
+    if let Some(domain) = tls.domain_name.as_deref() {
+        config = config.domain_name(domain.to_string());
+    }
+
+    if let Some(ca_path) = tls.ca_path.as_ref() {
+        let pem = tokio::fs::read(ca_path)
+            .await
+            .map_err(|err| format!("failed to read TLS CA at {}: {err}", ca_path.display()))?;
+        config = config.ca_certificate(Certificate::from_pem(pem));
+    }
+
+    if tls.mode() == ChoreoMcpGrpcTlsMode::Mutual {
+        let cert_path = tls
+            .cert_path
+            .as_ref()
+            .ok_or_else(|| "TLS mode=mutual requires CHOREO_MCP_GRPC_TLS_CERT_PATH".to_string())?;
+        let key_path = tls
+            .key_path
+            .as_ref()
+            .ok_or_else(|| "TLS mode=mutual requires CHOREO_MCP_GRPC_TLS_KEY_PATH".to_string())?;
+        let cert = tokio::fs::read(cert_path).await.map_err(|err| {
+            format!(
+                "failed to read client cert at {}: {err}",
+                cert_path.display()
+            )
+        })?;
+        let key = tokio::fs::read(key_path)
+            .await
+            .map_err(|err| format!("failed to read client key at {}: {err}", key_path.display()))?;
+        config = config.identity(Identity::from_pem(cert, key));
+    }
+
+    Ok(config)
+}

--- a/crates/choreo-mcp/src/grpc/json_to_proto.rs
+++ b/crates/choreo-mcp/src/grpc/json_to_proto.rs
@@ -1,0 +1,353 @@
+//! JSON-arguments → proto-request mappers.
+//!
+//! Hand-written field-by-field so every choreo.proto field has an
+//! explicit code path. No `serde_json::to_value(proto)` shortcuts —
+//! that would happily ignore fields the schema added and silently
+//! lose information.
+
+use std::collections::BTreeMap;
+
+use choreo_proto::v1 as pb;
+use prost_types::{
+    value::Kind as PbKind, ListValue, Struct as PbStruct, Timestamp, Value as PbValue,
+};
+use serde_json::Value;
+
+// ---------------------------------------------------------------------------
+// Primitive helpers
+// ---------------------------------------------------------------------------
+
+pub(crate) fn require_object<'a>(
+    value: &'a Value,
+    where_: &str,
+) -> Result<&'a serde_json::Map<String, Value>, String> {
+    value
+        .as_object()
+        .ok_or_else(|| format!("{where_}: expected an object"))
+}
+
+pub(crate) fn require_str<'a>(
+    obj: &'a serde_json::Map<String, Value>,
+    key: &str,
+) -> Result<&'a str, String> {
+    obj.get(key)
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("missing required string `{key}`"))
+}
+
+pub(crate) fn optional_str<'a>(
+    obj: &'a serde_json::Map<String, Value>,
+    key: &str,
+) -> Option<&'a str> {
+    obj.get(key).and_then(Value::as_str)
+}
+
+pub(crate) fn optional_u32(obj: &serde_json::Map<String, Value>, key: &str) -> Result<u32, String> {
+    match obj.get(key) {
+        None | Some(Value::Null) => Ok(0),
+        Some(Value::Number(n)) => n
+            .as_u64()
+            .and_then(|n| u32::try_from(n).ok())
+            .ok_or_else(|| format!("`{key}` must be a non-negative u32")),
+        Some(_) => Err(format!("`{key}` must be a number")),
+    }
+}
+
+pub(crate) fn optional_u64(obj: &serde_json::Map<String, Value>, key: &str) -> Result<u64, String> {
+    match obj.get(key) {
+        None | Some(Value::Null) => Ok(0),
+        Some(Value::Number(n)) => n
+            .as_u64()
+            .ok_or_else(|| format!("`{key}` must be a non-negative u64")),
+        Some(_) => Err(format!("`{key}` must be a number")),
+    }
+}
+
+pub(crate) fn optional_bool(obj: &serde_json::Map<String, Value>, key: &str) -> bool {
+    matches!(obj.get(key), Some(Value::Bool(true)))
+}
+
+pub(crate) fn json_to_pb_value(value: &Value) -> PbValue {
+    let kind = match value {
+        Value::Null => PbKind::NullValue(0),
+        Value::Bool(b) => PbKind::BoolValue(*b),
+        Value::Number(n) => PbKind::NumberValue(n.as_f64().unwrap_or_default()),
+        Value::String(s) => PbKind::StringValue(s.clone()),
+        Value::Array(arr) => PbKind::ListValue(ListValue {
+            values: arr.iter().map(json_to_pb_value).collect(),
+        }),
+        Value::Object(obj) => PbKind::StructValue(json_object_to_pb_struct(obj)),
+    };
+    PbValue { kind: Some(kind) }
+}
+
+pub(crate) fn json_object_to_pb_struct(obj: &serde_json::Map<String, Value>) -> PbStruct {
+    PbStruct {
+        fields: obj
+            .iter()
+            .map(|(k, v)| (k.clone(), json_to_pb_value(v)))
+            .collect(),
+    }
+}
+
+pub(crate) fn optional_pb_struct(
+    obj: &serde_json::Map<String, Value>,
+    key: &str,
+) -> Result<Option<PbStruct>, String> {
+    match obj.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Object(o)) => Ok(Some(json_object_to_pb_struct(o))),
+        Some(_) => Err(format!("`{key}` must be a JSON object")),
+    }
+}
+
+pub(crate) fn parse_rfc3339_to_timestamp(value: &str) -> Result<Timestamp, String> {
+    // Minimal RFC3339 parsing using `time` crate.
+    let dt = time::OffsetDateTime::parse(value, &time::format_description::well_known::Rfc3339)
+        .map_err(|err| format!("invalid RFC3339 timestamp `{value}`: {err}"))?;
+    let nanos = dt.unix_timestamp_nanos();
+    let seconds = (nanos / 1_000_000_000) as i64;
+    let nanos = (nanos % 1_000_000_000) as i32;
+    Ok(Timestamp { seconds, nanos })
+}
+
+pub(crate) fn optional_timestamp(
+    obj: &serde_json::Map<String, Value>,
+    key: &str,
+) -> Result<Option<Timestamp>, String> {
+    match optional_str(obj, key) {
+        None | Some("") => Ok(None),
+        Some(value) => parse_rfc3339_to_timestamp(value).map(Some),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Composite mappers (one per proto type)
+// ---------------------------------------------------------------------------
+
+pub(crate) fn task_from_json(value: &Value) -> Result<pb::Task, String> {
+    let obj = require_object(value, "task")?;
+    Ok(pb::Task {
+        task_id: require_str(obj, "task_id")?.to_string(),
+        description: optional_str(obj, "description").unwrap_or("").to_string(),
+        specialty: require_str(obj, "specialty")?.to_string(),
+        constraints: optional_constraints(obj.get("constraints"))?,
+        attributes: optional_pb_struct(obj, "attributes")?,
+        external_context: optional_external_context(obj.get("external_context"))?,
+        metadata: optional_task_metadata(obj.get("metadata"))?,
+    })
+}
+
+fn optional_constraints(value: Option<&Value>) -> Result<Option<pb::Constraints>, String> {
+    let Some(value) = value else { return Ok(None) };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let obj = require_object(value, "task.constraints")?;
+    Ok(Some(pb::Constraints {
+        rubric: optional_pb_struct(obj, "rubric")?,
+        rounds: optional_u32(obj, "rounds")?,
+        num_agents: optional_u32(obj, "num_agents")?,
+        deadline_ms: optional_u64(obj, "deadline_ms")?,
+        output_contract: optional_output_contract(obj.get("output_contract"))?,
+    }))
+}
+
+fn optional_output_contract(value: Option<&Value>) -> Result<Option<pb::OutputContract>, String> {
+    let Some(value) = value else { return Ok(None) };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let obj = require_object(value, "task.constraints.output_contract")?;
+    let format = match optional_str(obj, "format") {
+        Some("json_object") | None => pb::OutputFormat::JsonObject as i32,
+        Some(other) => {
+            return Err(format!(
+                "output_contract.format `{other}` is not supported; only `json_object` is implemented"
+            ));
+        }
+    };
+    let mut fields: BTreeMap<String, pb::OutputFieldRule> = BTreeMap::new();
+    if let Some(map) = obj.get("fields").and_then(Value::as_object) {
+        for (name, rule_value) in map {
+            let rule_obj = require_object(rule_value, "output_contract.fields.<rule>")?;
+            let required = optional_bool(rule_obj, "required");
+            let allowed = rule_obj
+                .get("allowed_string_values")
+                .and_then(Value::as_array)
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(str::to_string))
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            fields.insert(
+                name.clone(),
+                pb::OutputFieldRule {
+                    required,
+                    allowed_string_values: allowed,
+                },
+            );
+        }
+    }
+    Ok(Some(pb::OutputContract {
+        contract_id: optional_str(obj, "contract_id").unwrap_or("").to_string(),
+        format,
+        fields: fields.into_iter().collect(),
+    }))
+}
+
+fn optional_external_context(
+    value: Option<&Value>,
+) -> Result<Option<pb::ExternalContextBundle>, String> {
+    let Some(value) = value else { return Ok(None) };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let obj = require_object(value, "external_context")?;
+    let items = obj
+        .get("items")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .map(context_item_from_json)
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()?
+        .unwrap_or_default();
+    let references = obj
+        .get("references")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .map(context_reference_from_json)
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()?
+        .unwrap_or_default();
+    Ok(Some(pb::ExternalContextBundle {
+        bundle_id: optional_str(obj, "bundle_id").unwrap_or("").to_string(),
+        schema_version: optional_str(obj, "schema_version")
+            .unwrap_or("")
+            .to_string(),
+        summary: optional_context_summary(obj.get("summary"))?,
+        items,
+        references,
+        metadata: optional_pb_struct(obj, "metadata")?,
+    }))
+}
+
+fn optional_context_summary(value: Option<&Value>) -> Result<Option<pb::ContextSummary>, String> {
+    let Some(value) = value else { return Ok(None) };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let obj = require_object(value, "external_context.summary")?;
+    Ok(Some(pb::ContextSummary {
+        text: optional_str(obj, "text").unwrap_or("").to_string(),
+        attributes: optional_pb_struct(obj, "attributes")?,
+    }))
+}
+
+fn context_item_from_json(value: &Value) -> Result<pb::ContextItem, String> {
+    let obj = require_object(value, "external_context.items[]")?;
+    let reference_ids = obj
+        .get("reference_ids")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    Ok(pb::ContextItem {
+        item_id: require_str(obj, "item_id")?.to_string(),
+        kind: require_str(obj, "kind")?.to_string(),
+        title: optional_str(obj, "title").unwrap_or("").to_string(),
+        narrative: optional_str(obj, "narrative").unwrap_or("").to_string(),
+        attributes: optional_pb_struct(obj, "attributes")?,
+        reference_ids,
+    })
+}
+
+fn context_reference_from_json(value: &Value) -> Result<pb::ContextReference, String> {
+    let obj = require_object(value, "external_context.references[]")?;
+    Ok(pb::ContextReference {
+        reference_id: require_str(obj, "reference_id")?.to_string(),
+        uri: require_str(obj, "uri")?.to_string(),
+        title: optional_str(obj, "title").unwrap_or("").to_string(),
+        media_type: optional_str(obj, "media_type").unwrap_or("").to_string(),
+        attributes: optional_pb_struct(obj, "attributes")?,
+    })
+}
+
+fn optional_task_metadata(value: Option<&Value>) -> Result<Option<pb::TaskMetadata>, String> {
+    let Some(value) = value else { return Ok(None) };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let obj = require_object(value, "task.metadata")?;
+    Ok(Some(pb::TaskMetadata {
+        source_event_id: optional_str(obj, "source_event_id")
+            .unwrap_or("")
+            .to_string(),
+        causation_id: optional_str(obj, "causation_id").unwrap_or("").to_string(),
+        correlation_id: optional_str(obj, "correlation_id")
+            .unwrap_or("")
+            .to_string(),
+        council_contract_id: optional_str(obj, "council_contract_id")
+            .unwrap_or("")
+            .to_string(),
+        output_contract_id: optional_str(obj, "output_contract_id")
+            .unwrap_or("")
+            .to_string(),
+        execution_profile: optional_pb_struct(obj, "execution_profile")?,
+    }))
+}
+
+pub(crate) fn agent_summary_from_json(value: &Value) -> Result<pb::AgentSummary, String> {
+    let obj = require_object(value, "agent")?;
+    Ok(pb::AgentSummary {
+        agent_id: require_str(obj, "agent_id")?.to_string(),
+        specialty: require_str(obj, "specialty")?.to_string(),
+        kind: require_str(obj, "kind")?.to_string(),
+        attributes: optional_pb_struct(obj, "attributes")?,
+    })
+}
+
+pub(crate) fn trigger_event_from_json(value: &Value) -> Result<pb::TriggerEvent, String> {
+    let obj = require_object(value, "event")?;
+    let requested_specialties = obj
+        .get("requested_specialties")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    if requested_specialties.is_empty() {
+        return Err("event.requested_specialties must be a non-empty array of strings".into());
+    }
+
+    let constraints = optional_constraints(obj.get("constraints"))?;
+    let external_context = optional_external_context(obj.get("external_context"))?;
+
+    Ok(pb::TriggerEvent {
+        event_id: require_str(obj, "event_id")?.to_string(),
+        kind: require_str(obj, "kind")?.to_string(),
+        source: require_str(obj, "source")?.to_string(),
+        emitted_at: optional_timestamp(obj, "emitted_at")?,
+        requested_specialties,
+        task_description_template: optional_str(obj, "task_description_template")
+            .unwrap_or("")
+            .to_string(),
+        constraints,
+        payload: optional_pb_struct(obj, "payload")?,
+        external_context,
+        correlation_id: optional_str(obj, "correlation_id")
+            .unwrap_or("")
+            .to_string(),
+        causation_id: optional_str(obj, "causation_id").unwrap_or("").to_string(),
+    })
+}

--- a/crates/choreo-mcp/src/grpc/proto_to_json.rs
+++ b/crates/choreo-mcp/src/grpc/proto_to_json.rs
@@ -1,0 +1,230 @@
+//! proto-response → JSON mappers.
+//!
+//! Mirror of `json_to_proto.rs`. Every proto field gets a named JSON
+//! key explicitly so the wire schema is documented in the code and
+//! reviewers can spot accidental drops at PR time.
+
+use choreo_proto::v1 as pb;
+use prost_types::{
+    value::Kind as PbKind, ListValue, Struct as PbStruct, Timestamp, Value as PbValue,
+};
+use serde_json::{json, Map, Number as JsonNumber, Value};
+
+// ---------------------------------------------------------------------------
+// Primitives
+// ---------------------------------------------------------------------------
+
+pub(crate) fn pb_value_to_json(value: PbValue) -> Value {
+    match value.kind {
+        None | Some(PbKind::NullValue(_)) => Value::Null,
+        Some(PbKind::BoolValue(b)) => Value::Bool(b),
+        Some(PbKind::NumberValue(n)) => JsonNumber::from_f64(n).map_or(Value::Null, Value::Number),
+        Some(PbKind::StringValue(s)) => Value::String(s),
+        Some(PbKind::ListValue(ListValue { values })) => {
+            Value::Array(values.into_iter().map(pb_value_to_json).collect())
+        }
+        Some(PbKind::StructValue(s)) => Value::Object(pb_struct_to_json(s)),
+    }
+}
+
+pub(crate) fn pb_struct_to_json(s: PbStruct) -> Map<String, Value> {
+    s.fields
+        .into_iter()
+        .map(|(k, v)| (k, pb_value_to_json(v)))
+        .collect()
+}
+
+pub(crate) fn optional_pb_struct_to_json(s: Option<PbStruct>) -> Value {
+    match s {
+        Some(s) => Value::Object(pb_struct_to_json(s)),
+        None => Value::Object(Map::new()),
+    }
+}
+
+pub(crate) fn timestamp_to_rfc3339(ts: Option<&Timestamp>) -> Value {
+    let Some(Timestamp { seconds, nanos }) = ts else {
+        return Value::Null;
+    };
+    let nanos_total = i128::from(*seconds) * 1_000_000_000 + i128::from(*nanos);
+    time::OffsetDateTime::from_unix_timestamp_nanos(nanos_total)
+        .ok()
+        .and_then(|dt| {
+            dt.format(&time::format_description::well_known::Rfc3339)
+                .ok()
+        })
+        .map_or(Value::Null, Value::String)
+}
+
+fn phase_name(phase: i32) -> &'static str {
+    match pb::DeliberationPhase::try_from(phase).unwrap_or(pb::DeliberationPhase::Unspecified) {
+        pb::DeliberationPhase::Unspecified => "DELIBERATION_PHASE_UNSPECIFIED",
+        pb::DeliberationPhase::Proposing => "DELIBERATION_PHASE_PROPOSING",
+        pb::DeliberationPhase::Revising => "DELIBERATION_PHASE_REVISING",
+        pb::DeliberationPhase::Validating => "DELIBERATION_PHASE_VALIDATING",
+        pb::DeliberationPhase::Scoring => "DELIBERATION_PHASE_SCORING",
+        pb::DeliberationPhase::Completed => "DELIBERATION_PHASE_COMPLETED",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Composite responses
+// ---------------------------------------------------------------------------
+
+pub(crate) fn proposal_to_json(p: pb::Proposal) -> Value {
+    json!({
+        "proposal_id": p.proposal_id,
+        "author_agent_id": p.author_agent_id,
+        "content": p.content,
+        "metadata": optional_pb_struct_to_json(p.metadata),
+    })
+}
+
+pub(crate) fn validation_outcome_to_json(v: pb::ValidationOutcome) -> Value {
+    let reports: Vec<Value> = v
+        .reports
+        .into_iter()
+        .map(|r| {
+            json!({
+                "kind": r.kind,
+                "passed": r.passed,
+                "summary": r.summary,
+                "details": optional_pb_struct_to_json(r.details),
+            })
+        })
+        .collect();
+    let passed_overall = reports
+        .iter()
+        .all(|r| r["passed"].as_bool().unwrap_or(false));
+    json!({
+        "score": v.score,
+        "passed": passed_overall,
+        "reports": reports,
+    })
+}
+
+pub(crate) fn deliberation_result_to_json(r: pb::DeliberationResult) -> Value {
+    json!({
+        "rank": r.rank,
+        "proposal": r.proposal.map_or(Value::Null, proposal_to_json),
+        "validation": r
+            .validation
+            .map_or(Value::Null, validation_outcome_to_json),
+    })
+}
+
+pub(crate) fn deliberate_response_to_json(r: pb::DeliberateResponse) -> Value {
+    json!({
+        "task_id": r.task_id,
+        "winner_proposal_id": r.winner_proposal_id,
+        "duration_ms": r.duration_ms,
+        "results": r
+            .results
+            .into_iter()
+            .map(deliberation_result_to_json)
+            .collect::<Vec<_>>(),
+        "metadata": optional_pb_struct_to_json(r.metadata),
+    })
+}
+
+pub(crate) fn deliberation_update_to_json(u: pb::DeliberationUpdate) -> Value {
+    let payload = match u.payload {
+        None => Value::Null,
+        Some(pb::deliberation_update::Payload::Proposal(p)) => json!({
+            "kind": "proposal",
+            "proposal": proposal_to_json(p),
+        }),
+        Some(pb::deliberation_update::Payload::Critique(c)) => json!({
+            "kind": "critique",
+            "critique": {
+                "reviewer_agent_id": c.reviewer_agent_id,
+                "target_proposal_id": c.target_proposal_id,
+                "feedback": c.feedback,
+            }
+        }),
+        Some(pb::deliberation_update::Payload::Revision(r)) => json!({
+            "kind": "revision",
+            "revision": {
+                "author_agent_id": r.author_agent_id,
+                "proposal_id": r.proposal_id,
+                "updated_content": r.updated_content,
+            }
+        }),
+        Some(pb::deliberation_update::Payload::Validation(v)) => json!({
+            "kind": "validation",
+            "validation": validation_outcome_to_json(v),
+        }),
+        Some(pb::deliberation_update::Payload::Result(r)) => json!({
+            "kind": "result",
+            "result": deliberation_result_to_json(r),
+        }),
+    };
+    json!({
+        "task_id": u.task_id,
+        "phase": phase_name(u.phase),
+        "emitted_at": timestamp_to_rfc3339(u.emitted_at.as_ref()),
+        "payload": payload,
+    })
+}
+
+pub(crate) fn orchestrate_response_to_json(r: pb::OrchestrateResponse) -> Value {
+    json!({
+        "task_id": r.task_id,
+        "execution_id": r.execution_id,
+        "duration_ms": r.duration_ms,
+        "winner": r
+            .winner
+            .map_or(Value::Null, deliberation_result_to_json),
+        "candidates": r
+            .candidates
+            .into_iter()
+            .map(deliberation_result_to_json)
+            .collect::<Vec<_>>(),
+        "metadata": optional_pb_struct_to_json(r.metadata),
+    })
+}
+
+pub(crate) fn agent_summary_to_json(a: pb::AgentSummary) -> Value {
+    json!({
+        "agent_id": a.agent_id,
+        "specialty": a.specialty,
+        "kind": a.kind,
+        "attributes": optional_pb_struct_to_json(a.attributes),
+    })
+}
+
+pub(crate) fn council_summary_to_json(c: pb::CouncilSummary) -> Value {
+    json!({
+        "specialty": c.specialty,
+        "num_agents": c.num_agents,
+        "created_at": timestamp_to_rfc3339(c.created_at.as_ref()),
+        "agents": c
+            .agents
+            .into_iter()
+            .map(agent_summary_to_json)
+            .collect::<Vec<_>>(),
+    })
+}
+
+pub(crate) fn trigger_ack_to_json(a: &pb::TriggerAck) -> Value {
+    json!({
+        "event_id": a.event_id,
+        "accepted": a.accepted,
+        "dispatched_task_ids": a.dispatched_task_ids,
+        "reason": a.reason,
+    })
+}
+
+pub(crate) fn statistics_to_json(s: pb::Statistics) -> Value {
+    let per_specialty: Map<String, Value> = s
+        .per_specialty_counts
+        .into_iter()
+        .map(|(k, v)| (k, Value::Number(JsonNumber::from(v))))
+        .collect();
+    json!({
+        "total_deliberations": s.total_deliberations,
+        "total_orchestrations": s.total_orchestrations,
+        "total_duration_ms": s.total_duration_ms,
+        "average_duration_ms": s.average_duration_ms,
+        "per_specialty_counts": Value::Object(per_specialty),
+    })
+}

--- a/crates/choreo-mcp/src/grpc/streaming.rs
+++ b/crates/choreo-mcp/src/grpc/streaming.rs
@@ -1,0 +1,53 @@
+//! Buffered collector for `StreamDeliberation`.
+//!
+//! MCP stdio is synchronous request/response — there is no
+//! progress-notification surface that would let a coding agent
+//! consume the stream live. We buffer the entire server stream into
+//! a single response, returning every frame in order plus the final
+//! winner pulled out of the last `result`-typed frame for caller
+//! convenience.
+
+use choreo_proto::v1 as pb;
+use futures::StreamExt;
+use serde_json::{json, Value};
+use tonic::Streaming;
+
+use super::proto_to_json::{deliberation_result_to_json, deliberation_update_to_json};
+
+/// Collect a `StreamDeliberation` server stream into a single JSON
+/// response. Errors mid-stream surface as a tool error; partial
+/// frames already seen are NOT returned (rejecting half-baked output
+/// is honest — the caller can retry).
+pub(crate) async fn collect_stream(
+    mut stream: Streaming<pb::StreamDeliberationResponse>,
+) -> Result<Value, String> {
+    let mut frames: Vec<Value> = Vec::new();
+    let mut winner: Option<Value> = None;
+    let mut task_id: Option<String> = None;
+
+    while let Some(item) = stream.next().await {
+        let response =
+            item.map_err(|status| format!("stream item failed: {}", status.message()))?;
+        let Some(update) = response.update else {
+            continue;
+        };
+
+        if task_id.is_none() && !update.task_id.is_empty() {
+            task_id = Some(update.task_id.clone());
+        }
+
+        // Extract the winner from a `result` payload before the
+        // value moves into `deliberation_update_to_json`.
+        if let Some(pb::deliberation_update::Payload::Result(ref r)) = update.payload {
+            winner = Some(deliberation_result_to_json(r.clone()));
+        }
+
+        frames.push(deliberation_update_to_json(update));
+    }
+
+    Ok(json!({
+        "task_id": task_id.unwrap_or_default(),
+        "frames": frames,
+        "winner": winner.unwrap_or(Value::Null),
+    }))
+}

--- a/crates/choreo-mcp/src/grpc/tools.rs
+++ b/crates/choreo-mcp/src/grpc/tools.rs
@@ -1,0 +1,284 @@
+//! Tool-name → gRPC RPC dispatch.
+//!
+//! One entry per choreographer RPC. The dispatcher parses JSON
+//! arguments into the proto request via `json_to_proto`, calls the
+//! generated tonic client, and converts the response back via
+//! `proto_to_json`. tonic `Status` errors collapse to plain strings.
+
+use choreo_proto::v1 as pb;
+use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
+use serde_json::{json, Value};
+use tonic::transport::Channel;
+
+use super::json_to_proto as j2p;
+use super::proto_to_json as p2j;
+use super::streaming;
+
+/// Dispatch one tool call. Returns the **structured content** of the
+/// MCP tool result (just the JSON; the caller wraps it in
+/// `tool_success_result`).
+#[allow(clippy::too_many_lines)] // 12 tool arms; splitting fragments the dispatch table
+pub(crate) async fn dispatch(
+    channel: Channel,
+    name: &str,
+    arguments: &Value,
+) -> Result<Value, String> {
+    let mut client = ChoreographerServiceClient::new(channel);
+
+    match name {
+        "choreo_deliberate" => {
+            let request = build_deliberate_request(arguments)?;
+            let response = client
+                .deliberate(request)
+                .await
+                .map_err(|s| status_error(&s))?;
+            Ok(p2j::deliberate_response_to_json(response.into_inner()))
+        }
+
+        "choreo_stream_deliberation" => {
+            let request = build_stream_deliberation_request(arguments)?;
+            let response = client
+                .stream_deliberation(request)
+                .await
+                .map_err(|s| status_error(&s))?;
+            streaming::collect_stream(response.into_inner()).await
+        }
+
+        "choreo_get_deliberation_result" => {
+            let request = build_get_deliberation_result_request(arguments)?;
+            let response = client
+                .get_deliberation_result(request)
+                .await
+                .map_err(|s| status_error(&s))?;
+            let pb::GetDeliberationResultResponse { found, result } = response.into_inner();
+            Ok(json!({
+                "found": found,
+                "result": result.map_or(Value::Null, p2j::deliberate_response_to_json),
+            }))
+        }
+
+        "choreo_orchestrate" => {
+            let request = build_orchestrate_request(arguments)?;
+            let response = client
+                .orchestrate(request)
+                .await
+                .map_err(|s| status_error(&s))?;
+            Ok(p2j::orchestrate_response_to_json(response.into_inner()))
+        }
+
+        "choreo_create_council" => {
+            let request = build_create_council_request(arguments)?;
+            let response = client
+                .create_council(request)
+                .await
+                .map_err(|s| status_error(&s))?;
+            let pb::CreateCouncilResponse { council } = response.into_inner();
+            Ok(json!({
+                "council": council.map_or(Value::Null, p2j::council_summary_to_json),
+            }))
+        }
+
+        "choreo_list_councils" => {
+            let request = build_list_councils_request(arguments);
+            let response = client
+                .list_councils(request)
+                .await
+                .map_err(|s| status_error(&s))?;
+            let pb::ListCouncilsResponse { councils } = response.into_inner();
+            Ok(json!({
+                "councils": councils
+                    .into_iter()
+                    .map(p2j::council_summary_to_json)
+                    .collect::<Vec<_>>(),
+            }))
+        }
+
+        "choreo_delete_council" => {
+            let request = build_delete_council_request(arguments)?;
+            let response = client
+                .delete_council(request)
+                .await
+                .map_err(|s| status_error(&s))?;
+            let pb::DeleteCouncilResponse { deleted } = response.into_inner();
+            Ok(json!({ "deleted": deleted }))
+        }
+
+        "choreo_register_agent" => {
+            let request = build_register_agent_request(arguments)?;
+            let response = client
+                .register_agent(request)
+                .await
+                .map_err(|s| status_error(&s))?;
+            let pb::RegisterAgentResponse { agent_id } = response.into_inner();
+            Ok(json!({ "agent_id": agent_id }))
+        }
+
+        "choreo_unregister_agent" => {
+            let request = build_unregister_agent_request(arguments)?;
+            let response = client
+                .unregister_agent(request)
+                .await
+                .map_err(|s| status_error(&s))?;
+            let pb::UnregisterAgentResponse { unregistered } = response.into_inner();
+            Ok(json!({ "unregistered": unregistered }))
+        }
+
+        "choreo_process_trigger_event" => {
+            let request = build_process_trigger_event_request(arguments)?;
+            let response = client
+                .process_trigger_event(request)
+                .await
+                .map_err(|s| status_error(&s))?;
+            let pb::ProcessTriggerEventResponse { ack } = response.into_inner();
+            Ok(json!({
+                "ack": ack.as_ref().map_or(Value::Null, p2j::trigger_ack_to_json),
+            }))
+        }
+
+        "choreo_get_status" => {
+            let request = build_get_status_request(arguments);
+            let response = client
+                .get_status(request)
+                .await
+                .map_err(|s| status_error(&s))?;
+            let pb::GetStatusResponse {
+                version,
+                uptime_seconds,
+                health,
+                stats,
+            } = response.into_inner();
+            Ok(json!({
+                "version": version,
+                "uptime_seconds": uptime_seconds,
+                "health": health,
+                "stats": stats.map_or(Value::Null, p2j::statistics_to_json),
+            }))
+        }
+
+        "choreo_get_metrics" => {
+            let response = client
+                .get_metrics(pb::GetMetricsRequest {})
+                .await
+                .map_err(|s| status_error(&s))?;
+            let pb::GetMetricsResponse { stats } = response.into_inner();
+            Ok(json!({
+                "stats": stats.map_or(Value::Null, p2j::statistics_to_json),
+            }))
+        }
+
+        other => Err(format!("unknown choreo MCP tool `{other}`")),
+    }
+}
+
+fn status_error(status: &tonic::Status) -> String {
+    format!("gRPC {}: {}", status.code(), status.message())
+}
+
+// ---------------------------------------------------------------------------
+// Request builders. Each takes the raw `tools/call.arguments` JSON
+// value and produces a typed proto request. Validation errors come
+// back as plain strings; tonic gets a fully-formed proto.
+// ---------------------------------------------------------------------------
+
+fn build_deliberate_request(args: &Value) -> Result<pb::DeliberateRequest, String> {
+    let obj = j2p::require_object(args, "tools/call.arguments")?;
+    let task_value = obj
+        .get("task")
+        .ok_or_else(|| "missing required `task` object".to_string())?;
+    Ok(pb::DeliberateRequest {
+        task: Some(j2p::task_from_json(task_value)?),
+    })
+}
+
+fn build_stream_deliberation_request(
+    args: &Value,
+) -> Result<pb::StreamDeliberationRequest, String> {
+    let obj = j2p::require_object(args, "tools/call.arguments")?;
+    let task_value = obj
+        .get("task")
+        .ok_or_else(|| "missing required `task` object".to_string())?;
+    Ok(pb::StreamDeliberationRequest {
+        task: Some(j2p::task_from_json(task_value)?),
+    })
+}
+
+fn build_get_deliberation_result_request(
+    args: &Value,
+) -> Result<pb::GetDeliberationResultRequest, String> {
+    let obj = j2p::require_object(args, "tools/call.arguments")?;
+    Ok(pb::GetDeliberationResultRequest {
+        task_id: j2p::require_str(obj, "task_id")?.to_string(),
+    })
+}
+
+fn build_orchestrate_request(args: &Value) -> Result<pb::OrchestrateRequest, String> {
+    let obj = j2p::require_object(args, "tools/call.arguments")?;
+    let task_value = obj
+        .get("task")
+        .ok_or_else(|| "missing required `task` object".to_string())?;
+    Ok(pb::OrchestrateRequest {
+        task: Some(j2p::task_from_json(task_value)?),
+        execution_options: j2p::optional_pb_struct(obj, "execution_options")?,
+    })
+}
+
+fn build_create_council_request(args: &Value) -> Result<pb::CreateCouncilRequest, String> {
+    let obj = j2p::require_object(args, "tools/call.arguments")?;
+    Ok(pb::CreateCouncilRequest {
+        specialty: j2p::require_str(obj, "specialty")?.to_string(),
+        num_agents: j2p::optional_u32(obj, "num_agents")?,
+        agent_config: j2p::optional_pb_struct(obj, "agent_config")?,
+    })
+}
+
+fn build_list_councils_request(args: &Value) -> pb::ListCouncilsRequest {
+    let include_agents = args
+        .as_object()
+        .is_some_and(|obj| j2p::optional_bool(obj, "include_agents"));
+    pb::ListCouncilsRequest { include_agents }
+}
+
+fn build_delete_council_request(args: &Value) -> Result<pb::DeleteCouncilRequest, String> {
+    let obj = j2p::require_object(args, "tools/call.arguments")?;
+    Ok(pb::DeleteCouncilRequest {
+        specialty: j2p::require_str(obj, "specialty")?.to_string(),
+    })
+}
+
+fn build_register_agent_request(args: &Value) -> Result<pb::RegisterAgentRequest, String> {
+    let obj = j2p::require_object(args, "tools/call.arguments")?;
+    let agent_value = obj
+        .get("agent")
+        .ok_or_else(|| "missing required `agent` object".to_string())?;
+    Ok(pb::RegisterAgentRequest {
+        specialty: j2p::require_str(obj, "specialty")?.to_string(),
+        agent: Some(j2p::agent_summary_from_json(agent_value)?),
+        agent_config: j2p::optional_pb_struct(obj, "agent_config")?,
+    })
+}
+
+fn build_unregister_agent_request(args: &Value) -> Result<pb::UnregisterAgentRequest, String> {
+    let obj = j2p::require_object(args, "tools/call.arguments")?;
+    Ok(pb::UnregisterAgentRequest {
+        agent_id: j2p::require_str(obj, "agent_id")?.to_string(),
+    })
+}
+
+fn build_process_trigger_event_request(
+    args: &Value,
+) -> Result<pb::ProcessTriggerEventRequest, String> {
+    let obj = j2p::require_object(args, "tools/call.arguments")?;
+    let event_value = obj
+        .get("event")
+        .ok_or_else(|| "missing required `event` object".to_string())?;
+    Ok(pb::ProcessTriggerEventRequest {
+        event: Some(j2p::trigger_event_from_json(event_value)?),
+    })
+}
+
+fn build_get_status_request(args: &Value) -> pb::GetStatusRequest {
+    let include_stats = args
+        .as_object()
+        .is_some_and(|obj| j2p::optional_bool(obj, "include_stats"));
+    pb::GetStatusRequest { include_stats }
+}

--- a/crates/choreo-mcp/src/lib.rs
+++ b/crates/choreo-mcp/src/lib.rs
@@ -1,0 +1,25 @@
+//! Stdio MCP adapter for the Underpass Choreographer.
+//!
+//! Exposes every RPC in `underpass.choreo.v1` as an MCP tool over
+//! JSON-RPC 2.0 on stdin/stdout. Designed so coding agents (Codex,
+//! Claude Desktop) can talk to a running choreographer without
+//! re-implementing gRPC.
+//!
+//! See `crates/choreo-mcp/README.md` for end-user installation, and
+//! `docs/operations/mcp-stdio.md` for the canonical UX.
+
+pub mod backend;
+pub mod fixture;
+pub mod grpc;
+pub mod observability;
+pub mod protocol;
+pub mod server;
+
+pub use backend::{
+    ChoreoMcpGrpcTlsConfig, ChoreoMcpGrpcTlsMode, ChoreoMcpToolBackend, GRPC_ENDPOINT_ENV,
+    GRPC_TLS_CA_PATH_ENV, GRPC_TLS_CERT_PATH_ENV, GRPC_TLS_DOMAIN_NAME_ENV, GRPC_TLS_KEY_PATH_ENV,
+    GRPC_TLS_MODE_ENV, MCP_BACKEND_ENV,
+};
+pub use fixture::FixtureChoreoMcpBackend;
+pub use grpc::GrpcChoreoMcpBackend;
+pub use server::ChoreoMcpServer;

--- a/crates/choreo-mcp/src/main.rs
+++ b/crates/choreo-mcp/src/main.rs
@@ -1,0 +1,71 @@
+//! `choreo-mcp` — stdio MCP adapter for the Underpass Choreographer.
+//!
+//! Reads one JSON-RPC line at a time from stdin, dispatches to the
+//! inner [`ChoreoMcpServer`], writes the response to stdout. Stdout
+//! is reserved for JSON-RPC responses; logs go to stderr as JSON.
+//!
+//! See `docs/operations/mcp-stdio.md` for end-user setup.
+
+use std::io::{self, BufRead, Write};
+
+use choreo_mcp::{
+    ChoreoMcpServer, GRPC_ENDPOINT_ENV, GRPC_TLS_CA_PATH_ENV, GRPC_TLS_CERT_PATH_ENV,
+    GRPC_TLS_DOMAIN_NAME_ENV, GRPC_TLS_KEY_PATH_ENV, GRPC_TLS_MODE_ENV, MCP_BACKEND_ENV,
+};
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    init_tracing();
+
+    let server = match ChoreoMcpServer::try_from_env() {
+        Ok(server) => server,
+        Err(message) => {
+            eprintln!("choreo-mcp: {message}");
+            eprintln!(
+                "choreo-mcp: set {GRPC_ENDPOINT_ENV} for live gRPC, or set {MCP_BACKEND_ENV}=fixture explicitly for fixture mode"
+            );
+            std::process::exit(2);
+        }
+    };
+
+    let stdin = io::stdin();
+    let mut stdout = io::stdout();
+
+    if server.backend_name() == "grpc" {
+        eprintln!(
+            "choreo-mcp: using live gRPC backend from {GRPC_ENDPOINT_ENV} with {GRPC_TLS_MODE_ENV}={}",
+            server.grpc_tls_mode_name()
+        );
+        if server.grpc_tls_mode_name() != "disabled" {
+            eprintln!(
+                "choreo-mcp: TLS envs: {GRPC_TLS_CA_PATH_ENV}, {GRPC_TLS_CERT_PATH_ENV}, {GRPC_TLS_KEY_PATH_ENV}, {GRPC_TLS_DOMAIN_NAME_ENV}"
+            );
+        }
+    } else {
+        eprintln!("choreo-mcp: using explicit fixture backend");
+    }
+
+    for line in stdin.lock().lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        if let Some(response) = server.handle_json_line(&line).await {
+            writeln!(stdout, "{response}")?;
+            stdout.flush()?;
+        }
+    }
+
+    Ok(())
+}
+
+fn init_tracing() {
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("choreo_mcp=info"));
+    tracing_subscriber::fmt()
+        .json()
+        .with_writer(io::stderr)
+        .with_env_filter(filter)
+        .init();
+}

--- a/crates/choreo-mcp/src/observability.rs
+++ b/crates/choreo-mcp/src/observability.rs
@@ -1,0 +1,125 @@
+//! Tracing + OTel records for every MCP tool call.
+//!
+//! Discipline: tool error messages may contain user payload (an
+//! invalid argument echoes part of the request). We never put them
+//! into metrics raw — they get content-hashed first. The full message
+//! goes to the tool result text (where the caller wanted it) and to
+//! structured tracing (where the operator opted in via log levels).
+
+use std::time::Duration;
+
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use tracing::{debug, warn};
+
+/// Coarse error taxonomy for metrics. Stays a small enum so charts
+/// have a finite label set. Only `Backend` is constructed today —
+/// `Validation` will land when we move JSON-args validation out of
+/// the backend trait into the server.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum ToolErrorKind {
+    /// Backend (gRPC / fixture) returned an error.
+    Backend,
+}
+
+impl ToolErrorKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Backend => "backend",
+        }
+    }
+}
+
+/// Record a successful tool call. Captures duration + size hints of
+/// the request and response so operators can spot pathological tool
+/// shapes (huge requests, empty responses) without seeing the payload.
+pub(crate) fn record_tool_success(
+    backend: &str,
+    grpc_tls: &str,
+    tool: &str,
+    arguments: &Value,
+    result: &Value,
+    duration: Duration,
+) {
+    debug!(
+        backend,
+        grpc_tls,
+        tool,
+        status = "success",
+        duration_ms = duration.as_millis() as u64,
+        args_size = approx_size(arguments),
+        result_size = approx_size(result),
+        "choreo_mcp_tool"
+    );
+}
+
+/// Record a failed tool call. The user-visible `message` is **not**
+/// emitted raw — only its SHA-256 prefix, so metrics never leak
+/// payload fragments.
+pub(crate) fn record_tool_error(
+    backend: &str,
+    grpc_tls: &str,
+    tool: &str,
+    arguments: &Value,
+    kind: ToolErrorKind,
+    message: &str,
+    duration: Duration,
+) {
+    use std::fmt::Write as _;
+    let mut hasher = Sha256::new();
+    hasher.update(message.as_bytes());
+    let digest = hasher.finalize();
+    let mut error_hash = String::with_capacity(16);
+    for byte in digest.iter().take(8) {
+        let _ = write!(&mut error_hash, "{byte:02x}");
+    }
+    warn!(
+        backend,
+        grpc_tls,
+        tool,
+        status = "error",
+        error_kind = kind.as_str(),
+        error_hash,
+        duration_ms = duration.as_millis() as u64,
+        args_size = approx_size(arguments),
+        "choreo_mcp_tool"
+    );
+}
+
+fn approx_size(value: &Value) -> u64 {
+    match value {
+        Value::Null => 0,
+        Value::Bool(_) => 1,
+        Value::Number(_) => 8,
+        Value::String(s) => s.len() as u64,
+        Value::Array(arr) => arr.iter().map(approx_size).sum(),
+        Value::Object(obj) => obj
+            .iter()
+            .map(|(k, v)| (k.len() as u64).saturating_add(approx_size(v)))
+            .sum(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_kind_labels_are_stable() {
+        assert_eq!(ToolErrorKind::Backend.as_str(), "backend");
+    }
+
+    #[test]
+    fn approx_size_is_recursive() {
+        let v = serde_json::json!({
+            "a": "hi",
+            "b": [1, 2, 3],
+            "c": { "d": "x" }
+        });
+        // Order: keys + values. "hi"=2, [1,2,3]=24, "x"=1 plus key bytes.
+        // Not a strict guarantee — just smoke that it's >0 and stable.
+        assert!(approx_size(&v) > 0);
+        assert_eq!(approx_size(&Value::Null), 0);
+        assert_eq!(approx_size(&serde_json::json!("hi")), 2);
+    }
+}

--- a/crates/choreo-mcp/src/protocol.rs
+++ b/crates/choreo-mcp/src/protocol.rs
@@ -1,0 +1,575 @@
+//! MCP wire-protocol helpers and tool catalog.
+//!
+//! Hand-rolled JSON-RPC 2.0 + MCP `tools/*` shapes — no SDK, the
+//! adapter owns every byte that crosses stdio so it never drifts from
+//! the gRPC contract it wraps.
+//!
+//! Tool definitions are 1:1 with the `underpass.choreo.v1` gRPC
+//! service: 12 tools, one per RPC. The choreographer's API is
+//! respected verbatim — these schemas describe the same fields the
+//! caller would have passed over gRPC, only flattened into JSON shape
+//! suitable for an MCP `tools/call.arguments` object.
+
+use serde_json::{json, Value};
+
+/// MCP protocol version we advertise.
+pub(crate) const PROTOCOL_VERSION: &str = "2024-11-05";
+/// `serverInfo.name` returned by `initialize`.
+pub(crate) const SERVER_NAME: &str = "underpass-choreo-mcp";
+/// `serverInfo.version` — pulled from the crate version at build time.
+pub(crate) const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Build the `initialize` result. Includes adapter-side metadata so
+/// the client can record which backend + TLS posture it negotiated
+/// without an extra round-trip.
+pub(crate) fn initialize_result(backend: &str, grpc_tls: &str) -> Value {
+    json!({
+        "protocolVersion": PROTOCOL_VERSION,
+        "capabilities": {
+            "tools": {}
+        },
+        "serverInfo": {
+            "name": SERVER_NAME,
+            "version": SERVER_VERSION,
+        },
+        "metadata": {
+            "backend": backend,
+            "grpc_tls": grpc_tls,
+        }
+    })
+}
+
+/// `tools/list` result. Every choreographer RPC has exactly one tool.
+pub(crate) fn tools_list_result() -> Value {
+    json!({ "tools": tool_catalog() })
+}
+
+#[allow(clippy::too_many_lines)] // 12 tool definitions; splitting just for the line count loses readability
+fn tool_catalog() -> Vec<Value> {
+    vec![
+        tool_def(
+            "choreo_deliberate",
+            "Run a deliberation on the council for the task's specialty. Returns ranked proposals once the council finishes.",
+            json!({
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["task"],
+                "properties": { "task": task_schema() }
+            }),
+        ),
+        tool_def(
+            "choreo_stream_deliberation",
+            "Run a deliberation and return every phase-transition / result frame buffered into a single response array (no live streaming over MCP stdio).",
+            json!({
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["task"],
+                "properties": { "task": task_schema() }
+            }),
+        ),
+        tool_def(
+            "choreo_get_deliberation_result",
+            "Fetch a previously-executed deliberation by task id.",
+            json!({
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["task_id"],
+                "properties": { "task_id": string_schema("Stable task id used at deliberation time.") }
+            }),
+        ),
+        tool_def(
+            "choreo_orchestrate",
+            "Deliberate AND execute the winning proposal through the wired executor port. Returns the winner plus an execution id.",
+            json!({
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["task"],
+                "properties": {
+                    "task": task_schema(),
+                    "execution_options": {
+                        "type": "object",
+                        "additionalProperties": true,
+                        "description": "Opaque executor options. Forwarded verbatim to the configured ExecutorPort."
+                    }
+                }
+            }),
+        ),
+        tool_def(
+            "choreo_create_council",
+            "Create or replace the council for a specialty. `agent_config` is opaque and passed to the agent factory.",
+            json!({
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["specialty", "num_agents"],
+                "properties": {
+                    "specialty": string_schema("Free-form specialty label, e.g. \"triage\"."),
+                    "num_agents": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Number of agents to seat on the council."
+                    },
+                    "agent_config": {
+                        "type": "object",
+                        "additionalProperties": true,
+                        "description": "Opaque config forwarded to the agent factory."
+                    }
+                }
+            }),
+        ),
+        tool_def(
+            "choreo_list_councils",
+            "List the councils registered on the choreographer.",
+            json!({
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "include_agents": {
+                        "type": "boolean",
+                        "description": "When true, return each council's agent roster."
+                    }
+                }
+            }),
+        ),
+        tool_def(
+            "choreo_delete_council",
+            "Delete the council registered for a specialty. Idempotent: `deleted=false` means the council did not exist.",
+            json!({
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["specialty"],
+                "properties": { "specialty": string_schema("Specialty whose council to delete.") }
+            }),
+        ),
+        tool_def(
+            "choreo_register_agent",
+            "Register an agent on a council. `agent.kind` must be one supported by the wired AgentFactoryPort (e.g. noop, anthropic, openai, vllm).",
+            json!({
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["specialty", "agent"],
+                "properties": {
+                    "specialty": string_schema("Specialty the agent belongs to."),
+                    "agent": agent_summary_schema(),
+                    "agent_config": {
+                        "type": "object",
+                        "additionalProperties": true,
+                        "description": "Opaque per-agent factory config."
+                    }
+                }
+            }),
+        ),
+        tool_def(
+            "choreo_unregister_agent",
+            "Unregister a previously-registered agent by id.",
+            json!({
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["agent_id"],
+                "properties": { "agent_id": string_schema("Agent id returned by choreo_register_agent.") }
+            }),
+        ),
+        tool_def(
+            "choreo_process_trigger_event",
+            "Submit a domain event that should fan out to one or more deliberations. Returns a TriggerAck reporting the dispatched task ids.",
+            json!({
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["event"],
+                "properties": { "event": trigger_event_schema() }
+            }),
+        ),
+        tool_def(
+            "choreo_get_status",
+            "Return service health, version, uptime, and optionally statistics.",
+            json!({
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "include_stats": {
+                        "type": "boolean",
+                        "description": "When true, include the full Statistics snapshot in the response."
+                    }
+                }
+            }),
+        ),
+        tool_def(
+            "choreo_get_metrics",
+            "Return the current statistics snapshot.",
+            json!({
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {}
+            }),
+        ),
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// Composite schema fragments (kept in sync with `choreo.proto`)
+// ---------------------------------------------------------------------------
+
+fn task_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["task_id", "description", "specialty"],
+        "properties": {
+            "task_id": string_schema("Stable task identifier."),
+            "description": string_schema("Free-form prompt the council deliberates over."),
+            "specialty": string_schema("Specialty label of the council to dispatch to."),
+            "constraints": constraints_schema(),
+            "attributes": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Opaque per-task attributes. Forwarded to agents and validators."
+            },
+            "external_context": external_context_bundle_schema(),
+            "metadata": task_metadata_schema()
+        }
+    })
+}
+
+fn constraints_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "rubric": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Opaque rubric forwarded to agents and validators."
+            },
+            "rounds": { "type": "integer", "minimum": 0, "description": "Peer-review rounds (0 = adapter default)." },
+            "num_agents": { "type": "integer", "minimum": 0, "description": "Requested parallelism (0 = use council size)." },
+            "deadline_ms": { "type": "integer", "minimum": 0, "description": "Optional soft deadline in ms (0 = none)." },
+            "output_contract": output_contract_schema()
+        }
+    })
+}
+
+fn output_contract_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["contract_id", "format"],
+        "properties": {
+            "contract_id": string_schema("Stable contract identifier."),
+            "format": {
+                "type": "string",
+                "enum": ["json_object"],
+                "description": "Wire format. Only `json_object` is implemented today."
+            },
+            "fields": {
+                "type": "object",
+                "additionalProperties": output_field_rule_schema(),
+                "description": "Map from field name to its rule."
+            }
+        }
+    })
+}
+
+fn output_field_rule_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "required": { "type": "boolean" },
+            "allowed_string_values": {
+                "type": "array",
+                "items": { "type": "string" }
+            }
+        }
+    })
+}
+
+fn external_context_bundle_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "bundle_id": string_schema("Caller-supplied bundle id."),
+            "schema_version": string_schema("Bundle schema version label."),
+            "summary": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "text": string_schema("Human-facing summary."),
+                    "attributes": {
+                        "type": "object",
+                        "additionalProperties": true
+                    }
+                }
+            },
+            "items": {
+                "type": "array",
+                "items": context_item_schema()
+            },
+            "references": {
+                "type": "array",
+                "items": context_reference_schema()
+            },
+            "metadata": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Application-owned bundle metadata. Choreographer treats this as opaque."
+            }
+        }
+    })
+}
+
+fn context_item_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["item_id", "kind"],
+        "properties": {
+            "item_id": string_schema("Stable item id within the bundle."),
+            "kind": string_schema("Caller-defined kind label."),
+            "title": { "type": "string" },
+            "narrative": { "type": "string" },
+            "attributes": { "type": "object", "additionalProperties": true },
+            "reference_ids": {
+                "type": "array",
+                "items": { "type": "string" }
+            }
+        }
+    })
+}
+
+fn context_reference_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["reference_id", "uri"],
+        "properties": {
+            "reference_id": string_schema("Stable reference id within the bundle."),
+            "uri": string_schema("Pointer to the referenced artifact."),
+            "title": { "type": "string" },
+            "media_type": { "type": "string" },
+            "attributes": { "type": "object", "additionalProperties": true }
+        }
+    })
+}
+
+fn task_metadata_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "source_event_id": { "type": "string" },
+            "causation_id": { "type": "string" },
+            "correlation_id": { "type": "string" },
+            "council_contract_id": { "type": "string" },
+            "output_contract_id": { "type": "string" },
+            "execution_profile": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Opaque executor hints. Explicit Orchestrate options take precedence on overlap."
+            }
+        }
+    })
+}
+
+fn agent_summary_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["agent_id", "specialty", "kind"],
+        "properties": {
+            "agent_id": string_schema("Stable agent id."),
+            "specialty": string_schema("Specialty the agent serves."),
+            "kind": string_schema("Adapter-defined agent kind (e.g. noop, vllm, anthropic, openai)."),
+            "attributes": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Per-agent factory hints (provider.model, provider.endpoint, …)."
+            }
+        }
+    })
+}
+
+fn trigger_event_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["event_id", "kind", "source", "requested_specialties"],
+        "properties": {
+            "event_id": string_schema("Stable producer-side event id."),
+            "kind": string_schema("Free-form event kind (e.g. alert.fired, case.opened)."),
+            "source": string_schema("Producer identifier."),
+            "emitted_at": string_schema("RFC3339 emit timestamp. Server fills in `now` when absent."),
+            "requested_specialties": {
+                "type": "array",
+                "minItems": 1,
+                "items": { "type": "string" }
+            },
+            "task_description_template": { "type": "string" },
+            "constraints": constraints_schema(),
+            "payload": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Opaque domain payload."
+            },
+            "external_context": external_context_bundle_schema(),
+            "correlation_id": { "type": "string" },
+            "causation_id": { "type": "string" }
+        }
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Primitive helpers
+// ---------------------------------------------------------------------------
+
+#[allow(clippy::needless_pass_by_value)] // json! consumes via macro clone — clippy can't see that
+fn tool_def(name: &str, description: &str, input_schema: Value) -> Value {
+    json!({
+        "name": name,
+        "description": description,
+        "inputSchema": input_schema,
+    })
+}
+
+fn string_schema(description: &str) -> Value {
+    json!({
+        "type": "string",
+        "minLength": 1,
+        "description": description,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tool-call result shape (MCP spec)
+// ---------------------------------------------------------------------------
+
+/// MCP success result: `content[].text` for human consumers +
+/// `structuredContent` for machine consumers + `isError: false`.
+#[allow(clippy::needless_pass_by_value)] // structured is used twice; consumed by json!
+pub(crate) fn tool_success_result(structured: Value) -> Value {
+    let text = serde_json::to_string_pretty(&structured).expect("structured JSON should serialize");
+    json!({
+        "content": [{ "type": "text", "text": text }],
+        "structuredContent": structured,
+        "isError": false,
+    })
+}
+
+/// MCP tool error: spec says `isError: true` in the *tool result*,
+/// **not** as a JSON-RPC `error`.
+pub(crate) fn tool_error_result(message: &str) -> Value {
+    json!({
+        "content": [{ "type": "text", "text": message }],
+        "isError": true,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// JSON-RPC framing
+// ---------------------------------------------------------------------------
+
+#[allow(clippy::needless_pass_by_value)] // both args consumed by json!
+pub(crate) fn jsonrpc_result(id: Value, result: Value) -> String {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": result,
+    })
+    .to_string()
+}
+
+#[allow(clippy::needless_pass_by_value)] // id consumed by json!
+pub(crate) fn jsonrpc_error(id: Value, code: i64, message: &str) -> String {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": { "code": code, "message": message },
+    })
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initialize_advertises_protocol_version_and_metadata() {
+        let r = initialize_result("grpc", "server");
+        assert_eq!(r["protocolVersion"], PROTOCOL_VERSION);
+        assert_eq!(r["serverInfo"]["name"], SERVER_NAME);
+        assert_eq!(r["metadata"]["backend"], "grpc");
+        assert_eq!(r["metadata"]["grpc_tls"], "server");
+    }
+
+    #[test]
+    fn tools_catalog_is_one_for_one_with_grpc_service() {
+        let tools = tools_list_result();
+        let arr = tools["tools"].as_array().unwrap();
+        let names: Vec<&str> = arr.iter().map(|t| t["name"].as_str().unwrap()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "choreo_deliberate",
+                "choreo_stream_deliberation",
+                "choreo_get_deliberation_result",
+                "choreo_orchestrate",
+                "choreo_create_council",
+                "choreo_list_councils",
+                "choreo_delete_council",
+                "choreo_register_agent",
+                "choreo_unregister_agent",
+                "choreo_process_trigger_event",
+                "choreo_get_status",
+                "choreo_get_metrics",
+            ]
+        );
+        assert_eq!(arr.len(), 12);
+    }
+
+    #[test]
+    fn task_schema_includes_metadata_and_external_context() {
+        let s = task_schema();
+        let props = &s["properties"];
+        assert!(props.get("task_id").is_some());
+        assert!(props.get("description").is_some());
+        assert!(props.get("specialty").is_some());
+        assert!(props.get("constraints").is_some());
+        assert!(props.get("attributes").is_some());
+        assert!(props.get("external_context").is_some());
+        assert!(props.get("metadata").is_some());
+    }
+
+    #[test]
+    fn output_contract_format_enum_pins_implemented_modes() {
+        let s = output_contract_schema();
+        let formats = s["properties"]["format"]["enum"].as_array().unwrap();
+        assert_eq!(formats.len(), 1);
+        assert_eq!(formats[0], "json_object");
+    }
+
+    #[test]
+    fn tool_results_carry_both_text_and_structured() {
+        let success = tool_success_result(json!({"answer": "yes"}));
+        assert_eq!(success["isError"], false);
+        assert_eq!(success["structuredContent"]["answer"], "yes");
+        assert!(success["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("yes"));
+
+        let error = tool_error_result("nope");
+        assert_eq!(error["isError"], true);
+        assert_eq!(error["content"][0]["text"], "nope");
+    }
+
+    #[test]
+    fn jsonrpc_helpers_wrap_results_and_errors() {
+        let r = serde_json::from_str::<Value>(&jsonrpc_result(json!(1), json!({"x": 2}))).unwrap();
+        assert_eq!(r["jsonrpc"], "2.0");
+        assert_eq!(r["id"], 1);
+        assert_eq!(r["result"]["x"], 2);
+
+        let e = serde_json::from_str::<Value>(&jsonrpc_error(json!(2), -32601, "no")).unwrap();
+        assert_eq!(e["error"]["code"], -32601);
+        assert_eq!(e["error"]["message"], "no");
+    }
+}

--- a/crates/choreo-mcp/src/server.rs
+++ b/crates/choreo-mcp/src/server.rs
@@ -1,0 +1,276 @@
+//! Request dispatch for the choreo MCP stdio adapter.
+//!
+//! Parses one JSON-RPC line at a time, routes `initialize` /
+//! `tools/list` / `tools/call` to the inner backend, and serializes
+//! the response back to stdout. Logs and telemetry happen on the side
+//! through [`observability`](crate::observability).
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use serde_json::Value;
+
+use crate::backend::{
+    ChoreoMcpGrpcTlsConfig, ChoreoMcpToolBackend, ChoreoMcpToolFuture, GRPC_ENDPOINT_ENV,
+    MCP_BACKEND_ENV,
+};
+use crate::fixture::FixtureChoreoMcpBackend;
+use crate::grpc::GrpcChoreoMcpBackend;
+use crate::observability::{record_tool_error, record_tool_success, ToolErrorKind};
+use crate::protocol::{
+    initialize_result, jsonrpc_error, jsonrpc_result, tool_error_result, tools_list_result,
+};
+
+/// Boxed-trait holder over any [`ChoreoMcpToolBackend`].
+pub struct ChoreoMcpServer {
+    backend: Arc<dyn ChoreoMcpToolBackend>,
+}
+
+impl Default for ChoreoMcpServer {
+    fn default() -> Self {
+        Self::fixture()
+    }
+}
+
+impl ChoreoMcpServer {
+    /// Fixture-backed server. Returns canned responses; useful for
+    /// client wiring without a running choreographer.
+    #[must_use]
+    pub fn fixture() -> Self {
+        Self::with_backend(FixtureChoreoMcpBackend)
+    }
+
+    /// gRPC-backed server with TLS disabled.
+    #[must_use]
+    pub fn grpc(endpoint: impl Into<String>) -> Self {
+        Self::grpc_with_tls(endpoint, ChoreoMcpGrpcTlsConfig::disabled())
+    }
+
+    /// gRPC-backed server with a caller-supplied TLS posture.
+    #[must_use]
+    pub fn grpc_with_tls(endpoint: impl Into<String>, tls: ChoreoMcpGrpcTlsConfig) -> Self {
+        Self::with_backend(GrpcChoreoMcpBackend::new(endpoint, tls))
+    }
+
+    /// Wrap an arbitrary backend.
+    pub fn with_backend(backend: impl ChoreoMcpToolBackend + 'static) -> Self {
+        Self {
+            backend: Arc::new(backend),
+        }
+    }
+
+    /// Read backend selection from environment.
+    ///
+    /// Defaults to `grpc`; `CHOREO_MCP_BACKEND=fixture` opts in to
+    /// the fixture impl. When `grpc` is selected, the endpoint env
+    /// is mandatory — no silent fallback to fixtures.
+    pub fn try_from_env() -> Result<Self, String> {
+        let backend = std::env::var(MCP_BACKEND_ENV)
+            .ok()
+            .map(|value| value.trim().to_ascii_lowercase())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "grpc".to_string());
+        let endpoint = std::env::var(GRPC_ENDPOINT_ENV).ok();
+        let tls = ChoreoMcpGrpcTlsConfig::from_env_for_endpoint(endpoint.as_deref());
+
+        match backend.as_str() {
+            "grpc" | "live" => {
+                let Some(endpoint) = endpoint.filter(|endpoint| !endpoint.trim().is_empty()) else {
+                    return Err(format!(
+                        "{GRPC_ENDPOINT_ENV} is required when {MCP_BACKEND_ENV}=grpc"
+                    ));
+                };
+                Ok(Self::grpc_with_tls(endpoint, tls))
+            }
+            "fixture" | "fixtures" => Ok(Self::fixture()),
+            other => Err(format!(
+                "unsupported {MCP_BACKEND_ENV} value `{other}`; use `grpc` or `fixture`"
+            )),
+        }
+    }
+
+    /// Backend label for the `initialize` response.
+    #[must_use]
+    pub fn backend_name(&self) -> &'static str {
+        self.backend.backend_name()
+    }
+
+    /// TLS posture label for the `initialize` response.
+    #[must_use]
+    pub fn grpc_tls_mode_name(&self) -> &'static str {
+        self.backend.grpc_tls_mode_name()
+    }
+
+    /// Handle one JSON-RPC line. Returns `None` when the message was
+    /// a notification (no `id`) or when the method is
+    /// `notifications/initialized`. Any other case returns one
+    /// JSON-RPC response string ready to write to stdout.
+    pub async fn handle_json_line(&self, line: &str) -> Option<String> {
+        let request = match serde_json::from_str::<Value>(line) {
+            Ok(request) => request,
+            Err(error) => {
+                return Some(jsonrpc_error(
+                    Value::Null,
+                    -32700,
+                    &format!("invalid JSON-RPC message: {error}"),
+                ));
+            }
+        };
+
+        let id = request.get("id").cloned();
+        let method = request.get("method").and_then(Value::as_str);
+
+        match method {
+            Some("initialize") => id.map(|id| {
+                jsonrpc_result(
+                    id,
+                    initialize_result(self.backend_name(), self.grpc_tls_mode_name()),
+                )
+            }),
+            Some("notifications/initialized") => None,
+            Some("tools/list") => id.map(|id| jsonrpc_result(id, tools_list_result())),
+            Some("tools/call") => match id {
+                Some(id) => Some(self.handle_tool_call(id, request.get("params")).await),
+                None => None,
+            },
+            Some(other) => id.map(|id| {
+                jsonrpc_error(
+                    id,
+                    -32601,
+                    &format!("unsupported JSON-RPC method `{other}`"),
+                )
+            }),
+            None => Some(jsonrpc_error(
+                Value::Null,
+                -32600,
+                "missing JSON-RPC method",
+            )),
+        }
+    }
+
+    async fn handle_tool_call(&self, id: Value, params: Option<&Value>) -> String {
+        let Some(params) = params.and_then(Value::as_object) else {
+            return jsonrpc_error(id, -32602, "tools/call requires object params");
+        };
+        let Some(name) = params.get("name").and_then(Value::as_str) else {
+            return jsonrpc_error(id, -32602, "tools/call requires params.name");
+        };
+        let arguments = params.get("arguments").unwrap_or(&Value::Null);
+        let start = Instant::now();
+
+        match self.backend.call_tool(name, arguments).await {
+            Ok(result) => {
+                record_tool_success(
+                    self.backend_name(),
+                    self.grpc_tls_mode_name(),
+                    name,
+                    arguments,
+                    &result,
+                    start.elapsed(),
+                );
+                jsonrpc_result(id, result)
+            }
+            Err(message) => {
+                record_tool_error(
+                    self.backend_name(),
+                    self.grpc_tls_mode_name(),
+                    name,
+                    arguments,
+                    ToolErrorKind::Backend,
+                    &message,
+                    start.elapsed(),
+                );
+                jsonrpc_result(id, tool_error_result(&message))
+            }
+        }
+    }
+}
+
+// Allow holding the server's backend behind an Arc directly.
+impl<T> ChoreoMcpToolBackend for Arc<T>
+where
+    T: ChoreoMcpToolBackend + ?Sized,
+{
+    fn backend_name(&self) -> &'static str {
+        self.as_ref().backend_name()
+    }
+
+    fn grpc_tls_mode_name(&self) -> &'static str {
+        self.as_ref().grpc_tls_mode_name()
+    }
+
+    fn call_tool<'a>(&'a self, name: &'a str, arguments: &'a Value) -> ChoreoMcpToolFuture<'a> {
+        self.as_ref().call_tool(name, arguments)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::SERVER_NAME;
+
+    #[tokio::test]
+    async fn initialize_returns_protocol_metadata() {
+        let server = ChoreoMcpServer::fixture();
+        let response = server
+            .handle_json_line(r#"{"jsonrpc":"2.0","id":1,"method":"initialize"}"#)
+            .await
+            .expect("initialize must return a response");
+        let parsed: Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(parsed["jsonrpc"], "2.0");
+        assert_eq!(parsed["id"], 1);
+        assert_eq!(parsed["result"]["serverInfo"]["name"], SERVER_NAME);
+        assert_eq!(parsed["result"]["metadata"]["backend"], "fixture");
+    }
+
+    #[tokio::test]
+    async fn notifications_initialized_returns_none() {
+        let server = ChoreoMcpServer::fixture();
+        assert!(server
+            .handle_json_line(r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#)
+            .await
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn tools_list_lists_twelve_tools() {
+        let server = ChoreoMcpServer::fixture();
+        let response = server
+            .handle_json_line(r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#)
+            .await
+            .unwrap();
+        let parsed: Value = serde_json::from_str(&response).unwrap();
+        let tools = parsed["result"]["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 12);
+    }
+
+    #[tokio::test]
+    async fn unsupported_method_returns_jsonrpc_error() {
+        let server = ChoreoMcpServer::fixture();
+        let response = server
+            .handle_json_line(r#"{"jsonrpc":"2.0","id":3,"method":"resources/list"}"#)
+            .await
+            .unwrap();
+        let parsed: Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(parsed["error"]["code"], -32601);
+    }
+
+    #[tokio::test]
+    async fn invalid_json_returns_parse_error() {
+        let server = ChoreoMcpServer::fixture();
+        let response = server.handle_json_line("not json").await.unwrap();
+        let parsed: Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(parsed["error"]["code"], -32700);
+    }
+
+    #[tokio::test]
+    async fn tools_call_with_missing_name_returns_invalid_params() {
+        let server = ChoreoMcpServer::fixture();
+        let response = server
+            .handle_json_line(r#"{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{}}"#)
+            .await
+            .unwrap();
+        let parsed: Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(parsed["error"]["code"], -32602);
+    }
+}


### PR DESCRIPTION
## Summary

New crate `choreo-mcp` — a stdio MCP (Model Context Protocol) adapter that exposes every RPC of `underpass.choreo.v1` as an MCP tool over JSON-RPC 2.0 on stdin/stdout.

Designed so coding agents (Codex CLI, Claude Desktop) can talk to a running choreographer without re-implementing gRPC.

**Foundation slice.** Distribution scripts, end-user docs, and the broader UX wiring follow in PR 2.

## What landed

**Architecture (no SDK — hand-rolled, ~2700 LOC):**

- `protocol.rs` — 12 tool JSON schemas, one per RPC. Tool result shape is MCP-spec compliant (`content[].text` + `structuredContent` + `isError`). Every Task/Constraints/OutputContract/ExternalContextBundle/TaskMetadata/AgentSummary/TriggerEvent field appears in the schemas — **100% API respected**.
- `backend.rs` — `ChoreoMcpToolBackend` trait + env-driven TLS config. Mirrors the rehydration-kernel pattern: `https://` → server TLS auto, cert/key → mutual auto, explicit `CHOREO_MCP_GRPC_TLS_MODE` always wins.
- `server.rs` — JSON-RPC dispatch (`initialize`, `notifications/initialized`, `tools/list`, `tools/call`). Default backend is `grpc`; fail-fast when endpoint missing.
- `fixture.rs` — canned-response backend so client wiring is testable without a running choreographer.
- `grpc/channel.rs` — tonic Channel + `ClientTlsConfig` for `server`/`mutual` modes.
- `grpc/json_to_proto.rs` + `grpc/proto_to_json.rs` — **hand-written field-by-field** mappers (no `serde_json::to_value(proto)` shortcuts). Enums collapse to stable string labels.
- `grpc/tools.rs` — 12-arm dispatch from tool name → tonic RPC.
- `grpc/streaming.rs` — `StreamDeliberation` collected into a single response (frames array + winner). MCP stdio is sync, so live streaming is not surfaced.
- `observability.rs` — per-tool-call tracing. Error messages SHA-256-prefix-hashed before going into metrics; payload fragments never leak.
- `main.rs` — tokio + stdin/stdout newline-delimited loop. Stderr-only JSON tracing; stdout reserved for JSON-RPC.

## Env vars

| Var | Purpose |
|---|---|
| `CHOREO_MCP_BACKEND` | `grpc` (default) or `fixture` |
| `CHOREO_MCP_GRPC_ENDPOINT` | URL of a running choreographer |
| `CHOREO_MCP_GRPC_TLS_MODE` | `disabled` / `server` / `mutual` |
| `CHOREO_MCP_GRPC_TLS_CA_PATH` | server CA bundle (server/mutual) |
| `CHOREO_MCP_GRPC_TLS_CERT_PATH` | client cert (mutual) |
| `CHOREO_MCP_GRPC_TLS_KEY_PATH` | client key (mutual) |
| `CHOREO_MCP_GRPC_TLS_DOMAIN_NAME` | TLS SNI/domain override |

## Honest scope — deferred to PR 2

- `scripts/mcp/install-choreo-mcp.sh` wrapper
- `scripts/mcp/choreo-stdio-smoke.sh` smoke
- `docs/operations/mcp-stdio.md` user-facing UX (Codex + Claude Desktop snippets)
- `crates/choreo-mcp/README.md` developer twin
- backlog entry replacing the PIR-framed status with an MCP entry
- `crates.io` is documented debt: proto tree is path-deped from the MCP crate; `cargo install --git` is the only distribution path until a vendored proto crate exists

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --locked $PROVIDER_FEATURES -- -D warnings` — clean
- [x] `cargo test --workspace --locked $PROVIDER_FEATURES` — **443 passed, 0 failed** (+21 new MCP tests)
- [ ] Per-PR CI gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)