### PR TITLE
feat(epic-12): generic consumer-smoke harness — RunCouncilDecision + handoff report chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,10 +47,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "anyhow"
@@ -476,6 +520,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "choreo-consumer-smoke"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-nats",
+ "async-trait",
+ "choreo-adapters",
+ "choreo-app",
+ "choreo-core",
+ "choreo-proto",
+ "choreo-tests-integration",
+ "clap",
+ "futures",
+ "jsonschema",
+ "prost-types",
+ "serde_json",
+ "time",
+ "tokio",
+ "tonic",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "choreo-core"
 version = "0.1.0"
 dependencies = [
@@ -604,6 +673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -612,8 +682,22 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -621,6 +705,12 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "concurrent-queue"
@@ -1718,6 +1808,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "iso8601"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2111,6 +2207,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oorandom"
@@ -4181,6 +4283,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/choreo-tests-integration",
     "crates/choreo-e2e-runner",
     "crates/choreo-mcp",
+    "crates/choreo-consumer-smoke",
 ]
 
 [workspace.package]
@@ -108,6 +109,7 @@ choreo-core = { path = "crates/choreo-core" }
 choreo-app = { path = "crates/choreo-app" }
 choreo-adapters = { path = "crates/choreo-adapters" }
 choreo-proto = { path = "crates/choreo-proto" }
+choreo-tests-integration = { path = "crates/choreo-tests-integration" }
 
 [profile.release]
 lto = "thin"

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ VERSION ?=
 	contract fmt-check fmt clippy test bench-compile check \
 	integration-nats integration-postgres integration \
 	e2e-compose e2e-kubernetes e2e-provider-vllm \
+	consumer-smoke \
 	helm-lint build-image build-provider-image \
 	run run-otel \
 	bench-trace bench-deliberate bench-experiment-001 bench-experiment-002 \
@@ -23,6 +24,7 @@ help:
 		'  make e2e-compose            # manual E2E via docker/podman compose or podman-compose' \
 		'  make e2e-kubernetes         # manual E2E via Kubernetes Job' \
 		'  make e2e-provider-vllm      # provider-level vLLM E2E' \
+		'  make consumer-smoke         # drive the public RPC + bus surface as a consumer would' \
 		'  make helm-lint              # helm lint + hardened render assertions' \
 		'  make build-image            # production container image' \
 		'  make build-provider-image   # provider E2E runner image' \
@@ -67,6 +69,11 @@ e2e-kubernetes:
 
 e2e-provider-vllm:
 	bash scripts/ci/e2e-provider-vllm.sh
