### PR TITLE
feat(e2e): stack runs Orchestrate through real RuntimeExecutor + docs index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,7 @@ dependencies = [
  "choreo-core",
  "choreo-proto",
  "futures",
+ "prost-types",
  "serde_json",
  "time",
  "tokio",

--- a/README.md
+++ b/README.md
@@ -3,19 +3,26 @@
 Event-driven coordination plane for specialist agents. Domain-agnostic port of
 the `swe-ai-fleet` orchestrator service to Rust.
 
-Role in the Underpass platform:
+## The Underpass platform
 
-- **Rehydration Kernel** — memory plane (context graph)
-- **Choreographer** — event-driven coordination (this repo)
-- **Underpass Runtime** — execution plane (governed tools)
+Three planes, three repos:
 
-The choreographer reacts to domain events, composes councils of agents,
-runs deliberations, and publishes outcome events. It does **not** embed any
-domain vocabulary (no stories, plans, roles hardcoded) — all that is injected
-via configuration and proto messages.
+| Plane | Repo | Brand name | Role |
+|---|---|---|---|
+| Memory + context | [`rehydration-kernel`](https://github.com/underpass-ai/rehydration-kernel) | **Underpass KMP** (Kernel Memory Plane / Kernel Memory Protocol) | Renders LLM-ready context bundles from a typed knowledge graph. |
+| Coordination | this repo | **Underpass Choreographer** | Composes councils, runs deliberations, validates outputs, hands winners to an executor. |
+| Execution + governed tools | [`underpass-runtime`](https://github.com/underpass-ai/underpass-runtime) | **Underpass Runtime** | Sessions, governed tool invocations, artifacts, policy decisions. |
+
+The choreographer talks to KMP through caller-supplied
+`ExternalContextBundle`s, and to the Runtime through the
+`RuntimeExecutor` adapter. It does **not** embed any product
+vocabulary (no stories, plans, incidents, claims hardcoded) — all that
+is injected via configuration and proto messages.
 
 ## Start here
 
+- [`docs/index.md`](docs/index.md) — full navigation hub for every
+  doc in this repo, grouped by audience.
 - [`docs/dev-loop.md`](docs/dev-loop.md) — local iteration loop,
   every command mirrors a CI gate.
 - [`docs/release.md`](docs/release.md) — versioning + cut-a-release
@@ -26,6 +33,8 @@ via configuration and proto messages.
 - [`docs/operations/mcp-stdio.md`](docs/operations/mcp-stdio.md) —
   installable stdio MCP adapter exposing the gRPC API to coding
   agents (Codex CLI, Claude Desktop).
+- [`docs/backlog.md`](docs/backlog.md) — epic-by-epic readiness
+  status + session log.
 - `justfile` at the repo root — `just` lists every recipe.
 
 ## Workspace

--- a/crates/choreo-e2e-runner/Cargo.toml
+++ b/crates/choreo-e2e-runner/Cargo.toml
@@ -24,12 +24,20 @@ path = "src/main.rs"
 name = "choreo-e2e-provider"
 path = "src/bin/provider.rs"
 
+# Stub-runtime sidecar for the stack E2E. Serves the choreographer's
+# RuntimeExecutor a real gRPC peer to talk to without dragging the
+# real underpass-runtime image into this repo's test path.
+[[bin]]
+name = "choreo-stub-runtime"
+path = "src/bin/stub_runtime.rs"
+
 [dependencies]
 choreo-proto = { workspace = true }
 choreo-core = { workspace = true }
 choreo-adapters = { workspace = true, features = ["agent-vllm"] }
 tokio = { workspace = true }
 tonic = { workspace = true }
+prost-types = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/choreo-e2e-runner/src/bin/stub_runtime.rs
+++ b/crates/choreo-e2e-runner/src/bin/stub_runtime.rs
@@ -1,0 +1,135 @@
+//! Minimal stub of `underpass.runtime.v1.SessionService` +
+//! `InvocationService` for stack E2E.
+//!
+//! Wired into `tests/e2e/docker-compose.e2e.yaml` as the `stub-runtime`
+//! sidecar so the choreographer's `RuntimeExecutor` has a real gRPC
+//! peer to talk to without dragging the actual `underpass-runtime`
+//! image into this repo's test path.
+//!
+//! Every RPC returns a deterministic canned response:
+//!   - `CreateSession` → `{ id: "stub-session-1", ... }`
+//!   - `InvokeTool`    → `{ id: "stub-invocation-1", status: SUCCEEDED, ... }`
+//!   - `CloseSession`  → `{ closed: true }`
+//!
+//! `STUB_RUNTIME_GRPC_ADDR` (default `0.0.0.0:50053`) controls the
+//! listener.
+
+use std::env;
+use std::net::SocketAddr;
+
+use anyhow::{Context, Result};
+use choreo_proto::runtime_v1 as rt;
+use tonic::transport::Server;
+use tonic::{Request, Response, Status};
+use tracing::info;
+use tracing_subscriber::EnvFilter;
+
+#[derive(Default, Clone)]
+struct StubRuntime;
+
+#[tonic::async_trait]
+impl rt::session_service_server::SessionService for StubRuntime {
+    async fn create_session(
+        &self,
+        request: Request<rt::CreateSessionRequest>,
+    ) -> Result<Response<rt::CreateSessionResponse>, Status> {
+        let request = request.into_inner();
+        info!(
+            requested_session_id = request.session_id.as_str(),
+            "stub-runtime: CreateSession"
+        );
+        Ok(Response::new(rt::CreateSessionResponse {
+            session: Some(rt::Session {
+                id: "stub-session-1".to_owned(),
+                workspace_path: "/tmp/stub-workspace".to_owned(),
+                runtime: None,
+                repo_url: request.repo_url,
+                repo_ref: request.repo_ref,
+                allowed_paths: request.allowed_paths,
+                principal: request.principal,
+                metadata: request.metadata,
+                created_at: None,
+                expires_at: None,
+            }),
+        }))
+    }
+
+    async fn close_session(
+        &self,
+        request: Request<rt::CloseSessionRequest>,
+    ) -> Result<Response<rt::CloseSessionResponse>, Status> {
+        let request = request.into_inner();
+        info!(
+            session_id = request.session_id.as_str(),
+            "stub-runtime: CloseSession"
+        );
+        Ok(Response::new(rt::CloseSessionResponse { closed: true }))
+    }
+}
+
+#[tonic::async_trait]
+impl rt::invocation_service_server::InvocationService for StubRuntime {
+    async fn invoke_tool(
+        &self,
+        request: Request<rt::InvokeToolRequest>,
+    ) -> Result<Response<rt::InvokeToolResponse>, Status> {
+        let request = request.into_inner();
+        info!(
+            session_id = request.session_id.as_str(),
+            tool_name = request.tool_name.as_str(),
+            correlation_id = request.correlation_id.as_str(),
+            "stub-runtime: InvokeTool"
+        );
+        Ok(Response::new(rt::InvokeToolResponse {
+            invocation: Some(rt::Invocation {
+                id: "stub-invocation-1".to_owned(),
+                session_id: request.session_id,
+                tool_name: request.tool_name,
+                correlation_id: request.correlation_id,
+                status: rt::InvocationStatus::Succeeded as i32,
+                started_at: None,
+                completed_at: None,
+                duration_ms: 5,
+                trace_name: String::new(),
+                span_name: String::new(),
+                exit_code: 0,
+                output: None,
+                output_ref: String::new(),
+                logs: Vec::new(),
+                logs_ref: String::new(),
+                artifacts: Vec::new(),
+                error: None,
+            }),
+        }))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .compact()
+        .init();
+
+    let addr_raw =
+        env::var("STUB_RUNTIME_GRPC_ADDR").unwrap_or_else(|_| "0.0.0.0:50053".to_string());
+    let addr: SocketAddr = addr_raw
+        .parse()
+        .with_context(|| format!("invalid STUB_RUNTIME_GRPC_ADDR: {addr_raw}"))?;
+    info!(%addr, "stub-runtime listening");
+
+    let stub = StubRuntime;
+    Server::builder()
+        .add_service(rt::session_service_server::SessionServiceServer::new(
+            stub.clone(),
+        ))
+        .add_service(rt::invocation_service_server::InvocationServiceServer::new(
+            stub,
+        ))
+        .serve(addr)
+        .await
+        .context("stub-runtime gRPC server terminated with error")?;
+    Ok(())
+}

--- a/crates/choreo-e2e-runner/src/main.rs
+++ b/crates/choreo-e2e-runner/src/main.rs
@@ -12,8 +12,11 @@ use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context, Result};
 use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
-use choreo_proto::v1::{DeleteCouncilRequest, DeliberateRequest, ListCouncilsRequest, Task};
+use choreo_proto::v1::{
+    DeleteCouncilRequest, DeliberateRequest, ListCouncilsRequest, OrchestrateRequest, Task,
+};
 use futures::StreamExt;
+use prost_types::{value::Kind as PbKind, Struct as PbStruct, Value as PbValue};
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 use tonic::transport::{Channel, Endpoint};
@@ -118,8 +121,86 @@ async fn main() -> Result<()> {
         .await
         .context("scenario 4 failed")?;
 
+    info!("scenario 5: Orchestrate routes the winner through the configured Runtime executor");
+    verify_orchestrate_invokes_runtime_executor(&mut client, &seed_specialty)
+        .await
+        .context("scenario 5 failed")?;
+
     info!("E2E scenarios passed");
     Ok(())
+}
+
+/// Drives `Orchestrate` on the seeded council with a task that carries
+/// a `runtime.tool_name` attribute. The compose stack wires
+/// `CHOREO_EXECUTOR_KIND=runtime` pointing at the in-stack
+/// `stub-runtime` sidecar, so a successful outcome here proves the
+/// full chain — Deliberate -> winner -> RuntimeExecutor -> gRPC to
+/// `underpass.runtime.v1.{SessionService,InvocationService}` -> back
+/// up the use-case -> `TaskCompleted`.
+async fn verify_orchestrate_invokes_runtime_executor(
+    client: &mut ChoreographerServiceClient<Channel>,
+    specialty: &str,
+) -> Result<()> {
+    let attributes = pb_struct_from_pairs([(
+        "runtime.tool_name",
+        PbKind::StringValue("stub.echo".to_owned()),
+    )]);
+
+    let response = client
+        .orchestrate(OrchestrateRequest {
+            task: Some(Task {
+                task_id: "e2e-task-5".to_owned(),
+                specialty: specialty.to_owned(),
+                description: "End-to-end test: route winner through the Runtime executor."
+                    .to_owned(),
+                // No output_contract: NoopAgent emits free-form text,
+                // and a structured-output contract would force the
+                // proposal to be a JSON object. Validators stay no-op
+                // without a contract.
+                constraints: None,
+                attributes: Some(attributes),
+                external_context: None,
+                metadata: None,
+            }),
+            execution_options: None,
+        })
+        .await
+        .context("Orchestrate failed")?
+        .into_inner();
+
+    if response.task_id != "e2e-task-5" {
+        bail!("response.task_id = {:?}", response.task_id);
+    }
+    if response.execution_id != "stub-invocation-1" {
+        bail!(
+            "execution_id should be the stub-runtime's canned value, got {:?}",
+            response.execution_id
+        );
+    }
+    let winner = response
+        .winner
+        .ok_or_else(|| anyhow!("Orchestrate returned no winner"))?;
+    let winner_proposal = winner
+        .proposal
+        .ok_or_else(|| anyhow!("winner has no proposal"))?;
+    if winner_proposal.content.trim().is_empty() {
+        bail!("winner proposal content is empty");
+    }
+    info!(
+        execution_id = response.execution_id.as_str(),
+        winner_id = winner_proposal.proposal_id.as_str(),
+        "Orchestrate routed through stub-runtime"
+    );
+    Ok(())
+}
+
+fn pb_struct_from_pairs<'a>(pairs: impl IntoIterator<Item = (&'a str, PbKind)>) -> PbStruct {
+    PbStruct {
+        fields: pairs
+            .into_iter()
+            .map(|(k, kind)| (k.to_owned(), PbValue { kind: Some(kind) }))
+            .collect(),
+    }
 }
 
 /// Publishes a `TriggerEvent` on NATS with known `correlation_id` and

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -29,7 +29,7 @@ As of 2026-05-11 the eight stack-readiness areas resolve as follows:
 | 5 | provider-backed council materialization | done (`DispatchingAgentFactory` wired with `noop`/`anthropic`/`openai`/`vllm` arms) |
 | 6 | honest and durable transport semantics | done (AsyncAPI now declares plain core NATS; JetStream deferred) |
 | 7 | real TLS / mTLS posture | done (gRPC server TLS in `none`/`server`/`mutual` modes; chart honest; Runtime client TLS shipped 2026-05-12; handshake-level integration test still deferred) |
-| 8 | stack-level end-to-end proofs | partial (E2E covers Noop council + causal metadata; real-council + runtime legs missing) |
+| 8 | stack-level end-to-end proofs | mostly done (E2E covers seeded council, deliberation, causal metadata over NATS, and Orchestrate → RuntimeExecutor → stub-runtime; real-provider council is `make e2e-provider-vllm`) |
 
 Two surfaces beyond the eight areas:
 
@@ -53,9 +53,11 @@ Genuinely open work: the crates.io distribution debt for `choreo-mcp`
 council-decision RPC if and when a consumer asks for more than the
 generic `Deliberate` / `Orchestrate`), the handshake-level TLS
 integration test (currently the wiring is exercised by env-loading
-unit tests + helm-lint, not a real cert handshake), and the missing
-real-council / runtime legs of Epic 11. Milestone B is complete as of
-2026-05-12.
+unit tests + helm-lint, not a real cert handshake), and the Epic 11
+follow-ups (a stack scenario that asserts schema validation +
+ExternalContextBundle round-trip, and merging the provider-runner
+E2E into the same compose stack). Milestones A, B, and C are all
+complete as of 2026-05-12.
 
 The recommended remaining execution order is:
 
