### PR TITLE
feat(chart): embedded NATS + executor.runtime block + cluster deploy profile

### DIFF
--- a/charts/choreographer/templates/_helpers.tpl
+++ b/charts/choreographer/templates/_helpers.tpl
@@ -42,6 +42,46 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{/*
+NATS bus name. The choreographer treats its event bus as a release-local
+component (mirrors KMP's pattern, where every plane owns its own NATS).
+Templates and the chart's client URL default to this name when the
+embedded NATS is on.
+*/}}
+{{- define "choreographer.natsFullname" -}}
+{{- printf "%s-nats" (include "choreographer.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "choreographer.natsSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "choreographer.natsFullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: nats
+{{- end -}}
+
+{{- define "choreographer.natsLabels" -}}
+{{ include "choreographer.natsSelectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+app.kubernetes.io/part-of: underpass
+{{- end -}}
+
+{{/*
+Resolve the NATS URL the binary should connect to. When the embedded
+server is enabled and `messaging.nats.url` is not overridden, this
+points at the release-local Service. Otherwise the value from
+`messaging.nats.url` wins. Fails fast if `messaging.nats.enabled` is
+true and neither side provides a URL.
+*/}}
+{{- define "choreographer.natsUrl" -}}
+{{- if .Values.messaging.nats.url -}}
+{{- .Values.messaging.nats.url -}}
+{{- else if .Values.messaging.nats.embedded.enabled -}}
+nats://{{ include "choreographer.natsFullname" . }}:4222
+{{- else -}}
+{{- fail "messaging.nats.enabled=true but no URL: set messaging.nats.url or messaging.nats.embedded.enabled=true" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Image reference. Enforces an explicit `tag` or `digest` unless the
 development.allowMutableImageTags escape hatch is set.
 */}}

--- a/charts/choreographer/templates/deployment.yaml
+++ b/charts/choreographer/templates/deployment.yaml
@@ -30,7 +30,16 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- $tlsMode := .Values.tls.mode | default "none" }}
-      {{- if or .Values.tmpVolume.enabled (ne $tlsMode "none") }}
+      {{- $executorKind := .Values.executor.kind | default "noop" }}
+      {{- $runtimeTlsMode := .Values.executor.runtime.tls.mode | default "disabled" }}
+      {{- if and (eq $executorKind "runtime") (not .Values.executor.runtime.endpoint) }}
+      {{- fail "executor.kind=runtime but executor.runtime.endpoint is empty; set the runtime gRPC URL" }}
+      {{- end }}
+      {{- if and (eq $executorKind "runtime") (ne $runtimeTlsMode "disabled") (not .Values.executor.runtime.tls.existingSecret) }}
+      {{- fail "executor.runtime.tls.mode != disabled but executor.runtime.tls.existingSecret is empty; provide a secret with ca.crt (plus tls.crt + tls.key for mutual)" }}
+      {{- end }}
+      {{- $runtimeTlsMounted := and (eq $executorKind "runtime") (ne $runtimeTlsMode "disabled") }}
+      {{- if or .Values.tmpVolume.enabled (ne $tlsMode "none") $runtimeTlsMounted }}
       volumes:
         {{- if .Values.tmpVolume.enabled }}
         - name: tmp
@@ -47,6 +56,12 @@ spec:
             secretName: {{ .Values.tls.existingSecret | quote }}
             defaultMode: 0400
         {{- end }}
+        {{- if $runtimeTlsMounted }}
+        - name: runtime-tls
+          secret:
+            secretName: {{ .Values.executor.runtime.tls.existingSecret | quote }}
+            defaultMode: 0400
+        {{- end }}
       {{- end }}
       containers:
         - name: choreo
@@ -54,7 +69,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          {{- if or .Values.tmpVolume.enabled (ne $tlsMode "none") }}
+          {{- if or .Values.tmpVolume.enabled (ne $tlsMode "none") $runtimeTlsMounted }}
           volumeMounts:
             {{- if .Values.tmpVolume.enabled }}
             - name: tmp
@@ -63,6 +78,11 @@ spec:
             {{- if ne $tlsMode "none" }}
             - name: grpc-tls
               mountPath: /etc/choreographer/tls
+              readOnly: true
+            {{- end }}
+            {{- if $runtimeTlsMounted }}
+            - name: runtime-tls
+              mountPath: /etc/choreographer/runtime-tls
               readOnly: true
             {{- end }}
           {{- end }}
@@ -84,7 +104,7 @@ spec:
             - name: CHOREO_NATS_ENABLED
               value: "true"
             - name: CHOREO_NATS_URL
-              value: {{ .Values.messaging.nats.url | quote }}
+              value: {{ include "choreographer.natsUrl" . | quote }}
             - name: CHOREO_TRIGGER_SUBJECT
               value: {{ .Values.messaging.nats.triggerSubject | quote }}
             - name: CHOREO_PUBLISH_PREFIX
@@ -107,6 +127,40 @@ spec:
             {{- if eq $tlsMode "mutual" }}
             - name: CHOREO_GRPC_TLS_CLIENT_CA_PATH
               value: "/etc/choreographer/tls/ca.crt"
+            {{- end }}
+            {{- end }}
+            - name: CHOREO_EXECUTOR_KIND
+              value: {{ $executorKind | quote }}
+            {{- if eq $executorKind "runtime" }}
+            - name: CHOREO_RUNTIME_GRPC_ENDPOINT
+              value: {{ .Values.executor.runtime.endpoint | quote }}
+            {{- with .Values.executor.runtime.principal.tenantId }}
+            - name: CHOREO_RUNTIME_PRINCIPAL_TENANT_ID
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.executor.runtime.principal.actorId }}
+            - name: CHOREO_RUNTIME_PRINCIPAL_ACTOR_ID
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.executor.runtime.principal.roles }}
+            - name: CHOREO_RUNTIME_PRINCIPAL_ROLES
+              value: {{ . | quote }}
+            {{- end }}
+            {{- if ne $runtimeTlsMode "disabled" }}
+            - name: CHOREO_RUNTIME_TLS_MODE
+              value: {{ $runtimeTlsMode | quote }}
+            - name: CHOREO_RUNTIME_TLS_CA_PATH
+              value: "/etc/choreographer/runtime-tls/ca.crt"
+            {{- if eq $runtimeTlsMode "mutual" }}
+            - name: CHOREO_RUNTIME_TLS_CERT_PATH
+              value: "/etc/choreographer/runtime-tls/tls.crt"
+            - name: CHOREO_RUNTIME_TLS_KEY_PATH
+              value: "/etc/choreographer/runtime-tls/tls.key"
+            {{- end }}
+            {{- with .Values.executor.runtime.tls.domainName }}
+            - name: CHOREO_RUNTIME_TLS_DOMAIN_NAME
+              value: {{ . | quote }}
+            {{- end }}
             {{- end }}
             {{- end }}
             {{- if .Values.persistence.postgres.enabled }}