+
+consumer-smoke:
+	cargo run -p choreo-consumer-smoke -- \
+		--endpoint $${CHOREOGRAPHER_ENDPOINT:-http://localhost:50055} \
+		--chain $${CONSUMER_SMOKE_CHAIN:-all}
 
 helm-lint:
 	bash scripts/ci/helm-lint.sh

--- a/crates/choreo-consumer-smoke/Cargo.toml
+++ b/crates/choreo-consumer-smoke/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "choreo-consumer-smoke"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Generic consumer-shaped smoke harness for the Choreographer's public surface. Distributed as a CLI a consumer can point at a live cluster, plus a library the choreographer's own integration tests reuse."
+publish = false
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "choreo-consumer-smoke"
+path = "src/main.rs"
+
+[dependencies]
+choreo-proto = { workspace = true }
+choreo-core = { workspace = true }
+tokio = { workspace = true }
+tonic = { workspace = true }
+prost-types = { workspace = true }
+anyhow = { workspace = true }
+clap = { version = "4", features = ["derive", "env"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+async-nats = { workspace = true }
+serde_json = { workspace = true }
+jsonschema = { workspace = true }
+time = { workspace = true }
+uuid = { workspace = true }
+futures = { workspace = true }
+
+[dev-dependencies]
+choreo-adapters = { workspace = true }
+choreo-app = { workspace = true }
+choreo-tests-integration = { workspace = true }
+async-trait = { workspace = true }

--- a/crates/choreo-consumer-smoke/src/bundle.rs
+++ b/crates/choreo-consumer-smoke/src/bundle.rs
@@ -1,0 +1,90 @@
+//! Deterministic stub of the kernel rehydration bundle.
+//!
+//! **This is the seam where a real consumer would fetch a bundle
+//! from Underpass KMP** (or any other context source) before calling
+//! `RunCouncilDecision`. The smoke harness keeps that fetch out of
+//! its dependency surface — adding a kernel client here would force
+//! the binary to ship a kernel adapter, which couples Epic 12 to
+//! Epic 2's runtime. Instead, the deterministic literal below stands
+//! in for that fetch.
+//!
+//! A real consumer integration would replace this with:
+//!
+//! ```text
+//!   let bundle = kernel.rehydrate(...).await?;
+//!   harness.grpc.run_council_decision(req.with_external_context(bundle)).await
+//! ```
+//!
+//! The smoke binary documents this in `docs/operations/consumer-smoke.md`.
+
+use choreo_proto::v1 as pb;
+
+const BUNDLE_ID: &str = "consumer-smoke-bundle-v1";
+const SCHEMA_VERSION: &str = "v1";
+
+/// Build a deterministic [`pb::ExternalContextBundle`] suitable for
+/// Chain 1. Fields are stable across runs so an integration test can
+/// pin assertions against them.
+#[must_use]
+pub fn deterministic_bundle() -> pb::ExternalContextBundle {
+    pb::ExternalContextBundle {
+        bundle_id: BUNDLE_ID.to_owned(),
+        schema_version: SCHEMA_VERSION.to_owned(),
+        summary: Some(pb::ContextSummary {
+            text: "Deterministic stand-in for a real kernel rehydration bundle. \
+                Used by Epic 12's consumer-smoke harness."
+                .to_owned(),
+            attributes: None,
+        }),
+        items: vec![pb::ContextItem {
+            item_id: "stub-item-1".to_owned(),
+            kind: "note".to_owned(),
+            title: "Stub item".to_owned(),
+            narrative: "This bundle is synthetic. The real consumer would replace it \
+                with a kernel rehydration payload."
+                .to_owned(),
+            attributes: None,
+            reference_ids: vec!["kernel-seam".to_owned()],
+        }],
+        references: vec![pb::ContextReference {
+            reference_id: "kernel-seam".to_owned(),
+            uri: "stub://consumer-smoke/seam".to_owned(),
+            title: "kernel rehydration seam".to_owned(),
+            media_type: "text/plain".to_owned(),
+            attributes: None,
+        }],
+        metadata: None,
+    }
+}
+
+/// Stable identifier for the bundle the harness ships. Tests pin
+/// against it so a future shape change forces an explicit
+/// confirmation.
+#[must_use]
+pub const fn bundle_id() -> &'static str {
+    BUNDLE_ID
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deterministic_bundle_is_deterministic() {
+        let a = deterministic_bundle();
+        let b = deterministic_bundle();
+        assert_eq!(a.bundle_id, b.bundle_id);
+        assert_eq!(a.items.len(), b.items.len());
+        assert_eq!(a.references.len(), b.references.len());
+        assert_eq!(a.bundle_id, BUNDLE_ID);
+    }
+
+    #[test]
+    fn references_carry_a_kernel_seam_label() {
+        let bundle = deterministic_bundle();
+        assert!(bundle
+            .references
+            .iter()
+            .any(|r| r.reference_id == "kernel-seam"));
+    }
+}

--- a/crates/choreo-consumer-smoke/src/chain1.rs
+++ b/crates/choreo-consumer-smoke/src/chain1.rs
@@ -1,0 +1,13 @@
+//! Chain 1 placeholder — the live implementation lands in the
+//! follow-up commit by the agent. The signature is fixed so the
+//! binary + tests can wire against it from the start.
+
+use anyhow::Result;
+
+use crate::{ChainOutcome, Harness, HarnessConfig};
+
+/// To be implemented in the chain-1 commit. See plan in
+/// `docs/backlog.md` Epic 12.
+pub async fn run_chain_1(_h: &mut Harness, _cfg: &HarnessConfig) -> Result<ChainOutcome> {
+    anyhow::bail!("run_chain_1 is not implemented yet (Epic 12 follow-up commit)")
+}

--- a/crates/choreo-consumer-smoke/src/chain1.rs
+++ b/crates/choreo-consumer-smoke/src/chain1.rs
@@ -1,13 +1,375 @@
-//! Chain 1 placeholder — the live implementation lands in the
-//! follow-up commit by the agent. The signature is fixed so the
-//! binary + tests can wire against it from the start.
+//! Chain 1 — "consumer reevaluation" path.
+//!
+//! Drives the choreographer through the public surface a real
+//! consumer would touch:
+//!
+//! 1. Optional: publish a trigger envelope on `choreo.trigger.<specialty>`
+//!    mirroring scenario 4 in the e2e-runner (the current
+//!    implementation does not depend on the trigger path —
+//!    `RunCouncilDecision` is invoked directly — but a trigger publish
+//!    is one of the NATS-coupled assertions).
+//! 2. Pre-subscribe to `choreo.deliberation.completed` so the harness
+//!    can observe causal propagation when NATS is wired.
+//! 3. Call `RunCouncilDecision` in Warn mode with the deterministic
+//!    bundle and a synthetic causal pair.
+//! 4. Record assertions on the typed response + the bus envelope.
+//!
+//! The chain reports `Skipped { reason }` (never silent) for every
+//! assertion that depends on a NATS connection when `nats: None`.
+
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
+use choreo_proto::v1 as pb;
+use choreo_proto::v1::run_council_decision_request::Selector;
+use futures::StreamExt;
+use tracing::{debug, info};
 
-use crate::{ChainOutcome, Harness, HarnessConfig};
+use crate::bundle::deterministic_bundle;
+use crate::outcome::{AssertionRecord, BusEnvelopeRecord, ChainOutcome};
+use crate::{Harness, HarnessConfig};
 
-/// To be implemented in the chain-1 commit. See plan in
-/// `docs/backlog.md` Epic 12.
-pub async fn run_chain_1(_h: &mut Harness, _cfg: &HarnessConfig) -> Result<ChainOutcome> {
-    anyhow::bail!("run_chain_1 is not implemented yet (Epic 12 follow-up commit)")
+const DELIBERATION_COMPLETED_SUBJECT: &str = "choreo.deliberation.completed";
+const BUS_WAIT_BUDGET: Duration = Duration::from_secs(5);
+
+/// Run Chain 1 against a connected [`Harness`]. Always returns a
+/// [`ChainOutcome`] (gRPC errors land as `Failed` assertions, never
+/// as `Err`) — the binary needs to print a table regardless.
+#[allow(clippy::too_many_lines)] // a single chain run linearises 6 assertions + the bus wait; splitting fragments the causal flow
+pub async fn run_chain_1(h: &mut Harness, cfg: &HarnessConfig) -> Result<ChainOutcome> {
+    let start = Instant::now();
+    let mut assertions: Vec<AssertionRecord> = Vec::new();
+    let mut bus_envelopes: Vec<BusEnvelopeRecord> = Vec::new();
+
+    let correlation_id = format!("consumer-smoke-1-{}", uuid::Uuid::new_v4());
+    let causation_id = "consumer-smoke-1-cause".to_owned();
+
+    // 1. Pre-subscribe to deliberation.completed so we don't race
+    //    against the publish that immediately follows
+    //    RunCouncilDecision.
+    let mut subscription = match h.nats.as_ref() {
+        Some(client) => match client.subscribe(DELIBERATION_COMPLETED_SUBJECT).await {
+            Ok(sub) => {
+                debug!(
+                    subject = DELIBERATION_COMPLETED_SUBJECT,
+                    "consumer-smoke chain1: subscribed to deliberation.completed"
+                );
+                if let Err(err) = client.flush().await {
+                    debug!(error = %err, "flush after subscribe failed (non-fatal)");
+                }
+                Some(sub)
+            }
+            Err(err) => {
+                debug!(error = %err, "subscribe failed; bus assertions will downgrade to Failed");
+                None
+            }
+        },
+        None => None,
+    };
+
+    // 2. Optional: publish a trigger envelope. The choreographer does
+    //    NOT read this when we invoke RunCouncilDecision directly, but
+    //    a real consumer's deployment must wire the trigger path, so
+    //    we exercise the publish and (later) match on correlation_id
+    //    of the outbound `deliberation.completed`.
+    if let Some(client) = h.nats.as_ref() {
+        let trigger_subject = format!("choreo.trigger.{}", cfg.specialty);
+        let payload = serde_json::json!({
+            "event_id": format!("consumer-smoke-1-trigger-{}", uuid::Uuid::new_v4()),
+            "emitted_at": time::OffsetDateTime::now_utc()
+                .format(&time::format_description::well_known::Rfc3339)
+                .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned()),
+            "source": "consumer-smoke",
+            "correlation_id": correlation_id,
+            "causation_id": causation_id,
+            "kind": "alert",
+            "summary": "consumer-smoke chain 1 trigger envelope (informational)",
+            "requested_specialties": [cfg.specialty],
+        });
+        if let Err(err) = client
+            .publish(
+                trigger_subject.clone(),
+                serde_json::to_vec(&payload).unwrap_or_default().into(),
+            )
+            .await
+        {
+            debug!(error = %err, subject = %trigger_subject, "trigger publish failed (non-fatal for chain1)");
+        }
+    }
+
+    // 3. Invoke RunCouncilDecision directly. This is the call a real
+    //    consumer makes after rehydrating a bundle.
+    let request = pb::RunCouncilDecisionRequest {
+        contract_id: cfg.contract_id.clone(),
+        external_context: Some(deterministic_bundle()),
+        validation_mode: pb::ValidationMode::Warn as i32,
+        metadata: Some(pb::TaskMetadata {
+            source_event_id: String::new(),
+            causation_id: causation_id.clone(),
+            correlation_id: correlation_id.clone(),
+            council_contract_id: String::new(),
+            output_contract_id: cfg.contract_id.clone(),
+            execution_profile: None,
+        }),
+        description: "consumer-smoke chain 1 reevaluation".to_owned(),
+        selector: Some(Selector::Specialty(cfg.specialty.clone())),
+    };
+
+    let rpc_start = Instant::now();
+    let response = h.grpc.run_council_decision(request).await;
+    let rpc_elapsed = rpc_start.elapsed();
+
+    let (task_id, winner_proposal_id, validation_passed) = match response {
+        Ok(resp) => {
+            let resp = resp.into_inner();
+            let task_id = if resp.task_id.is_empty() {
+                None
+            } else {
+                Some(resp.task_id.clone())
+            };
+            let winner_proposal_id = resp
+                .winner
+                .as_ref()
+                .and_then(|d| d.proposal.as_ref())
+                .map(|p| p.proposal_id.clone());
+            let validation_passed = resp.validation.as_ref().map(|v| v.passed);
+
+            // rpc_returned_winner
+            if resp.winner.is_some() {
+                assertions.push(AssertionRecord::passed("rpc_returned_winner", rpc_elapsed));
+            } else {
+                assertions.push(AssertionRecord::failed(
+                    "rpc_returned_winner",
+                    "no winner in response",
+                    rpc_elapsed,
+                ));
+            }
+
+            // validation_summary_present
+            if resp.validation.is_some() {
+                assertions.push(AssertionRecord::passed(
+                    "validation_summary_present",
+                    Duration::ZERO,
+                ));
+            } else {
+                assertions.push(AssertionRecord::failed(
+                    "validation_summary_present",
+                    "no validation summary in response",
+                    Duration::ZERO,
+                ));
+            }
+
+            // candidates_non_empty
+            if resp.candidates.is_empty() {
+                assertions.push(AssertionRecord::failed(
+                    "candidates_non_empty",
+                    "candidates array is empty",
+                    Duration::ZERO,
+                ));
+            } else {
+                assertions.push(AssertionRecord::passed(
+                    "candidates_non_empty",
+                    Duration::ZERO,
+                ));
+            }
+
+            (task_id, winner_proposal_id, validation_passed)
+        }
+        Err(status) => {
+            let detail = format!("{status:?}");
+            assertions.push(AssertionRecord::failed(
+                "rpc_returned_winner",
+                detail.clone(),
+                rpc_elapsed,
+            ));
+            assertions.push(AssertionRecord::failed(
+                "validation_summary_present",
+                detail.clone(),
+                Duration::ZERO,
+            ));
+            assertions.push(AssertionRecord::failed(
+                "candidates_non_empty",
+                detail,
+                Duration::ZERO,
+            ));
+            (None, None, None)
+        }
+    };
+
+    // bundle_seam_documented — always Skipped; this is the documented
+    // gap and the doc points at scenario 7.
+    assertions.push(AssertionRecord::skipped(
+        "bundle_seam_documented",
+        "Epic 11 scenario 7 covers bundle round-trip; out of scope for Epic 12",
+    ));
+
+    // 4. Wait for `deliberation.completed` and assert correlation /
+    //    causation propagation.
+    match subscription.as_mut() {
+        None => {
+            assertions.push(AssertionRecord::skipped(
+                "trigger_envelope_observed",
+                "no NATS configured; bus-coupled assertions disabled",
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "causal_metadata_propagated",
+                "no NATS configured; bus-coupled assertions disabled",
+            ));
+        }
+        Some(sub) => {
+            let wait_start = Instant::now();
+            let mut matched: Option<BusEnvelopeRecord> = None;
+            let deadline = wait_start + BUS_WAIT_BUDGET;
+            while Instant::now() < deadline {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                let next = tokio::time::timeout(remaining, sub.next()).await;
+                let Ok(Some(msg)) = next else {
+                    break;
+                };
+                let value: serde_json::Value = match serde_json::from_slice(&msg.payload) {
+                    Ok(v) => v,
+                    Err(err) => {
+                        debug!(error = %err, "non-JSON deliberation.completed payload; skipping");
+                        continue;
+                    }
+                };
+                let envelope_record = envelope_record_from_value(msg.subject.as_str(), &value);
+                bus_envelopes.push(envelope_record.clone());
+                if envelope_record.correlation_id.as_deref() == Some(correlation_id.as_str()) {
+                    matched = Some(envelope_record);
+                    break;
+                }
+            }
+            let wait_elapsed = wait_start.elapsed();
+            if let Some(env) = matched {
+                assertions.push(AssertionRecord::passed(
+                    "trigger_envelope_observed",
+                    wait_elapsed,
+                ));
+                if env.causation_id.as_deref() == Some(causation_id.as_str()) {
+                    assertions.push(AssertionRecord::passed(
+                        "causal_metadata_propagated",
+                        Duration::ZERO,
+                    ));
+                } else {
+                    assertions.push(AssertionRecord::failed(
+                        "causal_metadata_propagated",
+                        format!(
+                            "expected causation_id={causation_id:?}, got {:?}",
+                            env.causation_id
+                        ),
+                        Duration::ZERO,
+                    ));
+                }
+            } else {
+                assertions.push(AssertionRecord::failed(
+                    "trigger_envelope_observed",
+                    format!(
+                        "no deliberation.completed envelope with correlation_id={correlation_id:?} \
+                         observed within {BUS_WAIT_BUDGET:?}"
+                    ),
+                    wait_elapsed,
+                ));
+                assertions.push(AssertionRecord::failed(
+                    "causal_metadata_propagated",
+                    "no matching envelope observed",
+                    Duration::ZERO,
+                ));
+            }
+        }
+    }
+
+    let outcome = ChainOutcome {
+        chain: "chain1",
+        contract_id: cfg.contract_id.clone(),
+        task_id,
+        winner_proposal_id,
+        validation_passed,
+        assertions,
+        bus_envelopes,
+        total_duration: start.elapsed(),
+    };
+    info!(
+        chain = outcome.chain,
+        passed = outcome.passed(),
+        passed_count = outcome.passed_count(),
+        failed_count = outcome.failed_count(),
+        skipped_count = outcome.skipped_count(),
+        "consumer-smoke chain1 finished"
+    );
+    Ok(outcome)
+}
+
+fn envelope_record_from_value(subject: &str, value: &serde_json::Value) -> BusEnvelopeRecord {
+    let event_id = value
+        .get("event_id")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .to_owned();
+    let correlation_id = value
+        .get("correlation_id")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned);
+    let causation_id = value
+        .get("causation_id")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned);
+    BusEnvelopeRecord {
+        subject: subject.to_owned(),
+        event_id,
+        correlation_id,
+        causation_id,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::outcome::AssertionStatus;
+
+    #[test]
+    fn envelope_record_extracts_fields() {
+        let v = serde_json::json!({
+            "event_id": "e1",
+            "correlation_id": "corr",
+            "causation_id": "cause",
+        });
+        let r = envelope_record_from_value("choreo.deliberation.completed", &v);
+        assert_eq!(r.subject, "choreo.deliberation.completed");
+        assert_eq!(r.event_id, "e1");
+        assert_eq!(r.correlation_id.as_deref(), Some("corr"));
+        assert_eq!(r.causation_id.as_deref(), Some("cause"));
+    }
+
+    #[test]
+    fn envelope_record_tolerates_missing_fields() {
+        let v = serde_json::json!({});
+        let r = envelope_record_from_value("s", &v);
+        assert_eq!(r.event_id, "");
+        assert!(r.correlation_id.is_none());
+        assert!(r.causation_id.is_none());
+    }
+
+    #[test]
+    fn outcome_shape_pins_assertion_names() {
+        // Pin the expected assertion names so a refactor that drops
+        // one is caught at the unit-test layer (the integration test
+        // covers the live behaviour against a fixture).
+        let expected = [
+            "rpc_returned_winner",
+            "validation_summary_present",
+            "candidates_non_empty",
+            "bundle_seam_documented",
+            "trigger_envelope_observed",
+            "causal_metadata_propagated",
+        ];
+        // Spot-check the constructors used by the live path produce
+        // the right status variants.
+        let p = AssertionRecord::passed(expected[0], Duration::from_millis(1));
+        assert!(matches!(p.status, AssertionStatus::Passed));
+        let s = AssertionRecord::skipped(expected[3], "reason");
+        assert!(matches!(s.status, AssertionStatus::Skipped { .. }));
+        let f = AssertionRecord::failed(expected[4], "detail", Duration::ZERO);
+        assert!(matches!(f.status, AssertionStatus::Failed { .. }));
+    }
 }

--- a/crates/choreo-consumer-smoke/src/chain2.rs
+++ b/crates/choreo-consumer-smoke/src/chain2.rs
@@ -1,0 +1,12 @@
+//! Chain 2 placeholder — the live implementation lands in the
+//! follow-up commit by the agent.
+
+use anyhow::Result;
+
+use crate::{ChainOutcome, Harness, HarnessConfig};
+
+/// To be implemented in the chain-2 commit. See plan in
+/// `docs/backlog.md` Epic 12.
+pub async fn run_chain_2(_h: &mut Harness, _cfg: &HarnessConfig) -> Result<ChainOutcome> {
+    anyhow::bail!("run_chain_2 is not implemented yet (Epic 12 follow-up commit)")
+}

--- a/crates/choreo-consumer-smoke/src/chain2.rs
+++ b/crates/choreo-consumer-smoke/src/chain2.rs
@@ -1,12 +1,341 @@
-//! Chain 2 placeholder — the live implementation lands in the
-//! follow-up commit by the agent.
+//! Chain 2 — "consumer handoff report" path.
+//!
+//! Drives the choreographer through the Strict-mode contract path:
+//!
+//! 1. Load the canonical Report JSON Schema (from disk by default, or
+//!    via the `run_chain_2_with_schema` overload that tests use).
+//! 2. Register the corresponding `OutputContract` on the choreographer
+//!    via `RegisterContract`.
+//! 3. Call `RunCouncilDecision` with `validation_mode = STRICT`.
+//! 4. Branch on the response:
+//!    - Ok → schema-validate the winner's content. The positive path
+//!      remains Skipped against a NoopAgent stack (free-form text
+//!      cannot satisfy the schema); a stub-LLM follow-up will exercise it.
+//!    - Err FailedPrecondition mentioning the contract id → the
+//!      rejection path triggered; that IS the assertion this chain
+//!      makes against the current compose stack.
+//!    - Other Err → both report assertions are recorded as Failed.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
+use choreo_proto::v1 as pb;
+use choreo_proto::v1::run_council_decision_request::Selector;
+use jsonschema::JSONSchema;
+use tonic::Code;
+use tracing::info;
 
-use crate::{ChainOutcome, Harness, HarnessConfig};
+use crate::bundle::deterministic_bundle;
+use crate::outcome::{AssertionRecord, ChainOutcome};
+use crate::{Harness, HarnessConfig};
 
-/// To be implemented in the chain-2 commit. See plan in
-/// `docs/backlog.md` Epic 12.
-pub async fn run_chain_2(_h: &mut Harness, _cfg: &HarnessConfig) -> Result<ChainOutcome> {
-    anyhow::bail!("run_chain_2 is not implemented yet (Epic 12 follow-up commit)")
+const DEFAULT_REPORT_SCHEMA_PATH: &str = "api/examples/output-contracts/report.schema.json";
+
+/// Read the Report schema from the path given by
+/// `CHOREO_REPORT_SCHEMA_PATH` (falling back to the in-repo default)
+/// and then call [`run_chain_2_with_schema`].
+///
+/// Tests should prefer [`run_chain_2_with_schema`] directly so they
+/// don't have to mutate process env (env mutation leaks across
+/// concurrent tests).
+pub async fn run_chain_2(h: &mut Harness, cfg: &HarnessConfig) -> Result<ChainOutcome> {
+    let path = std::env::var("CHOREO_REPORT_SCHEMA_PATH")
+        .unwrap_or_else(|_| DEFAULT_REPORT_SCHEMA_PATH.to_owned());
+    match std::fs::read_to_string(&path) {
+        Ok(schema) => run_chain_2_with_schema(h, cfg, &schema).await,
+        Err(err) => {
+            // The binary still needs a printable outcome — record a
+            // single Failed assertion and a Skipped Pair instead of
+            // bubbling the IO error.
+            let detail = format!("schema not found at {path}: {err}");
+            let assertions = vec![
+                AssertionRecord::failed("report_schema_registered", detail, Duration::ZERO),
+                AssertionRecord::skipped(
+                    "report_contract_rejects_freeform_text",
+                    "schema-registration step failed; downstream assertions did not run",
+                ),
+                AssertionRecord::skipped(
+                    "report_payload_validates",
+                    "schema-registration step failed; downstream assertions did not run",
+                ),
+            ];
+            Ok(ChainOutcome {
+                chain: "chain2",
+                contract_id: cfg.contract_id.clone(),
+                task_id: None,
+                winner_proposal_id: None,
+                validation_passed: None,
+                assertions,
+                bus_envelopes: vec![],
+                total_duration: Duration::ZERO,
+            })
+        }
+    }
+}
+
+/// Test-facing overload that takes the Report schema directly. Avoids
+/// the process-env mutation that the file-loading wrapper does, so
+/// tests can run concurrently without serialising on a shared lock.
+#[allow(clippy::too_many_lines)] // a single chain run linearises register → invoke → branch; splitting fragments the flow
+pub async fn run_chain_2_with_schema(
+    h: &mut Harness,
+    cfg: &HarnessConfig,
+    schema_json: &str,
+) -> Result<ChainOutcome> {
+    let start = Instant::now();
+    let mut assertions: Vec<AssertionRecord> = Vec::new();
+
+    // 1. Register the contract. The compose stack may have pre-seeded
+    //    it already (via CHOREO_CONTRACT_DIR), in which case the
+    //    server responds with AlreadyExists / FailedPrecondition —
+    //    treat both as "the contract IS registered, move on".
+    let register_start = Instant::now();
+    let register_req = pb::RegisterContractRequest {
+        contract: Some(pb::OutputContract {
+            contract_id: cfg.contract_id.clone(),
+            format: pb::OutputFormat::JsonObject as i32,
+            fields: HashMap::new(),
+            json_schema: schema_json.to_owned(),
+        }),
+    };
+    let register_result = h.grpc.register_contract(register_req).await;
+    let register_elapsed = register_start.elapsed();
+
+    match register_result {
+        Ok(_) => {
+            assertions.push(AssertionRecord::passed(
+                "report_schema_registered",
+                register_elapsed,
+            ));
+        }
+        Err(status)
+            if status.code() == Code::AlreadyExists
+                || status.code() == Code::FailedPrecondition =>
+        {
+            // The server reports the contract already exists. From
+            // the consumer's point of view, the contract IS in the
+            // registry, so the assertion still holds.
+            assertions.push(AssertionRecord::passed(
+                "report_schema_registered",
+                register_elapsed,
+            ));
+        }
+        Err(status) => {
+            assertions.push(AssertionRecord::failed(
+                "report_schema_registered",
+                format!("RegisterContract returned {status:?}"),
+                register_elapsed,
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "report_contract_rejects_freeform_text",
+                "schema-registration step failed; downstream assertions did not run",
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "report_payload_validates",
+                "schema-registration step failed; downstream assertions did not run",
+            ));
+            return Ok(ChainOutcome {
+                chain: "chain2",
+                contract_id: cfg.contract_id.clone(),
+                task_id: None,
+                winner_proposal_id: None,
+                validation_passed: None,
+                assertions,
+                bus_envelopes: vec![],
+                total_duration: start.elapsed(),
+            });
+        }
+    }
+
+    // 2. Run a Strict-mode decision.
+    let rpc_start = Instant::now();
+    let request = pb::RunCouncilDecisionRequest {
+        contract_id: cfg.contract_id.clone(),
+        external_context: Some(deterministic_bundle()),
+        validation_mode: pb::ValidationMode::Strict as i32,
+        metadata: None,
+        description: "consumer-smoke chain 2 handoff report".to_owned(),
+        selector: Some(Selector::Specialty(cfg.specialty.clone())),
+    };
+    let response = h.grpc.run_council_decision(request).await;
+    let rpc_elapsed = rpc_start.elapsed();
+
+    let (task_id, winner_proposal_id, validation_passed) = match response {
+        Ok(resp) => {
+            let resp = resp.into_inner();
+            let task_id = if resp.task_id.is_empty() {
+                None
+            } else {
+                Some(resp.task_id.clone())
+            };
+            let winner_proposal_id = resp
+                .winner
+                .as_ref()
+                .and_then(|d| d.proposal.as_ref())
+                .map(|p| p.proposal_id.clone());
+            let validation_passed = resp.validation.as_ref().map(|v| v.passed);
+
+            // Positive path: the council returned a winner under
+            // Strict mode. That requires structured-JSON output the
+            // schema accepts. Validate it here.
+            let content = resp
+                .winner
+                .as_ref()
+                .and_then(|d| d.proposal.as_ref())
+                .map(|p| p.content.clone())
+                .unwrap_or_default();
+            assertions.push(AssertionRecord::skipped(
+                "report_contract_rejects_freeform_text",
+                "positive path reached; rejection assertion not exercised",
+            ));
+            assertions.push(validate_payload_against_schema(
+                schema_json,
+                &content,
+                rpc_elapsed,
+            ));
+            (task_id, winner_proposal_id, validation_passed)
+        }
+        Err(status)
+            if status.code() == Code::FailedPrecondition
+                && status.message().contains(&cfg.contract_id) =>
+        {
+            // Rejection path: this IS the assertion the chain is
+            // designed to make against the current NoopAgent compose
+            // stack — free-form text cannot satisfy the Report schema.
+            assertions.push(AssertionRecord::passed(
+                "report_contract_rejects_freeform_text",
+                rpc_elapsed,
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "report_payload_validates",
+                "rejection path reached; positive validation requires a structured-JSON agent (stub-LLM not deployed)",
+            ));
+            (None, None, None)
+        }
+        Err(status) => {
+            let detail = format!("{status:?}");
+            assertions.push(AssertionRecord::failed(
+                "report_contract_rejects_freeform_text",
+                detail.clone(),
+                rpc_elapsed,
+            ));
+            assertions.push(AssertionRecord::failed(
+                "report_payload_validates",
+                detail,
+                Duration::ZERO,
+            ));
+            (None, None, None)
+        }
+    };
+
+    let outcome = ChainOutcome {
+        chain: "chain2",
+        contract_id: cfg.contract_id.clone(),
+        task_id,
+        winner_proposal_id,
+        validation_passed,
+        assertions,
+        bus_envelopes: vec![],
+        total_duration: start.elapsed(),
+    };
+    info!(
+        chain = outcome.chain,
+        passed = outcome.passed(),
+        passed_count = outcome.passed_count(),
+        failed_count = outcome.failed_count(),
+        skipped_count = outcome.skipped_count(),
+        "consumer-smoke chain2 finished"
+    );
+    Ok(outcome)
+}
+
+/// Validate `content` (a JSON string) against `schema_json` and
+/// produce the `report_payload_validates` assertion.
+///
+/// Implementation note: `JSONSchema::compile` borrows from its input
+/// `serde_json::Value`, so this function owns the schema value and
+/// the payload value locally and runs the compile+validate in one
+/// scope; that keeps the API of this helper simple (just `&str` in,
+/// `AssertionRecord` out) at the cost of a slightly nested control
+/// flow.
+fn validate_payload_against_schema(
+    schema_json: &str,
+    content: &str,
+    duration: Duration,
+) -> AssertionRecord {
+    let schema_value: serde_json::Value = match serde_json::from_str(schema_json) {
+        Ok(v) => v,
+        Err(err) => {
+            return AssertionRecord::failed(
+                "report_payload_validates",
+                format!("invalid schema JSON: {err}"),
+                duration,
+            );
+        }
+    };
+    let payload: serde_json::Value = match serde_json::from_str(content) {
+        Ok(v) => v,
+        Err(err) => {
+            return AssertionRecord::failed(
+                "report_payload_validates",
+                format!("winner content is not JSON: {err}"),
+                duration,
+            );
+        }
+    };
+    match JSONSchema::compile(&schema_value) {
+        Err(err) => AssertionRecord::failed(
+            "report_payload_validates",
+            format!("could not compile schema: {err}"),
+            duration,
+        ),
+        Ok(compiled) => {
+            if compiled.is_valid(&payload) {
+                AssertionRecord::passed("report_payload_validates", duration)
+            } else {
+                let errs: Vec<String> = compiled
+                    .validate(&payload)
+                    .err()
+                    .into_iter()
+                    .flat_map(|it| it.map(|e| format!("{e}")))
+                    .collect();
+                AssertionRecord::failed(
+                    "report_payload_validates",
+                    format!("schema mismatch: {}", errs.join("; ")),
+                    duration,
+                )
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TINY_SCHEMA: &str = r#"{
+        "type": "object",
+        "required": ["id"],
+        "properties": { "id": { "type": "string" } },
+        "additionalProperties": false
+    }"#;
+
+    #[test]
+    fn payload_validation_passes_on_match() {
+        let r = validate_payload_against_schema(TINY_SCHEMA, r#"{"id":"x"}"#, Duration::ZERO);
+        assert!(r.is_passed(), "expected pass, got {:?}", r.status);
+    }
+
+    #[test]
+    fn payload_validation_fails_on_mismatch() {
+        let r = validate_payload_against_schema(TINY_SCHEMA, r#"{"id":42}"#, Duration::ZERO);
+        assert!(r.is_failed());
+    }
+
+    #[test]
+    fn payload_validation_fails_on_non_json_content() {
+        let r = validate_payload_against_schema(TINY_SCHEMA, "not json", Duration::ZERO);
+        assert!(r.is_failed());
+    }
 }

--- a/crates/choreo-consumer-smoke/src/harness.rs
+++ b/crates/choreo-consumer-smoke/src/harness.rs
@@ -1,0 +1,97 @@
+//! [`Harness`] — the connected dependencies a chain needs:
+//! a `tonic::Channel` toward the Choreographer, and (optionally) an
+//! `async_nats::Client` toward the choreographer's own bus.
+//!
+//! `nats_url` is intentionally `Option`. When omitted the chains
+//! still run and the NATS-coupled assertions are recorded as
+//! [`AssertionStatus::Skipped`] with an explicit reason — never
+//! silently elided.
+
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
+use tonic::transport::{Channel, Endpoint};
+use tracing::{info, warn};
+
+#[derive(Debug, Clone)]
+pub struct HarnessConfig {
+    pub endpoint: String,
+    pub nats_url: Option<String>,
+    pub specialty: String,
+    pub contract_id: String,
+    pub connect_budget: Duration,
+}
+
+impl Default for HarnessConfig {
+    fn default() -> Self {
+        Self {
+            endpoint: "http://localhost:50055".to_owned(),
+            nats_url: None,
+            specialty: "triage".to_owned(),
+            contract_id: "consumer-smoke-report-v1".to_owned(),
+            connect_budget: Duration::from_secs(30),
+        }
+    }
+}
+
+pub struct Harness {
+    pub grpc: ChoreographerServiceClient<Channel>,
+    pub nats: Option<async_nats::Client>,
+}
+
+impl Harness {
+    /// Connect to the gRPC endpoint (retrying until the budget is
+    /// exhausted) and, when configured, to NATS. NATS connect
+    /// failures are NOT fatal — they downgrade the eventual
+    /// NATS-coupled assertions to `Skipped` so a partial deploy
+    /// still reports useful signal.
+    pub async fn connect(cfg: &HarnessConfig) -> Result<Self> {
+        let grpc = connect_with_retry(&cfg.endpoint, cfg.connect_budget).await?;
+        let nats = match cfg.nats_url.as_deref() {
+            None => None,
+            Some(url) => match async_nats::connect(url).await {
+                Ok(client) => {
+                    info!(nats_url = url, "consumer-smoke connected to NATS");
+                    Some(client)
+                }
+                Err(err) => {
+                    warn!(
+                        nats_url = url,
+                        error = %err,
+                        "consumer-smoke could not connect to NATS; bus assertions will be Skipped"
+                    );
+                    None
+                }
+            },
+        };
+        Ok(Self { grpc, nats })
+    }
+}
+
+async fn connect_with_retry(
+    endpoint: &str,
+    budget: Duration,
+) -> Result<ChoreographerServiceClient<Channel>> {
+    let deadline = std::time::Instant::now() + budget;
+    let parsed: Endpoint = endpoint
+        .parse()
+        .with_context(|| format!("invalid gRPC endpoint: {endpoint}"))?;
+    let mut last_err: Option<tonic::transport::Error> = None;
+    while std::time::Instant::now() < deadline {
+        match ChoreographerServiceClient::connect(parsed.clone()).await {
+            Ok(client) => {
+                info!(endpoint, "consumer-smoke connected to choreographer gRPC");
+                return Ok(client);
+            }
+            Err(err) => {
+                warn!(endpoint, error = %err, "gRPC not ready; will retry");
+                last_err = Some(err);
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+        }
+    }
+    Err(anyhow!(
+        "could not connect to {endpoint} within {budget:?}: {last_err:?}"
+    ))
+}

--- a/crates/choreo-consumer-smoke/src/harness.rs
+++ b/crates/choreo-consumer-smoke/src/harness.rs
@@ -67,6 +67,18 @@ impl Harness {
         };
         Ok(Self { grpc, nats })
     }
+
+    /// Build a [`Harness`] from already-constructed parts. Used by the
+    /// in-process integration tests that share a `tonic::Channel` from
+    /// `GrpcFixture` (the retry loop in [`Harness::connect`] only
+    /// makes sense against a real listener).
+    #[must_use]
+    pub fn from_parts(channel: Channel, nats: Option<async_nats::Client>) -> Self {
+        Self {
+            grpc: ChoreographerServiceClient::new(channel),
+            nats,
+        }
+    }
 }
 
 async fn connect_with_retry(

--- a/crates/choreo-consumer-smoke/src/lib.rs
+++ b/crates/choreo-consumer-smoke/src/lib.rs
@@ -1,0 +1,34 @@
+//! Generic consumer-smoke harness for the Choreographer's public
+//! surface (Epic 12).
+//!
+//! Two chains live here. Both drive the choreographer through its
+//! supported APIs (`tonic` gRPC client + `async-nats` core publisher
+//! and subscriber) and report a typed [`ChainOutcome`] so callers can
+//! assert against structured fields rather than parse strings.
+//!
+//! - [`chain1`] — trigger event → (kernel bundle, simulated) →
+//!   `RunCouncilDecision` reevaluation → validated remedy proposal
+//!   OR escalation decision (in `Warn` mode, an unsatisfied contract
+//!   still surfaces a top-ranked candidate with `passed = false` —
+//!   that IS the escalation signal a consumer would consume).
+//!
+//! - [`chain2`] — register the canonical Report `OutputContract`
+//!   (the JSON Schema lives at
+//!   `api/examples/output-contracts/report.schema.json`),
+//!   run a Strict deliberation, assert the rejection path against
+//!   the compose stack's `NoopAgent` (the positive path remains
+//!   `Skipped` until a stub-LLM that emits structured JSON ships).
+//!
+//! The crate is also a thin binary (`bin/choreo-consumer-smoke`)
+//! that a consumer can run against a live cluster.
+
+pub mod bundle;
+pub mod chain1;
+pub mod chain2;
+pub mod harness;
+pub mod outcome;
+
+pub use chain1::run_chain_1;
+pub use chain2::run_chain_2;
+pub use harness::{Harness, HarnessConfig};
+pub use outcome::{AssertionRecord, AssertionStatus, BusEnvelopeRecord, ChainOutcome};

--- a/crates/choreo-consumer-smoke/src/lib.rs
+++ b/crates/choreo-consumer-smoke/src/lib.rs
@@ -29,6 +29,6 @@ pub mod harness;
 pub mod outcome;
 
 pub use chain1::run_chain_1;
-pub use chain2::run_chain_2;
+pub use chain2::{run_chain_2, run_chain_2_with_schema};
 pub use harness::{Harness, HarnessConfig};
 pub use outcome::{AssertionRecord, AssertionStatus, BusEnvelopeRecord, ChainOutcome};

--- a/crates/choreo-consumer-smoke/src/main.rs
+++ b/crates/choreo-consumer-smoke/src/main.rs
@@ -1,0 +1,6 @@
+//! Placeholder binary — replaced in the follow-up commit.
+
+fn main() {
+    eprintln!("choreo-consumer-smoke: binary stub (Epic 12 in flight)");
+    std::process::exit(2);
+}

--- a/crates/choreo-consumer-smoke/src/main.rs
+++ b/crates/choreo-consumer-smoke/src/main.rs
@@ -1,6 +1,191 @@
-//! Placeholder binary — replaced in the follow-up commit.
+//! `choreo-consumer-smoke` binary.
+//!
+//! A CLI a consumer can point at a live choreographer cluster to
+//! validate the public surface end-to-end. Runs Chain 1 and / or
+//! Chain 2, prints a per-assertion table, and exits with:
+//!
+//! - `0` — every selected chain `passed()` (at least one assertion
+//!   Passed and no Failed).
+//! - `1` — at least one chain has a Failed assertion.
+//! - `2` — infrastructure error (could not connect to the gRPC
+//!   endpoint within the budget, for example).
+//!
+//! See `docs/operations/consumer-smoke.md` for the operational doc.
 
-fn main() {
-    eprintln!("choreo-consumer-smoke: binary stub (Epic 12 in flight)");
-    std::process::exit(2);
+use std::time::Duration;
+
+use choreo_consumer_smoke::outcome::AssertionStatus;
+use choreo_consumer_smoke::{run_chain_1, run_chain_2, ChainOutcome, Harness, HarnessConfig};
+use clap::{Parser, ValueEnum};
+use tracing_subscriber::EnvFilter;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "choreo-consumer-smoke",
+    about = "Drive the Choreographer's public surface as a generic consumer would."
+)]
+struct Args {
+    #[arg(
+        long,
+        env = "CHOREOGRAPHER_ENDPOINT",
+        default_value = "http://localhost:50055"
+    )]
+    endpoint: String,
+    #[arg(long, env = "CHOREO_NATS_URL")]
+    nats_url: Option<String>,
+    #[arg(long, default_value = "triage")]
+    specialty: String,
+    #[arg(long, default_value = "consumer-smoke-report-v1")]
+    contract_id: String,
+    #[arg(long, value_enum, default_value_t = ChainSelector::All)]
+    chain: ChainSelector,
+    #[arg(long, default_value_t = 30)]
+    connect_budget_secs: u64,
+}
+
+#[derive(ValueEnum, Clone, Debug, PartialEq, Eq)]
+enum ChainSelector {
+    One,
+    Two,
+    All,
+}
+
+#[tokio::main]
+async fn main() {
+    let exit = run().await;
+    std::process::exit(exit);
+}
+
+async fn run() -> i32 {
+    // `tracing-subscriber` honours `RUST_LOG`; fall back to `info` so
+    // the CLI is useful out of the box.
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_target(false)
+        .init();
+
+    let args = Args::parse();
+    let cfg = HarnessConfig {
+        endpoint: args.endpoint.clone(),
+        nats_url: args.nats_url.clone(),
+        specialty: args.specialty.clone(),
+        contract_id: args.contract_id.clone(),
+        connect_budget: Duration::from_secs(args.connect_budget_secs),
+    };
+
+    let mut harness = match Harness::connect(&cfg).await {
+        Ok(h) => h,
+        Err(err) => {
+            eprintln!("error: could not connect to choreographer: {err:#}");
+            return 2;
+        }
+    };
+
+    let mut outcomes: Vec<ChainOutcome> = Vec::new();
+    if args.chain == ChainSelector::One || args.chain == ChainSelector::All {
+        match run_chain_1(&mut harness, &cfg).await {
+            Ok(o) => outcomes.push(o),
+            Err(err) => {
+                eprintln!("error: chain1 failed to run: {err:#}");
+                return 2;
+            }
+        }
+    }
+    if args.chain == ChainSelector::Two || args.chain == ChainSelector::All {
+        match run_chain_2(&mut harness, &cfg).await {
+            Ok(o) => outcomes.push(o),
+            Err(err) => {
+                eprintln!("error: chain2 failed to run: {err:#}");
+                return 2;
+            }
+        }
+    }
+
+    print_table(&outcomes);
+    print_summary(&outcomes);
+
+    i32::from(outcomes.iter().any(|o| o.failed_count() > 0))
+}
+
+fn print_table(outcomes: &[ChainOutcome]) {
+    // Hand-rolled 4-column table. `tabled` isn't in the workspace and
+    // the per-line shape is regular enough that adding it for cosmetics
+    // would be gold-plating.
+    let col1 = outcomes
+        .iter()
+        .flat_map(|o| o.assertions.iter().map(|_| o.chain))
+        .map(str::len)
+        .max()
+        .unwrap_or(6)
+        .max(5);
+    let col2 = outcomes
+        .iter()
+        .flat_map(|o| o.assertions.iter().map(|a| a.name))
+        .map(str::len)
+        .max()
+        .unwrap_or(8)
+        .max(9);
+
+    for outcome in outcomes {
+        for assertion in &outcome.assertions {
+            let (verdict, detail) = match &assertion.status {
+                AssertionStatus::Passed => ("PASS", String::new()),
+                AssertionStatus::Skipped { reason } => ("SKIP", reason.clone()),
+                AssertionStatus::Failed { detail } => ("FAIL", detail.clone()),
+            };
+            let elapsed_ms = duration_ms(assertion.duration);
+            println!(
+                "{chain:<col1$}  {name:<col2$}  {verdict}  {elapsed_ms:>4}ms  {detail}",
+                chain = outcome.chain,
+                name = assertion.name,
+                col1 = col1,
+                col2 = col2,
+            );
+        }
+    }
+}
+
+fn print_summary(outcomes: &[ChainOutcome]) {
+    println!();
+    for outcome in outcomes {
+        let label = if outcome.passed() { "PASS" } else { "FAIL" };
+        let total = outcome.assertions.len();
+        println!(
+            "Summary: {chain} {label} ({p}/{t} passed, {s} skipped, {f} failed)",
+            chain = outcome.chain,
+            p = outcome.passed_count(),
+            t = total,
+            s = outcome.skipped_count(),
+            f = outcome.failed_count(),
+        );
+    }
+}
+
+fn duration_ms(d: Duration) -> u128 {
+    d.as_millis()
+}
+
+/// Re-exported so `clap` derives can be unit-tested if a future change
+/// adds option validation logic.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn args_parse_defaults() {
+        let args = Args::try_parse_from(["choreo-consumer-smoke"]).unwrap();
+        assert_eq!(args.endpoint, "http://localhost:50055");
+        assert_eq!(args.specialty, "triage");
+        assert_eq!(args.contract_id, "consumer-smoke-report-v1");
+        assert_eq!(args.chain, ChainSelector::All);
+        assert_eq!(args.connect_budget_secs, 30);
+        assert!(args.nats_url.is_none());
+    }
+
+    #[test]
+    fn args_parse_chain_two() {
+        let args = Args::try_parse_from(["choreo-consumer-smoke", "--chain", "two"]).unwrap();
+        assert_eq!(args.chain, ChainSelector::Two);
+    }
 }

--- a/crates/choreo-consumer-smoke/src/outcome.rs
+++ b/crates/choreo-consumer-smoke/src/outcome.rs
@@ -1,0 +1,190 @@
+//! Typed assertion + outcome model for the smoke chains.
+//!
+//! The harness never returns a loose JSON blob. Every chain records
+//! its per-step assertion status in [`ChainOutcome::assertions`] and
+//! every observed bus envelope in [`ChainOutcome::bus_envelopes`];
+//! tests assert on the typed structs directly so a future API change
+//! becomes a compile error, not a brittle string match.
+//!
+//! **A `Skipped` status is not silent.** It always carries a `reason`,
+//! and [`ChainOutcome::passed`] does not count a chain as passing
+//! when every assertion was skipped — at least one assertion must be
+//! `Passed` for the chain to count as exercising anything.
+
+use std::time::Duration;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AssertionStatus {
+    Passed,
+    Skipped { reason: String },
+    Failed { detail: String },
+}
+
+#[derive(Debug, Clone)]
+pub struct AssertionRecord {
+    pub name: &'static str,
+    pub status: AssertionStatus,
+    pub duration: Duration,
+}
+
+impl AssertionRecord {
+    #[must_use]
+    pub fn passed(name: &'static str, duration: Duration) -> Self {
+        Self {
+            name,
+            status: AssertionStatus::Passed,
+            duration,
+        }
+    }
+
+    #[must_use]
+    pub fn skipped(name: &'static str, reason: impl Into<String>) -> Self {
+        Self {
+            name,
+            status: AssertionStatus::Skipped {
+                reason: reason.into(),
+            },
+            duration: Duration::ZERO,
+        }
+    }
+
+    #[must_use]
+    pub fn failed(name: &'static str, detail: impl Into<String>, duration: Duration) -> Self {
+        Self {
+            name,
+            status: AssertionStatus::Failed {
+                detail: detail.into(),
+            },
+            duration,
+        }
+    }
+
+    #[must_use]
+    pub fn is_passed(&self) -> bool {
+        matches!(self.status, AssertionStatus::Passed)
+    }
+
+    #[must_use]
+    pub fn is_failed(&self) -> bool {
+        matches!(self.status, AssertionStatus::Failed { .. })
+    }
+
+    #[must_use]
+    pub fn is_skipped(&self) -> bool {
+        matches!(self.status, AssertionStatus::Skipped { .. })
+    }
+}
+
+/// Snapshot of a bus envelope observed on a subscription during a
+/// chain run. Captures only the fields the harness asserts on.
+#[derive(Debug, Clone)]
+pub struct BusEnvelopeRecord {
+    pub subject: String,
+    pub event_id: String,
+    pub correlation_id: Option<String>,
+    pub causation_id: Option<String>,
+}
+
+/// Aggregate outcome of a single chain run. Carries everything a
+/// caller needs to decide pass/fail without parsing strings.
+#[derive(Debug, Clone)]
+pub struct ChainOutcome {
+    pub chain: &'static str,
+    pub contract_id: String,
+    pub task_id: Option<String>,
+    pub winner_proposal_id: Option<String>,
+    /// `Some(true)` — the winning proposal satisfied every validator.
+    /// `Some(false)` — Warn mode surfaced a top-ranked candidate that
+    ///                 did not satisfy the contract (escalation).
+    /// `None` — the chain never reached a deliberation result (e.g.
+    ///          the gRPC call errored before the council ran).
+    pub validation_passed: Option<bool>,
+    pub assertions: Vec<AssertionRecord>,
+    pub bus_envelopes: Vec<BusEnvelopeRecord>,
+    pub total_duration: Duration,
+}
+
+impl ChainOutcome {
+    #[must_use]
+    pub fn passed(&self) -> bool {
+        !self.assertions.iter().any(AssertionRecord::is_failed)
+            && self.assertions.iter().any(AssertionRecord::is_passed)
+    }
+
+    #[must_use]
+    pub fn failed_count(&self) -> usize {
+        self.assertions.iter().filter(|a| a.is_failed()).count()
+    }
+
+    #[must_use]
+    pub fn passed_count(&self) -> usize {
+        self.assertions.iter().filter(|a| a.is_passed()).count()
+    }
+
+    #[must_use]
+    pub fn skipped_count(&self) -> usize {
+        self.assertions.iter().filter(|a| a.is_skipped()).count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn passed_requires_at_least_one_passed_assertion() {
+        let outcome = ChainOutcome {
+            chain: "test",
+            contract_id: "c".to_owned(),
+            task_id: None,
+            winner_proposal_id: None,
+            validation_passed: None,
+            assertions: vec![AssertionRecord::skipped("only_skip", "reason")],
+            bus_envelopes: vec![],
+            total_duration: Duration::ZERO,
+        };
+        assert!(
+            !outcome.passed(),
+            "an all-skipped outcome must not be reported as passing"
+        );
+    }
+
+    #[test]
+    fn passed_with_passing_assertion_and_skip_is_pass() {
+        let outcome = ChainOutcome {
+            chain: "test",
+            contract_id: "c".to_owned(),
+            task_id: None,
+            winner_proposal_id: None,
+            validation_passed: Some(true),
+            assertions: vec![
+                AssertionRecord::passed("a", Duration::from_millis(1)),
+                AssertionRecord::skipped("b", "no nats"),
+            ],
+            bus_envelopes: vec![],
+            total_duration: Duration::from_millis(1),
+        };
+        assert!(outcome.passed());
+        assert_eq!(outcome.passed_count(), 1);
+        assert_eq!(outcome.skipped_count(), 1);
+    }
+
+    #[test]
+    fn one_failure_taints_the_outcome() {
+        let outcome = ChainOutcome {
+            chain: "test",
+            contract_id: "c".to_owned(),
+            task_id: None,
+            winner_proposal_id: None,
+            validation_passed: None,
+            assertions: vec![
+                AssertionRecord::passed("a", Duration::from_millis(1)),
+                AssertionRecord::failed("b", "boom", Duration::from_millis(1)),
+            ],
+            bus_envelopes: vec![],
+            total_duration: Duration::from_millis(2),
+        };
+        assert!(!outcome.passed());
+        assert_eq!(outcome.failed_count(), 1);
+    }
+}

--- a/crates/choreo-consumer-smoke/tests/chain1_warn_against_fixture.rs
+++ b/crates/choreo-consumer-smoke/tests/chain1_warn_against_fixture.rs
@@ -1,0 +1,153 @@
+//! Integration test: Chain 1 against the in-process `GrpcFixture`.
+//!
+//! Seeds a noop agent + a permissive Warn-mode-friendly contract,
+//! builds a `Harness` directly from the fixture's `tonic::Channel`
+//! (so the test doesn't pay the `Harness::connect` retry budget
+//! against a server that's already accepting), and asserts:
+//!
+//! - `outcome.passed()` — the chain reports a green run.
+//! - At least the 3 expected RPC-shape assertions Passed.
+//! - The 3 NATS-coupled / bundle-seam assertions Skipped.
+//! - No assertion Failed.
+//!
+//! The NoopAgent emits free-form text. `JsonObjectOutputValidator`
+//! always fails on that, so the council's deliberation completes
+//! with a winner whose validation passed=false (the Warn-mode
+//! escalation signal). The chain treats that as a pass — it asserted
+//! that the response carried a winner + a validation summary +
+//! candidates, which is the consumer-visible contract.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use choreo_consumer_smoke::{run_chain_1, Harness, HarnessConfig};
+use choreo_core::entities::Council;
+use choreo_core::ports::AgentDescriptor;
+use choreo_core::value_objects::{
+    AgentId, AgentKind, Attributes, CouncilId, OutputContract, OutputFormat, Specialty,
+};
+use choreo_tests_integration::grpc_fixture::GrpcFixture;
+use time::OffsetDateTime;
+
+const SPECIALTY: &str = "triage";
+const CONTRACT_ID: &str = "consumer-smoke-chain1";
+
+async fn seed_agent(fixture: &GrpcFixture) -> AgentId {
+    let id = AgentId::new("agent-chain1").unwrap();
+    let descriptor = AgentDescriptor {
+        id: id.clone(),
+        specialty: Specialty::new(SPECIALTY).unwrap(),
+        kind: AgentKind::new("noop").unwrap(),
+        attributes: Attributes::empty(),
+    };
+    let factory = Arc::new(choreo_adapters::agents::DispatchingAgentFactory::new());
+    let usecase = choreo_app::usecases::RegisterAgentUseCase::new(factory, fixture.agents.clone());
+    usecase
+        .execute(descriptor)
+        .await
+        .expect("register agent should succeed");
+    id
+}
+
+async fn seed_council(fixture: &GrpcFixture, agent_id: AgentId) {
+    let council = Council::new(
+        CouncilId::new("council-chain1").unwrap(),
+        Specialty::new(SPECIALTY).unwrap(),
+        vec![agent_id],
+        OffsetDateTime::now_utc(),
+    )
+    .expect("council construction should succeed");
+    fixture
+        .councils
+        .register(council)
+        .await
+        .expect("council registration should succeed");
+}
+
+async fn seed_contract(fixture: &GrpcFixture) {
+    // Permissive JsonObject contract. The NoopAgent's free-form text
+    // won't satisfy it, but Warn mode still surfaces a winner with
+    // `validation.passed = false` — exactly the consumer-facing
+    // signal Chain 1 asserts on.
+    let contract = OutputContract::new(CONTRACT_ID, OutputFormat::JsonObject, BTreeMap::new())
+        .expect("contract construction should succeed");
+    fixture
+        .contracts
+        .register(contract)
+        .await
+        .expect("contract registration should succeed");
+}
+
+#[tokio::test]
+async fn chain1_warn_against_fixture_passes_without_nats() {
+    let fixture = GrpcFixture::start().await;
+    let agent_id = seed_agent(&fixture).await;
+    seed_council(&fixture, agent_id).await;
+    seed_contract(&fixture).await;
+
+    let mut harness = Harness::from_parts(fixture.channel.clone(), None);
+    let cfg = HarnessConfig {
+        endpoint: "in-process".to_owned(),
+        nats_url: None,
+        specialty: SPECIALTY.to_owned(),
+        contract_id: CONTRACT_ID.to_owned(),
+        connect_budget: std::time::Duration::from_secs(1),
+    };
+
+    let outcome = run_chain_1(&mut harness, &cfg)
+        .await
+        .expect("run_chain_1 should not error");
+
+    assert!(
+        outcome.passed(),
+        "chain1 should pass; got assertions={:#?}",
+        outcome.assertions
+    );
+    assert_eq!(
+        outcome.failed_count(),
+        0,
+        "no assertion should fail; got {:#?}",
+        outcome.assertions
+    );
+    assert!(
+        outcome.passed_count() >= 3,
+        "expected ≥3 Passed (rpc_returned_winner, validation_summary_present, \
+         candidates_non_empty); got passed={} assertions={:#?}",
+        outcome.passed_count(),
+        outcome.assertions
+    );
+    assert!(
+        outcome.skipped_count() >= 3,
+        "expected ≥3 Skipped (bundle_seam_documented, trigger_envelope_observed, \
+         causal_metadata_propagated); got skipped={} assertions={:#?}",
+        outcome.skipped_count(),
+        outcome.assertions
+    );
+
+    // Pin the specific assertion names so a refactor that renames one
+    // is caught here.
+    let names: Vec<&str> = outcome.assertions.iter().map(|a| a.name).collect();
+    for required in [
+        "rpc_returned_winner",
+        "validation_summary_present",
+        "candidates_non_empty",
+        "bundle_seam_documented",
+        "trigger_envelope_observed",
+        "causal_metadata_propagated",
+    ] {
+        assert!(
+            names.contains(&required),
+            "missing assertion {required:?}; got {names:?}"
+        );
+    }
+
+    // The chain should record the task id from the Warn response.
+    assert!(
+        outcome.task_id.is_some(),
+        "task_id should be populated by Warn mode"
+    );
+    // validation_passed should be Some(false) — the NoopAgent's
+    // free-form text fails the JsonObject contract, which is the
+    // escalation signal Warn mode surfaces.
+    assert_eq!(outcome.validation_passed, Some(false));
+}

--- a/crates/choreo-consumer-smoke/tests/chain2_strict_rejection_against_fixture.rs
+++ b/crates/choreo-consumer-smoke/tests/chain2_strict_rejection_against_fixture.rs
@@ -1,0 +1,126 @@
+//! Integration test: Chain 2 against the in-process `GrpcFixture`.
+//!
+//! Drives Strict mode against the canonical Report schema. The
+//! NoopAgent emits free-form text, so the `JsonSchemaValidator` (and
+//! the always-on `JsonObjectOutputValidator`) reject every candidate
+//! and the use case returns `NoValidProposal`, which the gRPC mapper
+//! surfaces as `Code::FailedPrecondition` whose message mentions the
+//! contract id.
+//!
+//! That IS the assertion this chain makes against today's stack:
+//! `report_contract_rejects_freeform_text` → Passed, with
+//! `report_payload_validates` → Skipped (positive path needs a
+//! stub-LLM that emits structured JSON).
+//!
+//! Uses `run_chain_2_with_schema` so the test doesn't have to mutate
+//! `CHOREO_REPORT_SCHEMA_PATH` (env mutation leaks across the
+//! concurrent test runner).
+
+use std::sync::Arc;
+
+use choreo_consumer_smoke::outcome::AssertionStatus;
+use choreo_consumer_smoke::{run_chain_2_with_schema, Harness, HarnessConfig};
+use choreo_core::entities::Council;
+use choreo_core::ports::AgentDescriptor;
+use choreo_core::value_objects::{AgentId, AgentKind, Attributes, CouncilId, Specialty};
+use choreo_tests_integration::grpc_fixture::GrpcFixture;
+use time::OffsetDateTime;
+
+const SPECIALTY: &str = "triage";
+const CONTRACT_ID: &str = "consumer-smoke-chain2";
+const REPORT_SCHEMA_PATH: &str = "../../api/examples/output-contracts/report.schema.json";
+
+async fn seed_agent(fixture: &GrpcFixture) -> AgentId {
+    let id = AgentId::new("agent-chain2").unwrap();
+    let descriptor = AgentDescriptor {
+        id: id.clone(),
+        specialty: Specialty::new(SPECIALTY).unwrap(),
+        kind: AgentKind::new("noop").unwrap(),
+        attributes: Attributes::empty(),
+    };
+    let factory = Arc::new(choreo_adapters::agents::DispatchingAgentFactory::new());
+    let usecase = choreo_app::usecases::RegisterAgentUseCase::new(factory, fixture.agents.clone());
+    usecase.execute(descriptor).await.unwrap();
+    id
+}
+
+async fn seed_council(fixture: &GrpcFixture, agent_id: AgentId) {
+    let council = Council::new(
+        CouncilId::new("council-chain2").unwrap(),
+        Specialty::new(SPECIALTY).unwrap(),
+        vec![agent_id],
+        OffsetDateTime::now_utc(),
+    )
+    .unwrap();
+    fixture.councils.register(council).await.unwrap();
+}
+
+fn load_report_schema() -> String {
+    // Tests run from the crate directory; the schema lives at the
+    // repo root.
+    std::fs::read_to_string(REPORT_SCHEMA_PATH).unwrap_or_else(|err| {
+        panic!(
+            "could not read Report schema at {REPORT_SCHEMA_PATH:?} (cwd={}): {err}",
+            std::env::current_dir().unwrap_or_default().display()
+        )
+    })
+}
+
+#[tokio::test]
+async fn chain2_strict_rejection_against_fixture_passes() {
+    let fixture = GrpcFixture::start().await;
+    let agent_id = seed_agent(&fixture).await;
+    seed_council(&fixture, agent_id).await;
+    let schema = load_report_schema();
+
+    let mut harness = Harness::from_parts(fixture.channel.clone(), None);
+    let cfg = HarnessConfig {
+        endpoint: "in-process".to_owned(),
+        nats_url: None,
+        specialty: SPECIALTY.to_owned(),
+        contract_id: CONTRACT_ID.to_owned(),
+        connect_budget: std::time::Duration::from_secs(1),
+    };
+
+    let outcome = run_chain_2_with_schema(&mut harness, &cfg, &schema)
+        .await
+        .expect("run_chain_2_with_schema should not error");
+
+    assert!(
+        outcome.passed(),
+        "chain2 should pass; assertions={:#?}",
+        outcome.assertions
+    );
+    assert_eq!(
+        outcome.failed_count(),
+        0,
+        "no assertion should fail; got {:#?}",
+        outcome.assertions
+    );
+
+    // The rejection-path assertion MUST be Passed and the positive
+    // assertion MUST be Skipped against today's NoopAgent stack.
+    let by_name = |target: &str| {
+        outcome
+            .assertions
+            .iter()
+            .find(|a| a.name == target)
+            .unwrap_or_else(|| panic!("missing assertion {target:?}: {:#?}", outcome.assertions))
+    };
+    assert!(
+        by_name("report_schema_registered").is_passed(),
+        "report_schema_registered should be Passed; got {:?}",
+        by_name("report_schema_registered").status
+    );
+    assert!(
+        by_name("report_contract_rejects_freeform_text").is_passed(),
+        "rejection assertion should be Passed; got {:?}",
+        by_name("report_contract_rejects_freeform_text").status
+    );
+    let validates = by_name("report_payload_validates");
+    assert!(
+        matches!(validates.status, AssertionStatus::Skipped { .. }),
+        "report_payload_validates should be Skipped (no structured-JSON agent in fixture); got {:?}",
+        validates.status
+    );
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -839,31 +839,59 @@ Status of the chain:
 
 ### Epic 12. Consumer integration smoke prerequisites
 
-Status: not started — blocked by Epic 6 (real agent factory composition),
-Epic 9 (dedicated council-decision RPC), Epic 10 (report artifact), and
-Epic 11's follow-ups (scenarios 6/7 + merging the provider-runner
-stack).
+Status: done (2026-05-14).
 
-#### Deliverables
+#### What shipped
 
-A test harness that can later prove:
+A consumer-shaped smoke harness — `crates/choreo-consumer-smoke` —
+that drives the choreographer's public surface (gRPC over `tonic` +
+optional core NATS over `async-nats`) the way a real downstream
+consumer would. Distributed as a library the choreographer's own
+integration tests reuse and a CLI a consumer can point at a live
+cluster.
 
-```text
-<consumer> specialist escalation
-  -> kernel bundle
-    -> choreographer reevaluation
-      -> validated remedy proposal or human-escalation decision
-```
+Two chains:
 
-and:
+- **Chain 1** (Warn-mode reevaluation): trigger-style envelope
+  publish on `choreo.trigger.<specialty>`, `RunCouncilDecision` in
+  Warn mode with a deterministic kernel-rehydration-shaped bundle,
+  then six typed assertions including correlation / causation
+  propagation on the outbound `choreo.deliberation.completed`.
+- **Chain 2** (Strict-mode handoff report): registers the canonical
+  Report `OutputContract`
+  (`api/examples/output-contracts/report.schema.json`), runs Strict
+  mode, asserts the rejection path against the NoopAgent stack
+  (free-form text fails the JSON Schema → `FailedPrecondition`
+  mentioning the contract id).
 
-```text
-<consumer> escalation decision
-  -> choreographer handoff report
-    -> final human escalation
-```
+Deliverables:
 
-This can begin only once the earlier epics are green.
+- New crate `crates/choreo-consumer-smoke` (lib + bin).
+- 11 lib unit tests + 2 binary unit tests + 2 integration tests
+  (`tests/chain1_warn_against_fixture.rs`,
+  `tests/chain2_strict_rejection_against_fixture.rs`) that reuse
+  `choreo_tests_integration::grpc_fixture::GrpcFixture`.
+- `Harness::from_parts(channel, nats)` helper so the integration
+  tests can share the fixture's `tonic::Channel`.
+- Operations doc: `docs/operations/consumer-smoke.md`.
+- `make consumer-smoke` Makefile target.
+
+#### Remaining gaps (out of Epic 12's scope, tracked under Epic 11)
+
+- **Bundle round-trip** (`bundle_seam_documented` Skipped). Owned by
+  Epic 11 scenario 7. Once that lands the assertion flips to Passed.
+- **Chain 2 positive path** (`report_payload_validates` Skipped on
+  today's stack). Needs a stub-LLM provider sidecar that emits JSON
+  satisfying the schema. Tracked under Epic 11's structured-output
+  follow-up.
+- **Provider-runner E2E merged into `make e2e-compose`** so a single
+  command exercises real provider council + real (stub) runtime in
+  one shot — also Epic 11.
+
+#### Relevant code
+
+- [`crates/choreo-consumer-smoke/`](../crates/choreo-consumer-smoke/)
+- [`docs/operations/consumer-smoke.md`](./operations/consumer-smoke.md)
 
 ### Epic 13. MCP stdio adapter
 
@@ -989,7 +1017,13 @@ Exit condition:
 
 - it is reasonable to begin consumer integration work
 
-**Open** — blocked by Milestones B (remaining), C, and D.
+**Cleared 2026-05-14.** Epic 12 done — consumer-smoke harness lives
+at `crates/choreo-consumer-smoke` with two chains, a CLI, and two
+integration tests against the in-process `GrpcFixture`. The
+remaining "open" assertions (`bundle_seam_documented` and Chain 2's
+positive `report_payload_validates`) are intentionally `Skipped`
+with explicit reasons that point at Epic 11's pending scenarios; they
+are not on Epic 12's critical path.
 
 ## Suggested issue breakdown
 

--- a/docs/operations/consumer-smoke.md
+++ b/docs/operations/consumer-smoke.md
@@ -1,0 +1,142 @@
+# Consumer-smoke harness
+
+`choreo-consumer-smoke` is a CLI that drives the Choreographer's
+public surface the way a real downstream consumer would. It does not
+share any in-process types with the choreographer's own runtime — it
+only talks gRPC over `tonic` and (optionally) core NATS over
+`async-nats`. That makes it a faithful smoke test of the integration
+contract a real consumer commits to.
+
+Two chains run, both shipped today:
+
+- **Chain 1** — Warn-mode reevaluation. Mirrors what a consumer
+  triggers after observing an incident or domain event: optionally
+  publish a trigger envelope, invoke `RunCouncilDecision` in Warn
+  mode with a kernel-rehydration-shaped bundle, then assert on the
+  typed response + the outbound `choreo.deliberation.completed`
+  envelope (correlation / causation propagation).
+
+- **Chain 2** — Strict-mode handoff report. Registers the canonical
+  Report `OutputContract` (JSON Schema body bound in
+  `OutputContract.json_schema`), invokes `RunCouncilDecision` in
+  Strict mode, and asserts that the choreographer either accepts a
+  schema-conformant response (positive path) or rejects free-form
+  text with `Code::FailedPrecondition` whose message mentions the
+  contract id (rejection path — the path today's NoopAgent stack
+  reaches).
+
+## Prerequisites
+
+- A running Choreographer (e.g. `make e2e-compose`, or a live
+  cluster you can reach over gRPC).
+- A seeded council under the target specialty (default `triage`)
+  with at least one agent registered. Without a council the gRPC
+  call returns `Code::NotFound` and Chain 1 records every assertion
+  as Failed.
+- For Chain 2: a writable contract registry. The chain calls
+  `RegisterContract` and tolerates `AlreadyExists` /
+  `FailedPrecondition` (already seeded) as a pass — but the registry
+  must accept new contracts when starting from empty.
+
+For the canonical bus subjects (Chain 1's NATS-coupled assertions):
+
+- Trigger: `choreo.trigger.<specialty>`
+- Deliberation completed: `choreo.deliberation.completed`
+
+If `--nats-url` is omitted, those assertions are recorded as
+`Skipped` (never silently dropped) and the rest of the chain still
+runs.
+
+## Invocation
+
+```bash
+cargo run -p choreo-consumer-smoke -- \
+    --endpoint http://localhost:50055 \
+    [--nats-url nats://localhost:4222] \
+    [--chain {one,two,all}] \
+    [--specialty triage] \
+    [--contract-id consumer-smoke-report-v1]
+```
+
+Environment overrides:
+
+- `CHOREOGRAPHER_ENDPOINT` — defaults to `http://localhost:50055`.
+- `CHOREO_NATS_URL` — optional. When set, Chain 1 publishes the
+  trigger envelope and subscribes to `choreo.deliberation.completed`
+  for the correlation/causation assertions.
+- `CHOREO_REPORT_SCHEMA_PATH` — Chain 2 reads the schema from this
+  path. Default `api/examples/output-contracts/report.schema.json`
+  (relative to the binary's cwd).
+- `RUST_LOG` — standard tracing filter. Default `info`.
+
+A `make consumer-smoke` target wraps the same call:
+
+```bash
+make consumer-smoke
+CONSUMER_SMOKE_CHAIN=two CHOREOGRAPHER_ENDPOINT=https://staging:50055 \
+    make consumer-smoke
+```
+
+## What each chain asserts
+
+| Chain | Assertion | Pass when |
+|-------|-----------|-----------|
+| chain1 | `rpc_returned_winner` | `response.winner` is `Some` |
+| chain1 | `validation_summary_present` | `response.validation` is `Some` |
+| chain1 | `candidates_non_empty` | `response.candidates.len() > 0` |
+| chain1 | `bundle_seam_documented` | always `Skipped` — points at Epic 11 scenario 7 (bundle round-trip) |
+| chain1 | `trigger_envelope_observed` | a `choreo.deliberation.completed` envelope with the run's `correlation_id` arrives within 5 s |
+| chain1 | `causal_metadata_propagated` | that envelope's `causation_id` matches the one the harness sent |
+| chain2 | `report_schema_registered` | `RegisterContract` succeeds or the contract already exists |
+| chain2 | `report_contract_rejects_freeform_text` | `RunCouncilDecision` returns `FailedPrecondition` mentioning the contract id |
+| chain2 | `report_payload_validates` | the winner's content satisfies the schema (positive path) |
+
+Each assertion is also typed (`Passed` / `Skipped { reason }` /
+`Failed { detail }`), so callers that embed the library can assert on
+the typed shape without parsing the printed table.
+
+## Known limitations
+
+- **`bundle_seam_documented` is intentionally `Skipped`.** The
+  external context bundle round-trip is owned by Epic 11 scenario 7
+  (still open in `docs/backlog.md`). Once that scenario lands the
+  assertion can be flipped to `Passed`.
+- **Chain 2's positive path needs a structured-JSON agent.** Today's
+  compose stack registers a `NoopAgent` that emits free-form text;
+  the `JsonSchemaValidator` always rejects it. Once a stub-LLM
+  provider sidecar that emits JSON satisfying the schema ships, the
+  rejection assertion will downgrade to `Skipped` and
+  `report_payload_validates` will go `Passed`.
+- The trigger publish in Chain 1 is informational only —
+  `RunCouncilDecision` is invoked directly, so the trigger path does
+  not gate the run. Pinning the trigger-driven path end-to-end is
+  Epic 11's territory.
+
+## Exit codes
+
+- `0` — every selected chain passed (at least one `Passed`
+  assertion, no `Failed`).
+- `1` — at least one chain recorded a `Failed` assertion.
+- `2` — infrastructure error: could not connect to the gRPC endpoint
+  within the configured budget, or a chain runner returned `Err`
+  (typically a panicking dependency).
+
+## The kernel rehydration seam
+
+`choreo_consumer_smoke::bundle::deterministic_bundle()` returns a
+literal `ExternalContextBundle`. A real consumer integration would
+replace it with the result of a kernel rehydration call (Underpass
+KMP, RAG, whatever the consumer wires) before invoking
+`RunCouncilDecision`:
+
+```text
+  let bundle = kernel.rehydrate(...).await?;
+  harness.grpc
+      .run_council_decision(req.with_external_context(bundle))
+      .await?;
+```
+
+Keeping the rehydration adapter out of this crate keeps the smoke
+binary's dependency surface narrow. The chains exercise the
+choreographer's public RPC + bus contract; the kernel boundary is a
+separate integration concern.


### PR DESCRIPTION
## Summary

Closes Epic 12. New `choreo-consumer-smoke` crate (lib + CLI binary) that drives the choreographer's public surface the way a generic consumer would: gRPC + optional NATS, no PIR-shaped vocabulary, no executor coupling.

Two chains:

- **Chain 1 — reevaluation**: trigger envelope → kernel bundle (stubbed, see *Honest scope*) → `RunCouncilDecision` (Warn mode) → asserts winner + validation summary + per-candidate breakdown. Skipped-with-reason for the NATS-coupled assertions when `--nats-url` is omitted.
- **Chain 2 — handoff report**: registers the canonical Report `OutputContract` from `api/examples/output-contracts/report.schema.json`, runs Strict mode, asserts the rejection path against a `NoopAgent`-shaped council (`FailedPrecondition` carrying the contract id). Positive path is Skipped-with-reason until a stub-LLM ships.

## What lands

- **New crate** `crates/choreo-consumer-smoke/` — lib + `bin/choreo-consumer-smoke` + 2 integration tests.
- **Typed outcome model** — `AssertionStatus { Passed, Skipped { reason }, Failed { detail } }`, `AssertionRecord`, `BusEnvelopeRecord`, `ChainOutcome`. `ChainOutcome::passed()` requires at least one `Passed` — an all-`Skipped` run is NOT a pass (silent skips are designed out).
- **CLI** (`clap`-derived) — `--endpoint`, `--nats-url`, `--specialty`, `--contract-id`, `--chain {one,two,all}`, `--connect-budget-secs`. Prints a per-assertion table + summary; exit 0/1/2 (pass / failed assertion / infra error).
- **Integration tests** — reuse `GrpcFixture` from Epic 9 (no env-var globals, parallel-safe). `Harness::from_parts(channel, nats)` added to skip the retry loop in tests.
- **Docs** — `docs/operations/consumer-smoke.md` (prerequisites, invocation, what each chain asserts, known limitations, the kernel-seam doc, exit codes).
- **Backlog flip** — Epic 12 + Milestone E → done.
- **Makefile target** — `make consumer-smoke` runs the CLI against `localhost:50055`.

## Honest scope

Documented gaps (recorded as `Skipped { reason }` in the outcomes, surfaced in the CLI table, and explicit in the docs):

- `bundle_seam_documented` (chain 1) — bundle round-trip assertion depends on Epic 11 scenario 7. The harness *sends* the bundle (the gRPC call carries it; rejection would fail the call) but does not assert it survived to the outbound event.
- `trigger_envelope_observed` / `causal_metadata_propagated` (chain 1) — Skipped when `--nats-url` is omitted.
- `report_payload_validates` (chain 2) — the positive path needs a structured-JSON agent (stub-LLM not deployed in this slice).

## Validation

Inside `podman run underpass-rust:1.90` (matches CI's toolchain pin):

- `cargo fmt --all -- --check` → clean
- `cargo clippy --workspace --all-targets --features choreo-adapters/{agent-anthropic,agent-openai,agent-vllm} -- -D warnings` → clean
- `cargo test --workspace ${PROVIDER_FEATURES}` → **496 passed, 0 failed**

Two `#[allow(clippy::too_many_lines)]` annotations on `run_chain_1` and `run_chain_2_with_schema`, each with a one-line rationale (consistent with PR #60).

🤖 Generated with [Claude Code](https://claude.com/claude-code)