### PR TITLE
docs(readme): link to underpassai.com homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Underpass Choreographer
 
+> Part of [Underpass AI](https://underpassai.com) — memory and execution infrastructure for reliable AI agents.
+
 Event-driven coordination plane for specialist agents. Domain-agnostic port of
 the `swe-ai-fleet` orchestrator service to Rust.
 


### PR DESCRIPTION
## Summary
- Adds a one-line pointer near the top of the README to https://underpassai.com so the project's homepage is discoverable from this repo.

## Why
- The repo currently has no link back to the Underpass AI website. Adding one improves discoverability for visitors arriving from search engines or other Underpass repos, and contributes a backlink that helps the website rank for relevant queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)