@@ -80,7 +82,7 @@ This backlog does not include:
 These items still block downstream consumer integration.
 
 - dedicated consumer-facing RPC surface (Epic 9)
-- stack E2E proof with real council + runtime executor (Epic 11 leg)
+- stack E2E proof with real provider council + ExternalContextBundle round-trip + schema-validated structured output in the same compose stack (Epic 11 follow-ups)
 
 Already cleared: Runtime executor adapter (Epic 1), Kernel context
 boundary (Epic 2), structured council output contracts (Epic 3),
@@ -740,27 +742,49 @@ schema (renamed to drop product vocabulary where appropriate, e.g.
 
 ### Epic 11. Choreographer stack E2E
 
-Status: partial
+Status: mostly done — runtime-executor leg landed 2026-05-12; only
+the "real provider council" leg (vLLM/Anthropic/OpenAI in the compose
+stack) remains, and is covered separately by `make e2e-provider-vllm`.
 
 Current state:
 
-- `crates/choreo-e2e-runner/src/main.rs` runs four scenarios against a
-  real gRPC + NATS stack:
+- `crates/choreo-e2e-runner/src/main.rs` runs five scenarios against
+  a real gRPC + NATS stack with a stub-runtime sidecar:
   1. seeded council is visible
   2. `Deliberate` on the seeded specialty returns a winner
   3. `DeleteCouncil` on an unknown specialty returns `deleted=false`
   4. inbound `TriggerEvent` over NATS produces an outbound
      `DeliberationCompleted` carrying the same `correlation_id` and
      `causation_id` (scenario added 2026-05-11, PR #45)
-- the stack uses `CHOREO_SEED_SPECIALTIES=triage` with the `NoopAgent`,
-  so the council is real-shaped but not real-content
-- the docker-compose stack has no `CHOREO_EXECUTOR_KIND=runtime` and no
-  provider agent config, so the run does not exercise the runtime
-  executor or a provider-backed council
+  5. `Orchestrate` routes the winning proposal through the
+     configured `RuntimeExecutor` to the `stub-runtime` sidecar
+     (added 2026-05-12). Asserts the response carries the
+     stub's canned `execution_id` and that the winner proposal
+     is non-empty.
+- the `stub-runtime` sidecar ships in this repo as
+  `crates/choreo-e2e-runner/src/bin/stub_runtime.rs` +
+  `tests/e2e/stub-runtime.Dockerfile`. It serves the canonical
+  `underpass.runtime.v1.{SessionService,InvocationService}` and
+  always returns a successful canned Session / Invocation. Lets
+  Choreographer's `RuntimeExecutor` exercise a real gRPC peer
+  without dragging the real underpass-runtime image into this
+  repo's test path.
+- the compose stack now wires `CHOREO_EXECUTOR_KIND=runtime` +
+  `CHOREO_RUNTIME_GRPC_ENDPOINT=http://stub-runtime:50053` so
+  scenarios 2 / 5 exercise the full Deliberate -> winner ->
+  RuntimeExecutor -> gRPC InvokeTool -> outcome path. Validated
+  locally with `CONTAINER_RUNTIME=podman-compose make e2e-compose`:
+  the stub-runtime logs `CreateSession`, `InvokeTool(stub.echo)`,
+  and `CloseSession` once per orchestration.
+- the council itself still uses `NoopAgent` in this stack;
+  real-provider councils are exercised separately by
+  `make e2e-provider-vllm` (Epic-6 provider runner).
 
 Relevant code:
 
 - [`crates/choreo-e2e-runner/src/main.rs`](../crates/choreo-e2e-runner/src/main.rs)
+- [`crates/choreo-e2e-runner/src/bin/stub_runtime.rs`](../crates/choreo-e2e-runner/src/bin/stub_runtime.rs)
+- [`tests/e2e/stub-runtime.Dockerfile`](../tests/e2e/stub-runtime.Dockerfile)
 - [`tests/e2e/docker-compose.e2e.yaml`](../tests/e2e/docker-compose.e2e.yaml)
 
 #### Deliverables
@@ -775,14 +799,35 @@ bounded external trigger
         -> runtime execution or bounded output
 ```
 
-This E2E does not need a downstream consumer yet, but it must prove the stack assumptions Choreographer
-will bring into any consumer integration.
+Status of the chain:
+
+- bounded external trigger → ✅ scenario 4 (NATS) + scenario 5 (gRPC).
+- context bundle → covered at the proto / value-object level (Epic 2);
+  not yet asserted end-to-end as part of scenarios 1–5 (open).
+- real council → ✅ via `make e2e-provider-vllm` (provider runner).
+- validated structured result → ✅ Epic 4 JsonSchemaValidator wired in
+  compose; scenarios 2 / 5 currently skip a structured contract so
+  NoopAgent's free-form output passes. A scenario 6 that requests a
+  Report-shape contract and asserts schema validation is a clean
+  follow-up.
+- runtime execution → ✅ scenario 5 (stub-runtime).
+
+#### Remaining follow-ups (out of Milestone D's critical path)
+
+- scenario 6: orchestrate with an embedded JSON Schema contract +
+  assert the validator stamps pass / fail on the structured output.
+- scenario 7: orchestrate with an `ExternalContextBundle` attached
+  + assert the bundle survives through the chain.
+- merge the provider-runner E2E (vLLM) into the same compose stack
+  so a single `make e2e-compose` exercises real provider council +
+  real (stub) runtime in one shot. Today they are two manual gates.
 
 ### Epic 12. Consumer integration smoke prerequisites
 
 Status: not started — blocked by Epic 6 (real agent factory composition),
 Epic 9 (dedicated council-decision RPC), Epic 10 (report artifact), and
-the missing real-council / runtime legs of Epic 11.
+Epic 11's follow-ups (scenarios 6/7 + merging the provider-runner
+stack).
 
 #### Deliverables
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,76 @@
+# Documentation Index
+
+Navigation hub for `underpass-choreographer` docs. Each entry links to
+the canonical file and gives a one-line orientation.
+
+The choreographer is one of three Underpass platform planes:
+
+- **[Underpass KMP](../README.md#the-underpass-platform)** — Kernel
+  Memory Plane / Kernel Memory Protocol. Memory + context plane.
+  Lives in the sibling repo `rehydration-kernel`; the brand-facing
+  name is "Underpass KMP".
+- **Underpass Choreographer** — this repo. Coordination plane:
+  domain-agnostic deliberation, council orchestration, executor
+  hand-off, and MCP exposure of every RPC.
+- **Underpass Runtime** — execution + governed-tools plane. Lives in
+  the sibling repo `underpass-runtime`; the choreographer talks to
+  it through `RuntimeExecutor` (Epic 1).
+
+## Operations — how to run, install, and configure
+
+| Doc | Purpose |
+|---|---|
+| [`dev-loop.md`](./dev-loop.md) | Local iteration loop; every command mirrors a CI gate. |
+| [`release.md`](./release.md) | Versioning + cut-a-release checklist. |
+| [`operations/mcp-stdio.md`](./operations/mcp-stdio.md) | **MCP entry point.** Installable stdio adapter exposing every gRPC RPC as an MCP tool. |
+| [`operations/mcp/codex.md`](./operations/mcp/codex.md) | Codex CLI specifics: `codex mcp add`, dev-from-checkout, mTLS, fixture. |
+| [`operations/mcp/claude-desktop.md`](./operations/mcp/claude-desktop.md) | `claude_desktop_config.json` snippets, per-OS paths, troubleshooting. |
+
+## Discipline — how this project decides what to ship
+
+| Doc | Purpose |
+|---|---|
+| [`PRINCIPLES.md`](./PRINCIPLES.md) | Honest documentation, demonstrable claims, scientific iteration. |
+
+## Status, gaps, and roadmap
+
+| Doc | Purpose |
+|---|---|
+| [`backlog.md`](./backlog.md) | Epic-by-epic readiness backlog + session log + gating rules. PIR framing was dropped 2026-05-12 — this is a generic stack-readiness backlog. |
+| [`stack-gap-analysis.md`](./stack-gap-analysis.md) | Honest snapshot of medium-severity gaps against the rest of the Underpass stack. |
+
+## Experiments — append-only lab notebook
+
+| Doc | Purpose |
+|---|---|
+| [`experiments/`](./experiments/) | Hypothesis → design → measurement → result per dated subfolder. Null results kept. |
+
+## Research / Design — direction, not implementation claims
+
+| Doc | Purpose |
+|---|---|
+| [`agentic-conversation-ceremony-evaluation-research.md`](./agentic-conversation-ceremony-evaluation-research.md) | How to evaluate agentic meeting ceremonies built on Choreographer + KMP + Runtime. Status explicitly disclaimed as research. |
+| [`agentic-meeting-ceremony-blueprints.md`](./agentic-meeting-ceremony-blueprints.md) | Catalog of product-agnostic meeting designs (intake, evidence review, past replay, future scenario, decision council, …). |
+
+## Historical / out-of-scope
+
+| Doc | Purpose |
+|---|---|
+| [`pir-choreographer-integration-design.md`](./pir-choreographer-integration-design.md) | Legacy design doc for the PIR product's Choreographer integration. PIR is owned by a separate project; this file is retained for context and is no longer load-bearing for this repo's backlog. |
+
+## Where API examples live
+
+| Path | Purpose |
+|---|---|
+| [`../api/examples/output-contracts/`](../api/examples/output-contracts/) | Canonical JSON Schemas for `OutputContract.json_schema` — currently a generic Report shape. |
+
+## Sibling repos (for cross-reference)
+
+- [`rehydration-kernel`](https://github.com/underpass-ai/rehydration-kernel)
+  — Underpass KMP. MCP adapter pattern this repo's `crates/choreo-mcp`
+  copies (`crates/rehydration-mcp/`).
+- [`underpass-runtime`](https://github.com/underpass-ai/underpass-runtime)
+  — execution plane. Proto vendored at
+  `crates/choreo-proto/proto/underpass/runtime/v1/runtime.proto`;
+  client adapter at `crates/choreo-adapters/src/runtime.rs`
+  (Epic 1).

--- a/tests/e2e/docker-compose.e2e.yaml
+++ b/tests/e2e/docker-compose.e2e.yaml
@@ -22,6 +22,19 @@ services:
     # on startup (see `compose::wire_messaging`), which is the real
     # invariant we care about.
 
+  # Canned-response stub of underpass.runtime.v1 — gives the
+  # choreographer's `RuntimeExecutor` a real gRPC peer to talk to so
+  # the stack E2E can exercise the full Orchestrate path
+  # (Deliberate -> winner -> RuntimeExecutor::execute) without pulling
+  # the real underpass-runtime image into this repo.
+  stub-runtime:
+    build:
+      context: ../..
+      dockerfile: tests/e2e/stub-runtime.Dockerfile
+    environment:
+      STUB_RUNTIME_GRPC_ADDR: "0.0.0.0:50053"
+      RUST_LOG: "info"
+
   choreographer:
     build:
       context: ../..
@@ -33,9 +46,12 @@ services:
       CHOREO_PUBLISH_PREFIX: "choreo"
       CHOREO_TRIGGER_SUBJECT: "choreo.trigger.>"
       CHOREO_SEED_SPECIALTIES: "triage"
+      CHOREO_EXECUTOR_KIND: "runtime"
+      CHOREO_RUNTIME_GRPC_ENDPOINT: "http://stub-runtime:50053"
       RUST_LOG: "info"
     depends_on:
       - nats
+      - stub-runtime
 
   e2e-runner:
     build:

--- a/tests/e2e/stub-runtime.Dockerfile
+++ b/tests/e2e/stub-runtime.Dockerfile
@@ -1,0 +1,51 @@
+# syntax=docker/dockerfile:1.7
+#
+# Stub-runtime sidecar for the stack E2E.
+#
+# Builds the `choreo-stub-runtime` binary and ships it in a minimal,
+# non-root image. Lets the choreographer's `RuntimeExecutor` talk to
+# a real gRPC peer (`SessionService` + `InvocationService`) without
+# dragging the real `underpass-runtime` image into this repo's test
+# path. Driven by `tests/e2e/docker-compose.e2e.yaml`.
+
+ARG RUST_VERSION=1.90.0
+ARG DEBIAN_RELEASE=bookworm
+
+FROM docker.io/library/rust:${RUST_VERSION}-${DEBIAN_RELEASE} AS builder
+
+ENV CARGO_INCREMENTAL=0 \
+    CARGO_TERM_COLOR=always \
+    RUSTFLAGS="-C strip=symbols"
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      protobuf-compiler \
+      libprotobuf-dev \
+      ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+
+COPY Cargo.toml Cargo.lock ./
+COPY rust-toolchain.toml ./
+COPY crates ./crates
+
+RUN --mount=type=cache,id=cargo-registry-stub-runtime,target=/usr/local/cargo/registry \
+    --mount=type=cache,id=cargo-target-stub-runtime,target=/src/target \
+    cargo build --release --locked --bin choreo-stub-runtime \
+ && install -Dm 0755 target/release/choreo-stub-runtime /out/stub-runtime
+
+FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
+
+LABEL org.opencontainers.image.title="underpass-choreographer-stub-runtime" \
+      org.opencontainers.image.description="Canned-response stub of underpass.runtime.v1 for stack E2E. Not shipped." \
+      org.opencontainers.image.vendor="Underpass AI" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+COPY --from=builder /out/stub-runtime /usr/local/bin/choreo-stub-runtime
+
+USER nonroot:nonroot
+
+EXPOSE 50053
+
+ENTRYPOINT ["/usr/local/bin/choreo-stub-runtime"]


### PR DESCRIPTION
## Summary

Closes the runtime-executor leg of **Epic 11** (stack E2E) end-to-end. Adds a navigation hub for the repo's docs.

### Stack

- new `choreo-stub-runtime` binary — canned `SessionService` + `InvocationService` of `underpass.runtime.v1`
- new `tests/e2e/stub-runtime.Dockerfile` — distroless non-root
- compose stack wires the sidecar + `CHOREO_EXECUTOR_KIND=runtime` env on the choreographer
- new **scenario 5** in the e2e-runner: drives `Orchestrate` with `runtime.tool_name="stub.echo"` and asserts the stub's `execution_id` flows back through the response

### Docs

- new `docs/index.md` — navigation hub mirroring the sibling **Underpass KMP** convention
- `README.md` gains an "Underpass platform" section that names the three planes by their product brand (KMP / Choreographer / Runtime) and clarifies that `rehydration-kernel` is the codename for Underpass KMP
- backlog Epic 11 updated to "mostly done"; only follow-up scenarios remain

## Validated locally

```
CONTAINER_RUNTIME=podman-compose make e2e-compose
...
[stub-runtime]    | stub-runtime: CreateSession requested_session_id=""
[stub-runtime]    | stub-runtime: InvokeTool session_id="stub-session-1" tool_name="stub.echo" correlation_id="5ae4a119-..."
[stub-runtime]    | stub-runtime: CloseSession session_id="stub-session-1"
[e2e-runner]      | Orchestrate routed through stub-runtime execution_id="stub-invocation-1" winner_id="5ae4a119-..."
[e2e-runner]      | E2E scenarios passed
```

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --locked $PROVIDER_FEATURES -- -D warnings`
- [x] `cargo test --workspace --locked $PROVIDER_FEATURES` — **461 passed, 0 failed**
- [x] `CONTAINER_RUNTIME=podman-compose make e2e-compose` — all 5 scenarios green; stub-runtime logs prove the full chain
- [ ] Per-PR CI gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)