### PR TITLE
fix(ci): vincular e2e-runner image al repo via OCI source label

### DIFF
--- a/tests/e2e/runner.Dockerfile
+++ b/tests/e2e/runner.Dockerfile
@@ -38,7 +38,8 @@ FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
 LABEL org.opencontainers.image.title="underpass-choreographer-e2e-runner" \
       org.opencontainers.image.description="Drives the Choreographer over gRPC for E2E tests. Not shipped." \
       org.opencontainers.image.vendor="Underpass AI" \
-      org.opencontainers.image.licenses="Apache-2.0"
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.source="https://github.com/underpass-ai/underpass-choreographer"
 
 COPY --from=builder /out/runner /usr/local/bin/choreo-e2e-runner
 

--- a/tests/e2e/stub-runtime.Dockerfile
+++ b/tests/e2e/stub-runtime.Dockerfile
@@ -40,7 +40,8 @@ FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
 LABEL org.opencontainers.image.title="underpass-choreographer-stub-runtime" \
       org.opencontainers.image.description="Canned-response stub of underpass.runtime.v1 for stack E2E. Not shipped." \
       org.opencontainers.image.vendor="Underpass AI" \
-      org.opencontainers.image.licenses="Apache-2.0"
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.source="https://github.com/underpass-ai/underpass-choreographer"
 
 COPY --from=builder /out/stub-runtime /usr/local/bin/choreo-stub-runtime
 


### PR DESCRIPTION
## Summary

`publish-distribution` lleva fallando en `main` desde varios merges con `403 Forbidden` al empujar `underpass-choreographer-e2e-runner` a GHCR. La imagen principal sí sube. La diferencia: el `Dockerfile` raíz tiene el label `org.opencontainers.image.source` que GHCR usa para auto-vincular el paquete al repo y conceder permisos a `GITHUB_TOKEN`. Los Dockerfiles auxiliares no lo tenían.

Fix: añadir el mismo label a `tests/e2e/runner.Dockerfile` y, por simetría, a `tests/e2e/stub-runtime.Dockerfile`.

## Evidencia del error

```
ERROR: failed to push ghcr.io/underpass-ai/underpass-choreographer-e2e-runner:main:
unexpected status from HEAD request to
https://ghcr.io/v2/underpass-ai/underpass-choreographer-e2e-runner/blobs/...: 403 Forbidden
```

(Run 25724660790, job `publish-image`, paso "Build and push E2E runner image".)

## Test plan

- [ ] Workflow `publish-distribution` se completa verde tras el merge.
- [ ] `underpass-choreographer-e2e-runner` recibe tags `sha-<commit>`, `main`, `e2e-latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)