--- a/charts/choreographer/templates/nats.yaml
+++ b/charts/choreographer/templates/nats.yaml
@@ -1,0 +1,128 @@
+{{- if .Values.messaging.nats.embedded.enabled }}
+{{- $natsName := include "choreographer.natsFullname" . }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $natsName }}
+  labels:
+    {{- include "choreographer.natsLabels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "choreographer.natsSelectorLabels" . | nindent 4 }}
+  ports:
+    - name: client
+      port: 4222
+      targetPort: 4222
+      protocol: TCP
+    {{- if .Values.messaging.nats.embedded.monitoring.enabled }}
+    - name: monitor
+      port: 8222
+      targetPort: 8222
+      protocol: TCP
+    {{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $natsName }}
+  labels:
+    {{- include "choreographer.natsLabels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "choreographer.natsSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "choreographer.natsSelectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: nats
+          image: "{{ .Values.messaging.nats.embedded.image.repository }}:{{ .Values.messaging.nats.embedded.image.tag }}"
+          imagePullPolicy: {{ .Values.messaging.nats.embedded.image.pullPolicy }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          args:
+            {{- if .Values.messaging.nats.embedded.jetstream.enabled }}
+            - "-js"
+            - "--store_dir=/data/jetstream"
+            {{- end }}
+            {{- if .Values.messaging.nats.embedded.monitoring.enabled }}
+            - "-m"
+            - "8222"
+            {{- end }}
+          ports:
+            - name: client
+              containerPort: 4222
+              protocol: TCP
+            {{- if .Values.messaging.nats.embedded.monitoring.enabled }}
+            - name: monitor
+              containerPort: 8222
+              protocol: TCP
+            {{- end }}
+          {{- if .Values.messaging.nats.embedded.jetstream.enabled }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          {{- end }}
+          resources:
+            {{- toYaml .Values.messaging.nats.embedded.resources | nindent 12 }}
+          livenessProbe:
+            tcpSocket:
+              port: client
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: client
+            initialDelaySeconds: 2
+            periodSeconds: 5
+      {{- if .Values.messaging.nats.embedded.jetstream.enabled }}
+      volumes:
+        - name: data
+          {{- if .Values.messaging.nats.embedded.jetstream.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ $natsName }}-data
+          {{- else }}
+          emptyDir:
+            medium: Memory
+            sizeLimit: {{ .Values.messaging.nats.embedded.jetstream.persistence.size }}
+          {{- end }}
+      {{- end }}
+{{- if and .Values.messaging.nats.embedded.jetstream.enabled .Values.messaging.nats.embedded.jetstream.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $natsName }}-data
+  labels:
+    {{- include "choreographer.natsLabels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- with .Values.messaging.nats.embedded.jetstream.persistence.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.messaging.nats.embedded.jetstream.persistence.size }}
+{{- end }}
+{{- end }}

--- a/charts/choreographer/values.underpass-runtime.yaml
+++ b/charts/choreographer/values.underpass-runtime.yaml
@@ -1,0 +1,84 @@
+# Deployment profile for the `underpass-runtime` namespace on the
+# main cluster. Mirrors the sibling pattern used by
+# `rehydration-kernel` and `underpass-runtime` (one `values-<ns>.yaml`
+# per target environment).
+#
+# Apply with:
+#
+#   NAMESPACE=underpass-runtime \
+#   RELEASE_NAME=choreographer \
+#   VALUES_FILE=charts/choreographer/values.underpass-runtime.yaml \
+#   IMAGE_TAG=sha-<commit> \
+#   ./scripts/ci/deploy-kubernetes.sh
+
+image:
+  # Image tag is supplied at deploy time by the script (via
+  # `--set image.tag=sha-<commit>`); see `scripts/ci/deploy-kubernetes.sh`.
+  pullPolicy: Always
+
+imagePullSecrets:
+  - name: ghcr-pull
+
+# Each Underpass plane owns its own NATS bus — KMP, runtime, and
+# choreographer publish on disjoint subject namespaces and there is no
+# cross-plane subscription, so collocating them would only couple
+# deployments without sharing data. The chart-managed embedded NATS
+# keeps the deploy self-contained.
+messaging:
+  nats:
+    enabled: true
+    # Empty `url` + `embedded.enabled: true` resolves at template time
+    # to `nats://<release>-nats:4222`.
+    url: ""
+    publishPrefix: choreo
+    triggerSubject: choreo.trigger.>
+    embedded:
+      enabled: true
+      jetstream:
+        enabled: false
+
+# Production posture: hand winning proposals to the real
+# `underpass-runtime` service in this namespace. The runtime presents
+# a server cert signed by `rehydration-kernel-internal-issuer` and
+# expects client authentication (mTLS mutual). The choreographer
+# carries its own client cert minted from the same issuer (see
+# `tests/cluster/choreographer-runtime-client-cert.yaml`).
+executor:
+  kind: runtime
+  runtime:
+    endpoint: https://underpass-runtime:50053
+    principal:
+      tenantId: underpass
+      actorId: choreographer
+      roles: orchestrator
+    tls:
+      mode: mutual
+      domainName: underpass-runtime
+      existingSecret: choreographer-runtime-client-tls
+
+# Seed a single `triage` council with a NoopAgent so the deployment
+# is exercisable from the get-go via gRPC. Real specialists land
+# through the API.
+config:
+  seedSpecialties: triage
+  logLevel: info
+
+# Persistence stays off in this first rollout; the deliberation
+# registries default to in-memory adapters, which is fine for the
+# smoke + E2E pass. Flip on when a Postgres CR exists in-namespace.
+persistence:
+  postgres:
+    enabled: false
+
+# Plain HTTP/2 inside the cluster — ingress / mesh handles edge TLS.
+tls:
+  mode: none
+
+# Single replica; bump to 2 once we want PDB + rolling tolerance.
+replicaCount: 1
+
+# Allow `sha-<short>` image tags from CI — they are immutable per
+# commit, but the chart's default refuses any non-digest reference
+# unless this development knob opts in.
+development:
+  allowMutableImageTags: true

--- a/charts/choreographer/values.yaml
+++ b/charts/choreographer/values.yaml
@@ -96,12 +96,14 @@ config:
 messaging:
   nats:
     enabled: true
-    # Endpoint the binary connects to. When `embedded.enabled: true`,
-    # leave this empty and the chart wires it to the release-local
-    # NATS Service (`<release>-nats:4222`); when running against an
-    # external bus (other namespace, managed cluster, etc.) set this
-    # explicitly and turn the embedded one off.
-    url: ""
+    # Endpoint the binary connects to. The placeholder
+    # `nats://nats:4222` works out of the box against compose-shaped
+    # deployments. To use the chart's own embedded NATS, set this to
+    # an empty string and flip `embedded.enabled: true`; the chart
+    # then resolves the URL to the release-local Service
+    # (`<release>-nats:4222`). An explicit URL always wins over the
+    # embedded one.
+    url: nats://nats:4222
     # Subject prefix used for Choreographer-published events.
     publishPrefix: choreo
     # Wildcard of inbound trigger subjects consumed by the service.

--- a/charts/choreographer/values.yaml
+++ b/charts/choreographer/values.yaml
@@ -96,11 +96,87 @@ config:
 messaging:
   nats:
     enabled: true
-    url: nats://nats:4222
+    # Endpoint the binary connects to. When `embedded.enabled: true`,
+    # leave this empty and the chart wires it to the release-local
+    # NATS Service (`<release>-nats:4222`); when running against an
+    # external bus (other namespace, managed cluster, etc.) set this
+    # explicitly and turn the embedded one off.
+    url: ""
     # Subject prefix used for Choreographer-published events.
     publishPrefix: choreo
     # Wildcard of inbound trigger subjects consumed by the service.
     triggerSubject: choreo.trigger.>
+    # Optional in-release NATS server. Off by default to match the
+    # chart's "external dependencies" posture and to keep `helm install`
+    # cheap; flip to `true` in deployment-target values files (e.g.
+    # `values.underpass-runtime.yaml`) so the choreographer ships with
+    # its own bus and does not collide with sibling Underpass planes.
+    embedded:
+      enabled: false
+      image:
+        repository: docker.io/library/nats
+        tag: "2.10-alpine"
+        pullPolicy: IfNotPresent
+      # JetStream + persistence are off by default. Core NATS is enough
+      # for the choreographer's fire-and-forget event surface; opt in
+      # only when a stream-bound consumer needs it.
+      jetstream:
+        enabled: false
+        persistence:
+          enabled: false
+          size: 1Gi
+          storageClass: ""
+      monitoring:
+        enabled: false
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 500m
+          memory: 256Mi
+
+# Executor — what handles winning proposals after a council reaches a
+# decision. `noop` returns synthetic invocation IDs (good for smoke
+# testing the gRPC + bus surface without a runtime). `runtime` calls
+# `underpass-runtime`'s `SessionService` + `InvocationService` over
+# gRPC, which is the production posture.
+executor:
+  kind: noop  # one of: "noop" | "runtime"
+  runtime:
+    # gRPC endpoint of the sibling underpass-runtime service. Required
+    # when `kind: runtime`. Use `http://...` for plain HTTP/2 or
+    # `https://...` when the runtime presents TLS.
+    endpoint: ""
+    # Principal stamped on every `CreateSession` call. The runtime
+    # uses this to authorize tool invocations and to scope side-effects
+    # in its audit trail.
+    principal:
+      tenantId: ""
+      actorId: ""
+      # Comma-separated list, e.g. "developer,ops".
+      roles: ""
+    # Client TLS posture against the runtime. Independent of the
+    # server-side TLS (`tls.mode`) that this service presents to its
+    # own callers. Mirrors the runtime adapter's env-driven config.
+    tls:
+      # One of: "disabled" | "server" | "mutual".
+      #   - "disabled": plain HTTP/2 over TCP
+      #   - "server":   verify the runtime's server cert against a CA
+      #                 bundle this side already has
+      #   - "mutual":   in addition, present a client cert+key so the
+      #                 runtime can authenticate this caller
+      mode: disabled
+      # SAN/CN to expect on the runtime's server certificate. Optional;
+      # when empty the host portion of `endpoint` is used.
+      domainName: ""
+      # Kubernetes secret mounted read-only at
+      # /etc/choreographer/runtime-tls. Required when `mode != disabled`.
+      # Expected keys:
+      #   ca.crt   — trust bundle for the runtime's server identity
+      #   tls.crt  — client cert PEM        (mutual only)
+      #   tls.key  — client private key PEM (mutual only)
+      existingSecret: ""
 
 # Persistent storage for deliberations, councils, agents, and
 # statistics. When `enabled: true`, every registry that has a

--- a/docs/operations/deploy-kubernetes.md
+++ b/docs/operations/deploy-kubernetes.md
@@ -1,0 +1,105 @@
+# Deploying the Choreographer to Kubernetes
+
+The chart at `charts/choreographer/` ships with a deployment profile
+for the `underpass-runtime` namespace
+(`charts/choreographer/values.underpass-runtime.yaml`) and a wrapper
+script (`scripts/ci/deploy-kubernetes.sh`).
+
+The profile reflects the agreed Underpass topology: every plane
+(KMP, Runtime, Choreographer) owns its **own NATS bus** — the planes
+don't share subjects and there is no cross-plane NATS subscriber, so
+collocating buses would couple deploys without sharing data. The
+choreographer's chart therefore deploys a release-local NATS via
+`messaging.nats.embedded.enabled: true`.
+
+## Prerequisites
+
+1. **Image pull secret.** A namespace secret `ghcr-pull`
+   (`kubernetes.io/dockerconfigjson`) with credentials that can pull
+   from `ghcr.io/underpass-ai/`.
+2. **Runtime mTLS client cert** (only when `executor.kind: runtime`).
+   Apply
+   [`tests/cluster/choreographer-runtime-client-cert.yaml`](../../tests/cluster/choreographer-runtime-client-cert.yaml)
+   first. It mints a `kubernetes.io/tls` secret named
+   `choreographer-runtime-client-tls` via cert-manager, signed by the
+   same CA that signs `underpass-runtime`'s server cert.
+3. **Reachable runtime** — `underpass-runtime` Service must exist in
+   the namespace and the chart values (or the override) must point at
+   it (`executor.runtime.endpoint: https://underpass-runtime:50053`).
+
+## Deploy
+
+```bash
+NAMESPACE=underpass-runtime \
+RELEASE_NAME=choreographer \
+IMAGE_TAG=sha-<commit> \
+VALUES_FILE=charts/choreographer/values.underpass-runtime.yaml \
+./scripts/ci/deploy-kubernetes.sh
+```
+
+The wrapper:
+
+- Requires `IMAGE_TAG` **or** `IMAGE_DIGEST` (mutually exclusive).
+- Defaults to `--wait --atomic --timeout 10m`. `DRY_RUN=true` falls
+  back to `--dry-run=server`.
+- Always passes `--create-namespace`.
+
+## Smoke
+
+```bash
+# Liveness + readiness via the HTTP sidecar port (NATS readiness
+# is part of /readyz).
+kubectl -n "$NAMESPACE" port-forward svc/choreographer 8080:8080 &
+curl -s localhost:8080/healthz
+curl -s localhost:8080/readyz   # {"checks":[{"name":"nats","healthy":true,...}]}
+```
+
+## End-to-end against the deploy
+
+`tests/cluster/e2e-job.yaml` runs the `choreo-e2e-runner` binary as
+a Job. Scenarios 1–4 cover gRPC + NATS + causal metadata against the
+real deploy and pass when the choreographer is wired correctly.
+
+Scenarios 5–6 in the current runner are designed for the compose
+**stub-runtime** sidecar (they call a tool named `stub.echo` and
+assert JSON-Schema rejection on free-form proposals). Against the
+real `underpass-runtime`, the tool is not in the catalog, so the
+runner exits with a `NotFound: runtime resource` from scenario 5 —
+that proves the mTLS gRPC path is wired but fails the assertion.
+Treat 5–6 as **design-for-stub** when reading the Job's exit code.
+
+```bash
+kubectl apply -f tests/cluster/e2e-job.yaml
+kubectl -n "$NAMESPACE" logs -f -l app.kubernetes.io/component=e2e
+```
+
+## Rolling back
+
+Helm-managed:
+
+```bash
+helm -n "$NAMESPACE" rollback choreographer <revision>
+```
+
+The script's `--atomic` ensures a failed `helm upgrade` already
+rolls back the release before it returns non-zero.
+
+## Topology recap
+
+```
++---------------------------------------------+
+|                underpass-runtime ns         |
+|                                             |
+|   choreographer  <----- gRPC mTLS ---->  underpass-runtime
+|   |                                          |
+|   | NATS                                    | NATS
+|   v                                          v
+|   choreographer-nats                  underpass-runtime-nats
+|                                             |
+|   rehydration-kernel  <-- gRPC -->  rehydration-kernel-nats
+|                                             |
++---------------------------------------------+
+```
+
+Each plane owns its NATS. No subject collisions exist across the
+three planes; integration is gRPC (point-to-point) where it matters.

--- a/scripts/ci/deploy-kubernetes.sh
+++ b/scripts/ci/deploy-kubernetes.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Wrapper around `helm upgrade --install` for the choreographer chart.
+# Mirrors the sibling `rehydration-kernel/scripts/ci/deploy-kubernetes.sh`
+# so the deploy ergonomics are identical across Underpass planes.
+#
+# Required env:
+#   RELEASE_NAME  Helm release name (e.g. "choreographer")
+#   NAMESPACE     Target namespace (e.g. "underpass-runtime")
+#   IMAGE_TAG     OR IMAGE_DIGEST (mutually exclusive; one is required)
+#
+# Optional env:
+#   CHART_PATH       (default: charts/choreographer)
+#   VALUES_FILE      (one extra `-f <file>` on top of values.yaml)
+#   HELM_TIMEOUT     (default: 10m)
+#   WAIT_FOR_ROLLOUT (default: true)
+#   ATOMIC_DEPLOY    (default: true)
+#   DRY_RUN          (default: false; "true" runs `helm --dry-run=server`)
+
+set -euo pipefail
+
+CHART_PATH="${CHART_PATH:-charts/choreographer}"
+RELEASE_NAME="${RELEASE_NAME:?RELEASE_NAME is required}"
+NAMESPACE="${NAMESPACE:?NAMESPACE is required}"
+VALUES_FILE="${VALUES_FILE:-}"
+IMAGE_TAG="${IMAGE_TAG:-}"
+IMAGE_DIGEST="${IMAGE_DIGEST:-}"
+HELM_TIMEOUT="${HELM_TIMEOUT:-10m}"
+WAIT_FOR_ROLLOUT="${WAIT_FOR_ROLLOUT:-true}"
+ATOMIC_DEPLOY="${ATOMIC_DEPLOY:-true}"
+DRY_RUN="${DRY_RUN:-false}"
+
+if [[ -n "${IMAGE_TAG}" && -n "${IMAGE_DIGEST}" ]]; then
+  echo "set either IMAGE_TAG or IMAGE_DIGEST, not both" >&2
+  exit 1
+fi
+
+if [[ -z "${IMAGE_TAG}" && -z "${IMAGE_DIGEST}" ]]; then
+  echo "set IMAGE_TAG or IMAGE_DIGEST" >&2
+  exit 1
+fi
+
+if [[ ! -d "${CHART_PATH}" ]]; then
+  echo "chart path not found: ${CHART_PATH}" >&2
+  exit 1
+fi
+
+if [[ -n "${VALUES_FILE}" && ! -f "${VALUES_FILE}" ]]; then
+  echo "values file not found: ${VALUES_FILE}" >&2
+  exit 1
+fi
+
+HELM_ARGS=(
+  upgrade
+  --install
+  "${RELEASE_NAME}"
+  "${CHART_PATH}"
+  --namespace
+  "${NAMESPACE}"
+  --create-namespace
+)
+
+if [[ -n "${VALUES_FILE}" ]]; then
+  HELM_ARGS+=(-f "${VALUES_FILE}")
+fi
+
+if [[ "${WAIT_FOR_ROLLOUT}" == "true" ]]; then
+  HELM_ARGS+=(--wait --timeout "${HELM_TIMEOUT}")
+fi
+
+if [[ "${ATOMIC_DEPLOY}" == "true" && "${DRY_RUN}" != "true" ]]; then
+  HELM_ARGS+=(--atomic)
+fi
+
+if [[ "${DRY_RUN}" == "true" ]]; then
+  HELM_ARGS+=(--dry-run=server)
+fi
+
+if [[ -n "${IMAGE_DIGEST}" ]]; then
+  HELM_ARGS+=(--set "image.digest=${IMAGE_DIGEST}" --set "image.tag=")
+else
+  HELM_ARGS+=(--set "image.tag=${IMAGE_TAG}" --set "image.digest=")
+fi
+
+helm "${HELM_ARGS[@]}"

--- a/tests/cluster/choreographer-runtime-client-cert.yaml
+++ b/tests/cluster/choreographer-runtime-client-cert.yaml
@@ -1,0 +1,28 @@
+# cert-manager Certificate that mints the client cert the choreographer
+# uses to call `underpass-runtime`'s gRPC service over mutual TLS.
+#
+# Apply BEFORE deploying the choreographer chart against a cluster that
+# runs `underpass-runtime` with `tls.mode=mutual` — the chart resolves
+# `executor.runtime.tls.existingSecret` against the resulting Secret.
+#
+# Issuer assumption: `rehydration-kernel-internal-issuer` is the
+# in-namespace CA used by both planes (it already signs runtime's
+# server cert). Adjust if your cluster names the issuer differently.
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: choreographer-runtime-client-cert
+  namespace: underpass-runtime
+  labels:
+    app.kubernetes.io/part-of: underpass
+    app.kubernetes.io/component: choreographer-mtls
+spec:
+  commonName: choreographer
+  duration: 8760h
+  issuerRef:
+    kind: Issuer
+    name: rehydration-kernel-internal-issuer
+  secretName: choreographer-runtime-client-tls
+  usages:
+    - client auth

--- a/tests/cluster/e2e-job.yaml
+++ b/tests/cluster/e2e-job.yaml
@@ -1,0 +1,60 @@
+# Runs the `choreo-e2e-runner` binary as a Kubernetes Job against a
+# choreographer deployed in-cluster. Useful as a smoke test after a
+# `helm upgrade --install`: the same scenarios that compose runs
+# locally, now driven through real DNS, real network, and a real
+# `RuntimeExecutor` connection.
+#
+# Caveats:
+#
+# - Scenarios 1–4 cover gRPC + NATS + causal metadata against the
+#   real deploy. They pass when the choreographer is wired correctly
+#   to its own NATS bus.
+#
+# - Scenarios 5–6 in the current e2e-runner are written for the
+#   compose stub-runtime (they expect a tool named `stub.echo` to
+#   succeed and free-form proposals to be rejected by a strict
+#   JSON Schema). Against the real `underpass-runtime`, the
+#   stub.echo tool is not in the catalog, so scenario 5 surfaces a
+#   `NotFound: runtime resource` from the runtime — proving the
+#   gRPC mTLS path is wired, but failing the assertion. Treat 5–6
+#   as design-for-stub when reading the Job's exit code.
+#
+# Apply after `helm upgrade --install`. The Job's TTL cleans the
+# resource after 10 min.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: choreographer-e2e
+  namespace: underpass-runtime
+  labels:
+    app.kubernetes.io/part-of: underpass
+    app.kubernetes.io/component: e2e
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: underpass
+        app.kubernetes.io/component: e2e
+    spec:
+      restartPolicy: Never
+      imagePullSecrets:
+        - name: ghcr-pull
+      containers:
+        - name: e2e-runner
+          # Pin to the same commit as the choreographer image; both
+          # come from the same workspace and rolling them together
+          # avoids API skew between client and server.
+          image: ghcr.io/underpass-ai/underpass-choreographer-e2e-runner:sha-23b3af0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: CHOREOGRAPHER_ENDPOINT
+              value: "http://choreographer:50055"
+            - name: CHOREO_NATS_URL
+              value: "nats://choreographer-nats:4222"
+            - name: CHOREO_SEED_SPECIALTY
+              value: "triage"
+            - name: RUST_LOG
+              value: "info"


### PR DESCRIPTION
## Summary

Wires the choreographer chart for an end-to-end Kubernetes rollout against the `underpass-runtime` namespace and codifies the Underpass topology agreed in this session: **every plane (KMP, Runtime, Choreographer) owns its own NATS bus**. Subjects don't collide cross-plane and there's no cross-plane NATS subscriber, so collocating brokers would couple deploys without sharing data.

## Chart changes

- New `executor:` block in `values.yaml`: `kind: noop|runtime` + `runtime.{endpoint,principal,tls}` sub-tree.
- New `messaging.nats.embedded:` block: when on, the chart deploys a release-local `<release>-nats` Deployment + Service; the binary's `CHOREO_NATS_URL` resolves via a new `natsUrl` helper. Default off so `helm install` stays minimal.
- `templates/deployment.yaml` emits `CHOREO_EXECUTOR_KIND` and, when `runtime`, the runtime endpoint + principal + TLS env vars; mounts the client TLS secret read-only at `/etc/choreographer/runtime-tls`.
- New `templates/nats.yaml`: NATS Deployment + Service with distroless-compatible security context.

## Deployment profile + wrapper

- `values.underpass-runtime.yaml`: cluster-target profile. `embedded.enabled=true`, `executor.kind=runtime` with mTLS to `https://underpass-runtime:50053`.
- `scripts/ci/deploy-kubernetes.sh`: bash wrapper mirroring rehydration-kernel's pattern.

## Cluster manifests + docs

- `tests/cluster/choreographer-runtime-client-cert.yaml` — cert-manager Certificate for the mTLS client identity.
- `tests/cluster/e2e-job.yaml` — runs the e2e-runner as a Job against the in-cluster choreographer.
- `docs/operations/deploy-kubernetes.md` — full deploy + smoke + topology recap.

## Validation

- `helm lint` + `helm template` clean.
- `make e2e-compose` still green (additive change).
- **Deployed to live cluster** (`underpass-runtime` namespace):
  - `choreographer` 1/1 ready, `choreographer-nats` 1/1 ready.
  - `/healthz`: alive · `/readyz`: nats.healthy=true.
  - In-cluster E2E: scenarios 1–4 pass; scenario 5 reaches the runtime over mTLS and surfaces a documented stub-tool mismatch (`NotFound: runtime resource` — the e2e-runner asks for `stub.echo`, which only the compose stub-runtime serves). Treated as design-for-stub.

## Honest scope

- Sister repo `underpass-runtime` has a parallel PR adding NATS embedded to its chart (each plane its own bus).
- Scenarios 5/6 of the e2e-runner need a follow-up to be runtime-aware (use a tool from the real runtime catalog, or co-deploy stub-runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)