### PR TITLE
docs: prepare publication readiness plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,17 @@ Three planes, three repos:
 
 | Plane | Repo | Brand name | Role |
 |---|---|---|---|
-| Memory + context | [`rehydration-kernel`](https://github.com/underpass-ai/rehydration-kernel) | **Underpass KMP** (Kernel Memory Plane / Kernel Memory Protocol) | Renders LLM-ready context bundles from a typed knowledge graph. |
+| Memory + context | [`rehydration-kernel`](https://github.com/underpass-ai/rehydration-kernel) | **Underpass KMP** (Kernel Memory Plane / Kernel Memory Protocol) | One possible producer of LLM-ready context bundles from a typed knowledge graph. |
 | Coordination | this repo | **Underpass Choreographer** | Composes councils, runs deliberations, validates outputs, hands winners to an executor. |
 | Execution + governed tools | [`underpass-runtime`](https://github.com/underpass-ai/underpass-runtime) | **Underpass Runtime** | Sessions, governed tool invocations, artifacts, policy decisions. |
 
-The choreographer talks to KMP through caller-supplied
-`ExternalContextBundle`s, and to the Runtime through the
-`RuntimeExecutor` adapter. It does **not** embed any product
-vocabulary (no stories, plans, incidents, claims hardcoded) — all that
-is injected via configuration and proto messages.
+Choreographer is agnostic and independently usable. It does not depend
+on KMP, PIR, or any downstream product. It accepts caller-supplied
+`ExternalContextBundle`s from any context source; KMP is one studied
+producer, not a required dependency. Runtime execution is optional via
+the `RuntimeExecutor` adapter. Choreographer does **not** embed any
+product vocabulary (no stories, plans, incidents, claims hardcoded) —
+all that is injected via configuration and proto messages.
 
 ## Start here
 
@@ -122,13 +124,14 @@ gate in this repository):
   serves the full `underpass.choreo.v1` gRPC contract.
 - Implemented RPCs: every RPC in the `underpass.choreo.v1` contract
   is backed by a use case — `Deliberate`, `StreamDeliberation`,
-  `Orchestrate`, `CreateCouncil`, `ListCouncils`, `DeleteCouncil`,
-  `GetDeliberationResult`, `ProcessTriggerEvent`, `GetStatus`,
-  `GetMetrics`, `RegisterAgent`, `UnregisterAgent`. No RPC returns
-  `UNIMPLEMENTED`. Caveats: (a) `RegisterAgent` currently materializes
-  agents with `kind == "noop"`; provider-backed kinds land through
-  richer `AgentFactoryPort` wirings in their respective feature
-  slices. (b) `StreamDeliberation` emits phase transitions + a final
+  `GetDeliberationResult`, `Orchestrate`, `CreateCouncil`,
+  `ListCouncils`, `DeleteCouncil`, `RegisterAgent`,
+  `UnregisterAgent`, `ProcessTriggerEvent`, `RunCouncilDecision`,
+  `RegisterContract`, `ListContracts`, `DeleteContract`, `GetStatus`,
+  and `GetMetrics`. No RPC returns `UNIMPLEMENTED`. Caveats:
+  (a) provider-backed `RegisterAgent` kinds require the matching Cargo
+  feature and boot-time credentials; `noop` is always available.
+  (b) `StreamDeliberation` emits phase transitions + a final
   `DeliberationResult` frame, not per-proposal/critique/revision
   events.
 - Optional NATS messaging: when `CHOREO_NATS_ENABLED=true`, the service
@@ -172,7 +175,7 @@ gate in this repository):
   Startup log emits `agent_kinds=` listing every kind the binary will
   accept on `RegisterAgent`.
 
-**What is *not* wired yet**:
+**Caveats and observability**:
 
 - `StreamDeliberation` streams phase transitions only; per-proposal,
   per-critique, and per-revision streaming arrives in a later slice.

--- a/crates/choreo-mcp/README.md
+++ b/crates/choreo-mcp/README.md
@@ -61,6 +61,10 @@ without an extra round trip.
 | `choreo_register_agent`           | `RegisterAgent`                   | control plane |
 | `choreo_unregister_agent`         | `UnregisterAgent`                 | control plane |
 | `choreo_process_trigger_event`    | `ProcessTriggerEvent`             | event ingest |
+| `choreo_run_council_decision`     | `RunCouncilDecision`              | validated council decision |
+| `choreo_register_contract`        | `RegisterContract`                | contract registry |
+| `choreo_list_contracts`           | `ListContracts`                   | contract registry |
+| `choreo_delete_contract`          | `DeleteContract`                  | contract registry |
 | `choreo_get_status`               | `GetStatus`                       | observability |
 | `choreo_get_metrics`              | `GetMetrics`                      | observability |
 

--- a/crates/choreo-proto/proto/underpass/choreo/v1/choreo.proto
+++ b/crates/choreo-proto/proto/underpass/choreo/v1/choreo.proto
@@ -46,10 +46,10 @@ import "google/protobuf/timestamp.proto";
 //
 // Caveats the project's honesty principles require to surface:
 //
-//   RegisterAgent currently materializes only `kind == "noop"` —
-//   provider-backed kinds (vLLM, Anthropic, OpenAI, …) are wired in
-//   their respective feature slices by composing a richer
-//   AgentFactoryPort in the binary.
+//   RegisterAgent accepts `kind == "noop"` unconditionally. Provider-
+//   backed kinds (vLLM, Anthropic, OpenAI, …) are accepted when the
+//   binary was compiled with the matching feature and booted with the
+//   required provider configuration.
 //
 //   StreamDeliberation emits one `DeliberationUpdate` per phase
 //   transition (Proposing → Revising → Validating → Scoring →
@@ -63,8 +63,9 @@ service ChoreographerService {
   // specialty. Blocks until the ranked results are ready.
   rpc Deliberate(DeliberateRequest) returns (DeliberateResponse);
 
-  // Like Deliberate but streams progress updates (proposals, critiques,
-  // revisions, scores) as they happen.
+  // Like Deliberate but streams phase updates plus a final winner frame.
+  // Per-proposal, per-critique, and per-revision frames are reserved
+  // for a later additive slice.
   rpc StreamDeliberation(StreamDeliberationRequest) returns (stream StreamDeliberationResponse);
 
   // Retrieve a previously-executed deliberation by task id.

--- a/docs/agentic-conversation-ceremony-evaluation-research.md
+++ b/docs/agentic-conversation-ceremony-evaluation-research.md
@@ -3,6 +3,11 @@
 Status: research and design proposal. This document is not an implementation
 claim.
 
+Choreographer is agnostic and independent. KMP, Runtime, and other
+systems mentioned here are studied as possible context, evidence, or
+tool providers for evaluations; they are not required dependencies of
+the Choreographer product.
+
 Date: 2026-04-26
 
 ## Scope
@@ -14,11 +19,11 @@ application-owned identifiers must stay at the edge through task attributes,
 external context metadata, output contracts, kernel graph data, or runtime
 session metadata.
 
-Code reviewed locally:
+Code reviewed locally for the original research snapshot:
 
-- Current repo: `/home/tirso/ai/developents/underpass-orchestrator`.
-- Downloaded runtime repo: `/tmp/underpass-agentic-research/underpass-runtime`.
-- Downloaded kernel repo: `/tmp/underpass-agentic-research/rehydration-kernel`.
+- this Choreographer repository
+- a local checkout of `underpass-runtime`
+- a local checkout of `rehydration-kernel`
 
 Detailed meeting blueprints live in
 `docs/agentic-meeting-ceremony-blueprints.md`.

--- a/docs/agentic-meeting-ceremony-blueprints.md
+++ b/docs/agentic-meeting-ceremony-blueprints.md
@@ -4,6 +4,10 @@ Status: initial blueprint catalog. These are product-agnostic meeting designs
 optimized for the Underpass sibling capabilities: rehydration kernel as the
 context/scenario provider and runtime client as the governed tool runtime.
 
+Choreographer itself remains agnostic and independent. The sibling
+systems named here are example providers for study and evaluation, not
+required dependencies of the Choreographer product.
+
 Date: 2026-04-26
 
 Related research: `docs/agentic-conversation-ceremony-evaluation-research.md`.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -5,6 +5,11 @@ dropped 2026-05-12 (PIR is owned by a separate project — this backlog
 tracks Choreographer's own stack-readiness, not any one downstream
 consumer).
 
+Choreographer is agnostic and independent. References to PIR, KMP,
+Runtime, or other repositories in this backlog are historical context,
+study material, or examples of possible integrations. They are not
+required dependencies for Choreographer as a product.
+
 Companion documents:
 
 - [`stack-gap-analysis.md`](./stack-gap-analysis.md)
@@ -18,7 +23,7 @@ agent-facing surface (gRPC + MCP), and reproducible stack E2E.
 
 ## Executive summary
 
-As of 2026-05-11 the eight stack-readiness areas resolve as follows:
+As of 2026-05-14 the eight stack-readiness areas resolve as follows:
 
 | # | Area | State |
 |---|---|---|
@@ -28,8 +33,8 @@ As of 2026-05-11 the eight stack-readiness areas resolve as follows:
 | 4 | complete causal metadata propagation | done (Epic 5) |
 | 5 | provider-backed council materialization | done (`DispatchingAgentFactory` wired with `noop`/`anthropic`/`openai`/`vllm` arms) |
 | 6 | honest and durable transport semantics | done (AsyncAPI now declares plain core NATS; JetStream deferred) |
-| 7 | real TLS / mTLS posture | done (gRPC server TLS in `none`/`server`/`mutual` modes; chart honest; Runtime client TLS shipped 2026-05-12; handshake-level integration test still deferred) |
-| 8 | stack-level end-to-end proofs | done (E2E covers seeded council, deliberation, causal metadata over NATS, `Orchestrate → RuntimeExecutor → stub-runtime`, `ExternalContextBundle` round-trip, and the positive structured-output `RunCouncilDecision` path via the `stub-llm` sidecar; real-provider vLLM council remains `make e2e-provider-vllm`) |
+| 7 | real TLS / mTLS posture | done (gRPC server TLS in `none`/`server`/`mutual` modes; chart honest; Runtime client TLS shipped 2026-05-12; handshake-level server + mutual TLS tests shipped 2026-05-14) |
+| 8 | stack-level end-to-end proofs | done (E2E covers seeded council, deliberation, causal metadata over NATS, `Orchestrate -> RuntimeExecutor -> stub-runtime`, `ExternalContextBundle` round-trip, positive structured-output `RunCouncilDecision` through the `stub-llm` sidecar, and OpenAI-shaped + vLLM-shaped provider paths; real external vLLM validation remains `make e2e-provider-vllm`) |
 
 Two surfaces beyond the eight areas:
 
@@ -47,42 +52,42 @@ Two surfaces beyond the eight areas:
   expose a clean, fully-typed gRPC API plus the MCP wrapping so any
   agentic consumer can drive it.
 
-Genuinely open work: the crates.io distribution debt for `choreo-mcp`
-(needs the proto tree vendored into a separate crate before
-`cargo install` from a registry will work), Epic 9 (a dedicated
-council-decision RPC if and when a consumer asks for more than the
-generic `Deliberate` / `Orchestrate`), the handshake-level TLS
-integration test (currently the wiring is exercised by env-loading
-unit tests + helm-lint, not a real cert handshake), and the Epic 11
-follow-ups (a stack scenario that asserts schema validation +
-ExternalContextBundle round-trip, and merging the provider-runner
-E2E into the same compose stack). Milestones A, B, and C are all
-complete as of 2026-05-12.
+Genuinely open work after the 2026-05-14 bundles is narrower:
+document the compose E2E stub-LLM surface, optionally teach
+`choreo-consumer-smoke` to drive the positive structured-output
+sidecar path, and keep the operator-facing `make e2e-provider-vllm`
+flow for real external vLLM endpoints. Milestones A, B, C, D, and E
+are all complete as of 2026-05-14. The `choreo-mcp` crates.io
+distribution debt is also cleared: vendored proto crate + tag-gated
+publish jobs + per-PR publish-dry-run + real-kernel container
+integration test.
 
 The recommended remaining execution order is:
 
-- Phase 3: `choreo-mcp` crates.io distribution + handshake-level TLS test
-- Phase 4: dedicated agent-facing RPC + report artifact (only if a
-  consumer asks for them)
-- Phase 5: stack E2E with a real council and the Runtime executor
+- compose-level operations doc for the stub-runtime / stub-LLM E2E path
+- optional consumer-smoke positive-path mode against a structured JSON agent
+- real-provider validation as an operator-run E2E (`make e2e-provider-vllm`)
 
 ## Out of scope
 
 This backlog does not include:
 
-- moving kernel graph semantics into Choreographer
+- moving any context system's graph semantics into Choreographer
 - making Choreographer domain-specific (payments, incidents, …)
 - implementing any downstream product (PIR, payments incident
   response, etc.) in this repository
 
 ## Priorities
 
-### P0 — hard blockers (remaining)
+### P0 — hard blockers (cleared)
 
-These items still block downstream consumer integration.
+No repo-owned P0 blockers remain as of 2026-05-14. The former P0
+items are now cleared:
 
 - dedicated consumer-facing RPC surface (Epic 9)
-- stack E2E proof with real provider council + ExternalContextBundle round-trip + schema-validated structured output in the same compose stack (Epic 11 follow-ups)
+- stack E2E proof with Runtime executor, provider-shaped council,
+  `ExternalContextBundle` round-trip, and schema-validated structured
+  output in the same compose stack (Epic 11)
 
 Already cleared: Runtime executor adapter (Epic 1), Kernel context
 boundary (Epic 2), structured council output contracts (Epic 3),
@@ -220,9 +225,9 @@ listed below are present in the repo today.
 - use-case integration test proving `OrchestrateUseCase` emits correct events
   for success and failure with the runtime adapter wired
 
-### Epic 2. Kernel context boundary
+### Epic 2. External context boundary
 
-Status: done (option A — caller-materialized context)
+Status: done (caller-materialized, context-provider-agnostic input)
 
 Current state:
 
@@ -247,14 +252,16 @@ Relevant code:
 - [`crates/choreo-app/src/usecases/deliberate.rs`](../crates/choreo-app/src/usecases/deliberate.rs)
 
 Progress as of 2026-05-11: implementation landed in commit `fab9bfb`
-(PR #43). Option B (a Kernel adapter port owned by Choreographer)
-remains explicitly deferred — the backlog recommended option A.
+(PR #43). A Choreographer-owned adapter for any specific context
+system remains intentionally out of scope unless a concrete product
+needs that boundary.
 
 #### Deliverables
 
 1. define one explicit context ingestion boundary:
-   - option A: caller fetches kernel context and passes it to Choreographer
-   - option B: Choreographer can fetch context itself through a new port
+   - caller fetches context and passes it to Choreographer
+   - a future product-specific adapter can fetch context through a new
+     port if needed
 2. choose one as the production path for the first downstream integration
 3. define a stable structured bundle shape for expert councils:
    - incident summary
@@ -266,15 +273,15 @@ remains explicitly deferred — the backlog recommended option A.
 
 #### Recommendation
 
-For the first slice, prefer caller-materialized context:
+Prefer caller-materialized context:
 
-- the consumer remains the kernel-first owner
+- the consumer remains the owner of its context system
 - Choreographer remains domain-agnostic
 - the integration boundary is cleaner
 
 That means Choreographer must still gain a first-class notion of
 "structured external context bundle", but it does not have to own
-Kernel transport in v1.
+context-provider transport.
 
 #### Acceptance criteria
 
@@ -569,8 +576,8 @@ integration on direct gRPC.
 
 ### Epic 8. TLS / mTLS parity
 
-Status: done end-to-end (server + client); only the handshake-level
-integration test remains deferred.
+Status: done end-to-end (server + client + handshake-level
+integration tests).
 
 Current state (2026-05-11):
 
@@ -755,14 +762,15 @@ schema (renamed to drop product vocabulary where appropriate, e.g.
 
 ### Epic 11. Choreographer stack E2E
 
-Status: positive structured-output leg landed 2026-05-14 (stub-LLM
-sidecar + scenario 8); the "real provider council" leg
-(vLLM/Anthropic/OpenAI in the compose stack) remains optional and is
-still covered separately by `make e2e-provider-vllm`.
+Status: done for the repo-owned stack E2E path as of 2026-05-14.
+The compose stack covers the Runtime executor via `stub-runtime`, the
+positive structured-output path via `stub-llm`, and both OpenAI-shaped
+and vLLM-shaped provider adapters. A real external vLLM endpoint
+remains an operator-run validation through `make e2e-provider-vllm`.
 
 Current state:
 
-- `crates/choreo-e2e-runner/src/main.rs` runs eight scenarios against
+- `crates/choreo-e2e-runner/src/main.rs` runs nine scenarios against
   a real gRPC + NATS stack with stub-runtime + stub-llm sidecars:
   1. seeded council is visible
   2. `Deliberate` on the seeded specialty returns a winner
@@ -790,6 +798,11 @@ Current state:
      agent is an `openai`-kind descriptor pointing at the `stub-llm`
      sidecar (added 2026-05-14); the outbound envelope omits
      `external_context_bundle_id` (no bundle was sent).
+  9. The same Report-contract success path runs through a `vllm`-kind
+     agent descriptor pointed at the same `stub-llm` sidecar. This
+     proves the vLLM-shaped adapter path in the same compose run; a
+     real external vLLM endpoint remains covered by
+     `make e2e-provider-vllm`.
 - the `stub-runtime` sidecar ships in this repo as
   `crates/choreo-e2e-runner/src/bin/stub_runtime.rs` +
   `tests/e2e/stub-runtime.Dockerfile`. It serves the canonical
@@ -806,11 +819,11 @@ Current state:
   the stub-runtime logs `CreateSession`, `InvokeTool(stub.echo)`,
   and `CloseSession` once per orchestration.
 - the seed council still uses `NoopAgent`; scenarios 1–7 stay on
-  that path. Scenario 8 dynamically registers an `openai`-kind agent
-  pointing at the `stub-llm` sidecar so the positive structured-
-  output path is exercised without a real provider in the compose
-  stack. Real-provider councils against vLLM remain exercised
-  separately by `make e2e-provider-vllm` (Epic-6 provider runner).
+  that path. Scenarios 8 and 9 dynamically register `openai` and
+  `vllm` agent descriptors pointing at the `stub-llm` sidecar so the
+  positive structured-output path is exercised without depending on a
+  real external provider. Real-provider councils against vLLM remain
+  exercised separately by `make e2e-provider-vllm`.
 
 Relevant code:
 
@@ -838,7 +851,9 @@ Status of the chain:
 - bounded external trigger → ✅ scenario 4 (NATS) + scenario 5 (gRPC).
 - context bundle → ✅ scenario 7 round-trips the bundle id into the
   outbound `DeliberationCompleted` envelope (2026-05-14).
-- real council → ✅ via `make e2e-provider-vllm` (provider runner).
+- real council → ✅ scenario 9 via the vLLM adapter against the
+  `stub-llm` OpenAI-compatible sidecar; real external vLLM remains
+  an operator-run validation via `make e2e-provider-vllm`.
 - validated structured result → ✅ scenario 6 covers the rejection
   path (JsonSchemaValidator fires, `error_kind =
   "deliberation.no_valid_proposal"` on the bus, `FailedPrecondition`
@@ -848,29 +863,17 @@ Status of the chain:
   schema.
 - runtime execution → ✅ scenario 5 (stub-runtime).
 
-#### Remaining follow-ups (out of Milestone D's critical path)
+#### Remaining follow-ups
 
-- scenario 7: `Deliberate` with an `ExternalContextBundle` attached
-  → ✅ done (2026-05-14). `DeliberationCompletedEvent` now carries
-  the optional `external_context_bundle_id` and the e2e-runner asserts
-  the bundle id round-trips to the outbound bus envelope.
-- positive structured-output scenario → ✅ done (2026-05-14).
-  Scenario 8 brings up a `stub-llm` sidecar (OpenAI Chat Completions
-  shape, always returns a JSON Report payload that satisfies the
-  canonical schema) and asserts the positive path through
-  `RunCouncilDecision` in Strict mode.
-- merge the provider-runner E2E (vLLM) into the same compose stack
-  → ✅ done 2026-05-14 (Bundle A). Scenario 9 registers a
-  `kind=vllm` agent pointing at the existing `stub-llm` sidecar
-  (both adapters speak `POST /v1/chat/completions`), so a single
-  `make e2e-compose` now covers both the openai-shaped and the
-  vllm-shaped paths. `make e2e-provider-vllm` stays for operators
-  who want to validate against a REAL vLLM endpoint.
 - compose-level operations doc (`docs/operations/compose-e2e.md`):
   the stub-llm sidecar, its OpenAI-compat surface, the hard-coded
   Report payload, and the `STUB_LLM_LISTEN` override all need a
   prose home. The doc itself does not exist yet — leaving as a
   follow-up so this slice stays additive.
+- optional consumer-smoke positive-path mode: the underlying stub-LLM
+  capability exists, but `choreo-consumer-smoke` still defaults to
+  the NoopAgent rejection path unless a consumer wires a structured
+  JSON agent.
 
 ### Epic 12. Consumer integration smoke prerequisites
 
@@ -911,20 +914,20 @@ Deliverables:
 - Operations doc: `docs/operations/consumer-smoke.md`.
 - `make consumer-smoke` Makefile target.
 
-#### Remaining gaps (out of Epic 12's scope, tracked under Epic 11)
+#### Remaining gaps (outside Epic 12's shipped surface)
 
-- **Bundle round-trip** (`bundle_seam_documented` Skipped). Owned by
-  Epic 11 scenario 7. Once that lands the assertion flips to Passed.
-- **Chain 2 positive path** (`report_payload_validates` Skipped on
-  today's stack). The stub-LLM sidecar shipped under Epic 11
-  scenario 8 (2026-05-14) — follow-up consumers can now register an
+- **Bundle round-trip** (`bundle_seam_documented`) remains `Skipped`
+  in the consumer-smoke harness by design; Epic 11 scenario 7 already
+  proves the stack-level round-trip in `make e2e-compose`.
+- **Chain 2 positive path** (`report_payload_validates`) remains
+  `Skipped` against the default NoopAgent stack. The stub-LLM sidecar
+  shipped under Epic 11 scenario 8, so consumers can now register an
   `openai`-kind agent against `http://stub-llm:8000` to exercise the
-  positive path. Wiring `choreo-consumer-smoke` chain 2 to that
-  sidecar (so the harness flips Skipped → Passed) is the remaining
-  work; the underlying capability is in place.
-- **Provider-runner E2E merged into `make e2e-compose`** so a single
-  command exercises real provider council + real (stub) runtime in
-  one shot — also Epic 11.
+  positive path; teaching the smoke harness to run that variant is a
+  follow-up.
+- **Provider-runner E2E merged into `make e2e-compose`** is done via
+  scenario 9. `make e2e-provider-vllm` remains for validating a real
+  external vLLM endpoint.
 
 #### Relevant code
 
@@ -933,12 +936,12 @@ Deliverables:
 
 ### Epic 13. MCP stdio adapter
 
-Status: foundation done (2026-05-12); distribution slice in flight.
+Status: done (foundation 2026-05-12; distribution 2026-05-14).
 
 Current state:
 
 - `crates/choreo-mcp` exposes every RPC of `underpass.choreo.v1` as
-  a `choreo_*` MCP tool (12 tools 1:1 with the gRPC service).
+  a `choreo_*` MCP tool (16 tools 1:1 with the gRPC service).
 - JSON-RPC 2.0 over stdin/stdout, no MCP SDK — the wire protocol is
   hand-rolled so it stays in lock-step with the proto contract.
 - `ChoreoMcpToolBackend` trait has two impls: fixture (canned
@@ -949,14 +952,16 @@ Current state:
 - `StreamDeliberation` buffered into one response (frames array +
   winner extracted from the last `result`-typed frame). MCP stdio is
   sync.
-- 6 env vars (`CHOREO_MCP_BACKEND` + 5 `CHOREO_MCP_GRPC_TLS_*`) with
-  the same auto-detection pattern as the sibling rehydration-mcp.
+- 7 env vars (`CHOREO_MCP_BACKEND`, `CHOREO_MCP_GRPC_ENDPOINT`, and
+  5 `CHOREO_MCP_GRPC_TLS_*`) with the same auto-detection pattern as
+  the sibling rehydration-mcp.
 - 21 unit tests + workspace clippy clean.
 
-Distribution slice (in flight):
+Distribution slice (done 2026-05-14):
 
-- `scripts/mcp/install-choreo-mcp.sh` — `cargo install --git` wrapper
-  with pinned `CHOREO_MCP_BRANCH/TAG/REV` (mutually exclusive).
+- `scripts/mcp/install-choreo-mcp.sh` — registry mode by default
+  (`cargo install choreo-mcp`); `CHOREO_MCP_INSTALL_MODE=git` falls
+  back to the `--git`/`--branch`/`--tag`/`--rev` source path.
 - `scripts/mcp/choreo-stdio-smoke.sh` — one `tools/call` + grep marker
   for both fixture and live modes.
 - `docs/operations/mcp-stdio.md` — canonical user-facing UX.
@@ -970,12 +975,10 @@ Relevant code:
 - [`crates/choreo-mcp/`](../crates/choreo-mcp/)
 - [`docs/operations/mcp-stdio.md`](./operations/mcp-stdio.md)
 
-#### Deliverables (open)
+#### Deliverables (met)
 
-1. `crates.io` publication. Blocked by the proto tree being path-deped
-   from `choreo-mcp`. Needs the proto package vendored into a
-   standalone crate (or `choreo-proto` itself published) before
-   `cargo install` from a registry will work.
+1. `crates.io` publication readiness: vendored proto crate,
+   tag-gated publish jobs, and per-PR publish dry-run.
 2. Real-kernel integration test that boots a choreographer in a
    container and exercises every tool through MCP (separate from the
    existing e2e-runner gRPC scenarios).
@@ -1027,9 +1030,8 @@ Exit condition:
 
 - composition, transport, and security claims match reality
 
-**Cleared 2026-05-12.** Epics 6, 7, 8 all done end-to-end. Handshake-
-level integration test remains as an Epic 8 follow-up but is not on
-the milestone-C critical path.
+**Cleared 2026-05-14.** Epics 6, 7, and 8 are all done end-to-end,
+including the server and mutual TLS handshake integration tests.
 
 ### Milestone D — Consumer-facing surface
 
@@ -1042,8 +1044,10 @@ Exit condition:
 
 - consumers have a clean RPC surface to integrate with
 
-**Open.** Epic 9 not started; Epic 11 partial (4 scenarios but no real
-council and no runtime executor wired in the stack).
+**Cleared 2026-05-14.** Epic 9 shipped `RunCouncilDecision` plus
+contract CRUD, and Epic 11 now runs the nine-scenario compose E2E
+path with Runtime executor, external context round-trip, structured
+output success, and OpenAI-shaped + vLLM-shaped provider paths.
 
 ### Milestone E — integration-ready
 
@@ -1057,11 +1061,11 @@ Exit condition:
 
 **Cleared 2026-05-14.** Epic 12 done — consumer-smoke harness lives
 at `crates/choreo-consumer-smoke` with two chains, a CLI, and two
-integration tests against the in-process `GrpcFixture`. The
-remaining "open" assertions (`bundle_seam_documented` and Chain 2's
-positive `report_payload_validates`) are intentionally `Skipped`
-with explicit reasons that point at Epic 11's pending scenarios; they
-are not on Epic 12's critical path.
+integration tests against the in-process `GrpcFixture`. The remaining
+`Skipped` assertions are explicit harness-scope choices: bundle
+round-trip is covered by Epic 11 scenario 7, and Chain 2's positive
+path needs a structured JSON agent instead of the default NoopAgent
+stack.
 
 ## Suggested issue breakdown
 
@@ -1074,7 +1078,7 @@ are not on Epic 12's critical path.
 - structured output mode — done
 - incident / run / causation metadata propagation — done
 
-### Open waves
+### Follow-up waves
 
 #### Wave 4a — real provider factories — done
 
@@ -1109,17 +1113,20 @@ tests via `NoopAgentFactory`).
   2026-05-12): mirrors the MCP adapter's pattern with auto-detection
   + 7 env-loading / URI-upgrade unit tests + explicit
   `TlsReadFailed { path, source }` error variant.
-- Open follow-up: handshake-level integration test against a
-  choreographer instance with a self-signed cert (likely with
-  `rcgen` as a dev-dep).
+- Handshake-level integration tests shipped 2026-05-14:
+  `tls_server_handshake.rs` and `tls_mutual_handshake.rs` mint
+  self-signed leaves through the shared TLS fixture and exercise real
+  server + mutual TLS handshakes.
 
 #### Wave 5 — Consumer-facing surface
 
-- add a dedicated `RunCouncilDecision` (or equivalent) RPC backed by
-  the structured-output mode
-- add JSON Schema validator and a report-shape validator
-- add `Report` / `HumanHandoffReport` entity + proto + persistence
-- extend the e2e-runner to drive a real council + the Runtime executor
+- `RunCouncilDecision` plus contract CRUD — done
+- JSON Schema validator and canonical Report schema — done
+- no bespoke `Report` / `HumanHandoffReport` entity by design; Report
+  stays a JSON Schema output contract so product vocabulary does not
+  enter the core
+- e2e-runner drives Runtime executor plus OpenAI-shaped and vLLM-shaped
+  provider paths — done
 
 ## Gating rule
 
@@ -1129,23 +1136,21 @@ The following rule should be treated as hard policy:
 > output should depend on Choreographer until Milestones A, B, and C
 > are complete.
 
-Status 2026-05-12: Milestones A, B, and C are all complete.
-Milestones D (Epic 9 consumer-facing RPC + Epic 11 real-council /
-runtime E2E legs) and the crates.io publication leg of Epic 13 are
-the remaining open items.
+Status 2026-05-14: Milestones A, B, C, D, and E are complete. The
+crates.io publication leg of Epic 13 also cleared in Bundle B.
 
 Why the rule still applies in spirit even with B and C now cleared:
 
-- without Milestone D (Epic 9's consumer-facing RPC + Epic 11's
-  real-council / runtime E2E legs) no consumer has been proven able
-  to drive Choreographer through its public surfaces at production
-  scale.
+- consumer-specific production readiness still requires each downstream
+  product to run its own smoke against its provider credentials,
+  Runtime catalog, context source, and output contracts.
 
 ## Final recommendation
 
 If only one sentence is carried forward from this document, it should be:
 
-> Choreographer's job is to be a trustworthy stack peer — real Runtime,
-> real context, structured outputs, honest transport, agent-callable
-> through gRPC and MCP, with stack E2E — and nothing more. Downstream
-> products integrate; they are not implemented here.
+> Choreographer's job is to be a trustworthy, agnostic coordination
+> product — structured external context input, structured outputs,
+> honest transport, optional execution adapters, and agent-callable
+> surfaces through gRPC and MCP. Downstream products integrate; they
+> are not implemented here.

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -171,7 +171,11 @@ lab-notebook contract).
 ## Running the binary
 
 ```bash
-# With defaults (no NATS, no Postgres).
+# With no external services.
+CHOREO_NATS_ENABLED=false just run
+
+# With defaults, the binary expects NATS at nats://nats:4222 and uses
+# in-memory persistence unless CHOREO_POSTGRES_URL is set.
 just run
 
 # With the OTLP exporter compiled in. At runtime, set

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,12 +3,14 @@
 Navigation hub for `underpass-choreographer` docs. Each entry links to
 the canonical file and gives a one-line orientation.
 
-The choreographer is one of three Underpass platform planes:
+Choreographer is agnostic and independently usable. In Underpass
+platform research it is often discussed alongside these planes, but it
+does not require KMP, PIR, or any downstream product to run:
 
 - **[Underpass KMP](../README.md#the-underpass-platform)** — Kernel
   Memory Plane / Kernel Memory Protocol. Memory + context plane.
-  Lives in the sibling repo `rehydration-kernel`; the brand-facing
-  name is "Underpass KMP".
+  Lives in the sibling repo `rehydration-kernel`; one possible producer
+  of caller-supplied `ExternalContextBundle`s.
 - **Underpass Choreographer** — this repo. Coordination plane:
   domain-agnostic deliberation, council orchestration, executor
   hand-off, and MCP exposure of every RPC.
@@ -37,7 +39,9 @@ The choreographer is one of three Underpass platform planes:
 | Doc | Purpose |
 |---|---|
 | [`backlog.md`](./backlog.md) | Epic-by-epic readiness backlog + session log + gating rules. PIR framing was dropped 2026-05-12 — this is a generic stack-readiness backlog. |
-| [`stack-gap-analysis.md`](./stack-gap-analysis.md) | Honest snapshot of medium-severity gaps against the rest of the Underpass stack. |
+| [`stack-gap-analysis.md`](./stack-gap-analysis.md) | Current honest snapshot of what is wired, what remains product-owned, and what still needs downstream proof. |
+| [`product-usability-publication-plan.md`](./product-usability-publication-plan.md) | Spanish plan for making the Choreographer usable and publishable as a product surface. |
+| [`product-publication-checklist.md`](./product-publication-checklist.md) | Living checklist for tracking the usability and publication plan. |
 
 ## Experiments — append-only lab notebook
 
@@ -49,14 +53,14 @@ The choreographer is one of three Underpass platform planes:
 
 | Doc | Purpose |
 |---|---|
-| [`agentic-conversation-ceremony-evaluation-research.md`](./agentic-conversation-ceremony-evaluation-research.md) | How to evaluate agentic meeting ceremonies built on Choreographer + KMP + Runtime. Status explicitly disclaimed as research. |
+| [`agentic-conversation-ceremony-evaluation-research.md`](./agentic-conversation-ceremony-evaluation-research.md) | Research on evaluating agentic meeting ceremonies using Choreographer with possible context/runtime providers such as KMP and Runtime. Status explicitly disclaimed as research. |
 | [`agentic-meeting-ceremony-blueprints.md`](./agentic-meeting-ceremony-blueprints.md) | Catalog of product-agnostic meeting designs (intake, evidence review, past replay, future scenario, decision council, …). |
 
 ## Historical / out-of-scope
 
 | Doc | Purpose |
 |---|---|
-| [`pir-choreographer-integration-design.md`](./pir-choreographer-integration-design.md) | Legacy design doc for the PIR product's Choreographer integration. PIR is owned by a separate project; this file is retained for context and is no longer load-bearing for this repo's backlog. |
+| [`pir-choreographer-integration-design.md`](./pir-choreographer-integration-design.md) | Legacy PIR case-study design. PIR is owned by a separate project; this file is retained only as a possible use-case study and is not load-bearing for this repo's backlog. |
 
 ## Where API examples live
 

--- a/docs/operations/consumer-smoke.md
+++ b/docs/operations/consumer-smoke.md
@@ -98,15 +98,15 @@ the typed shape without parsing the printed table.
 ## Known limitations
 
 - **`bundle_seam_documented` is intentionally `Skipped`.** The
-  external context bundle round-trip is owned by Epic 11 scenario 7
-  (still open in `docs/backlog.md`). Once that scenario lands the
-  assertion can be flipped to `Passed`.
-- **Chain 2's positive path needs a structured-JSON agent.** Today's
-  compose stack registers a `NoopAgent` that emits free-form text;
-  the `JsonSchemaValidator` always rejects it. Once a stub-LLM
-  provider sidecar that emits JSON satisfying the schema ships, the
-  rejection assertion will downgrade to `Skipped` and
-  `report_payload_validates` will go `Passed`.
+  stack-level external context bundle round-trip is covered by
+  `make e2e-compose` scenario 7; this consumer harness keeps that
+  assertion as a documented out-of-scope seam rather than duplicating
+  the stack E2E.
+- **Chain 2's positive path needs a structured-JSON agent.** The
+  default smoke path targets a NoopAgent stack and proves strict
+  schema rejection. The compose stack also ships a `stub-llm` sidecar
+  that emits Report-shaped JSON; wiring the consumer smoke harness to
+  register that agent is a follow-up positive-path mode.
 - The trigger publish in Chain 1 is informational only —
   `RunCouncilDecision` is invoked directly, so the trigger path does
   not gate the run. Pinning the trigger-driven path end-to-end is

--- a/docs/operations/deploy-kubernetes.md
+++ b/docs/operations/deploy-kubernetes.md
@@ -57,16 +57,20 @@ curl -s localhost:8080/readyz   # {"checks":[{"name":"nats","healthy":true,...}]
 ## End-to-end against the deploy
 
 `tests/cluster/e2e-job.yaml` runs the `choreo-e2e-runner` binary as
-a Job. Scenarios 1–4 cover gRPC + NATS + causal metadata against the
+a Job. The current runner is the same nine-scenario binary used by
+compose. Scenarios 1–4 cover gRPC + NATS + causal metadata against a
 real deploy and pass when the choreographer is wired correctly.
 
-Scenarios 5–6 in the current runner are designed for the compose
-**stub-runtime** sidecar (they call a tool named `stub.echo` and
-assert JSON-Schema rejection on free-form proposals). Against the
-real `underpass-runtime`, the tool is not in the catalog, so the
-runner exits with a `NotFound: runtime resource` from scenario 5 —
-that proves the mTLS gRPC path is wired but fails the assertion.
-Treat 5–6 as **design-for-stub** when reading the Job's exit code.
+Scenarios 5-9 are compose-shaped: scenario 5 expects a Runtime tool
+named `stub.echo`, scenarios 8-9 expect the `stub-llm` OpenAI-
+compatible sidecar, and scenario 6 asserts strict rejection of the
+NoopAgent's free-form output. Against the real `underpass-runtime`,
+the `stub.echo` tool is not normally in the catalog, so the runner can
+exit with `NotFound: runtime resource` from scenario 5. That proves
+the Runtime gRPC path was reached, but it is not a green full-stack
+acceptance signal. Treat the cluster Job as a targeted connectivity
+smoke unless the namespace also provides the same stub services or
+equivalent test fixtures.
 
 ```bash
 kubectl apply -f tests/cluster/e2e-job.yaml

--- a/docs/operations/mcp-stdio.md
+++ b/docs/operations/mcp-stdio.md
@@ -31,10 +31,10 @@ The 16 MCP tools are 1:1 with the choreographer's gRPC service:
 | `choreo_process_trigger_event`    | `ProcessTriggerEvent`                 | Submit a domain event; fans out to deliberations. |
 | `choreo_get_status`               | `GetStatus`                           | Service health, version, uptime, optional stats. |
 | `choreo_get_metrics`              | `GetMetrics`                          | Statistics snapshot. |
-| `choreo_run_council_decision`     | `RunCouncilDecision`                  | Epic 9: run a council against a registered output contract; returns the validated winner plus per-candidate breakdown. |
-| `choreo_register_contract`        | `RegisterContract`                    | Epic 9: register an `OutputContract` in the contract registry. |
-| `choreo_list_contracts`           | `ListContracts`                       | Epic 9: enumerate registered contracts. |
-| `choreo_delete_contract`          | `DeleteContract`                      | Epic 9: idempotent contract delete. |
+| `choreo_run_council_decision`     | `RunCouncilDecision`                  | Run a council against a registered output contract; returns the validated winner plus per-candidate breakdown. |
+| `choreo_register_contract`        | `RegisterContract`                    | Register an `OutputContract` in the contract registry. |
+| `choreo_list_contracts`           | `ListContracts`                       | Enumerate registered contracts. |
+| `choreo_delete_contract`          | `DeleteContract`                      | Idempotent contract delete. |
 
 The choreographer API is **respected at 100%** — every proto field has
 an explicit JSON key in both the tool input schema and the response.

--- a/docs/pir-choreographer-integration-design.md
+++ b/docs/pir-choreographer-integration-design.md
@@ -2,6 +2,12 @@
 
 Snapshot date: 2026-04-25
 
+Historical status: this is a legacy PIR product-integration design.
+PIR is owned outside this repository, and this file is retained for
+context only. It is a case-study document, not a product dependency or
+roadmap requirement. Current Choreographer readiness lives in
+[`backlog.md`](./backlog.md) and [`stack-gap-analysis.md`](./stack-gap-analysis.md).
+
 This document defines how `underpass-choreographer` could participate in
 `underpass-payments-incident-response` ("PIR") for complex incidents that
 should not escalate directly to a human.
@@ -23,7 +29,7 @@ deliberation engine for a narrow part of the incident lifecycle.
 Companion documents:
 
 - [`stack-gap-analysis.md`](./stack-gap-analysis.md)
-- [`pir-choreographer-readiness-backlog.md`](./pir-choreographer-readiness-backlog.md)
+- [`backlog.md`](./backlog.md)
 
 ## Executive summary
 
@@ -209,22 +215,23 @@ Choreographer already provides:
 
 This is good raw machinery for expert conversations.
 
-### What Choreographer still lacks for this use case
+### What Choreographer lacked at this snapshot
 
-Per this repo's own stack-gap analysis, Choreographer is not yet a real
-stack-integrated peer of Runtime and Kernel.
+At the 2026-04-25 snapshot, this repo's stack-gap analysis said
+Choreographer was not yet a real stack-integrated peer of Runtime and
+Kernel.
 
-Current blockers include:
+Blockers at that time included:
 
-- `NoopExecutor` is still wired in the binary
-- `NoopAgentFactory` is still wired in the binary
-- no real runtime gRPC executor adapter is composed
-- no kernel integration or context rehydration path exists
-- event correlation is partial
-- TLS server wiring is missing despite chart surface
-- JetStream semantics are not truly implemented even though the docs mention it
+- `NoopExecutor` was still wired in the binary
+- `NoopAgentFactory` was still wired in the binary
+- the real runtime gRPC executor adapter was not composed
+- no kernel integration or context rehydration path existed
+- event correlation was partial
+- TLS server wiring was missing despite chart surface
+- JetStream semantics were not truly implemented even though the docs mentioned it
 
-That means Choreographer can host deliberation today, but it cannot yet
+At that time, Choreographer could host deliberation, but could not yet
 truthfully own a production-critical PIR integration point that depends on:
 
 - real kernel-fed context

--- a/docs/product-publication-checklist.md
+++ b/docs/product-publication-checklist.md
@@ -1,0 +1,183 @@
+# Checklist De Usabilidad Y Publicación
+
+Fecha de creación: 2026-05-18
+
+Documento vivo para ejecutar el plan de
+[`product-usability-publication-plan.md`](./product-usability-publication-plan.md).
+
+Convención:
+
+- `[ ]` pendiente
+- `[x]` hecho
+- Cada check completado debería añadir una referencia breve: PR, commit,
+  comando validado, documento creado o evidencia reproducible.
+
+## Regla De Producto
+
+- [x] La documentación pública dice explícitamente que Choreographer es
+  agnóstico e independiente. Referencia: este documento,
+  `README.md`, `docs/index.md`, `docs/backlog.md` y
+  `docs/stack-gap-analysis.md`.
+- [x] PIR aparece solo como caso de estudio histórico o posible uso, no
+  como dependencia. Referencia: `docs/pir-choreographer-integration-design.md`
+  y `docs/index.md`.
+- [x] KMP aparece solo como posible proveedor de contexto, no como
+  dependencia. Referencia: `README.md`, `docs/stack-gap-analysis.md`
+  y `docs/product-usability-publication-plan.md`.
+- [x] Runtime aparece como adaptador de ejecución opcional, no como
+  requisito para usar Choreographer. Referencia: `README.md`,
+  `docs/product-usability-publication-plan.md` y
+  `docs/operations/deploy-kubernetes.md`.
+- [ ] Las claims públicas están respaldadas por tests, E2E, scripts o
+  documentación operativa reproducible.
+
+## Fase 1 - Camino Local Usable
+
+- [ ] Crear `docs/operations/compose-e2e.md`.
+- [ ] Documentar los 9 escenarios de `make e2e-compose`.
+- [ ] Documentar `stub-runtime`.
+- [ ] Documentar `stub-llm`.
+- [ ] Documentar el Report schema usado por los escenarios positivos.
+- [ ] Documentar los provider shapes OpenAI y vLLM usados en E2E.
+- [ ] Añadir quickstart sin servicios externos:
+  `CHOREO_NATS_ENABLED=false just run`.
+- [ ] Añadir quickstart de demo completa: `make e2e-compose`.
+- [ ] Añadir quickstart MCP fixture:
+  `CHOREO_MCP_BACKEND=fixture choreo-mcp`.
+- [ ] Añadir quickstart MCP live contra gRPC local.
+- [ ] Añadir ejemplo de `CreateCouncil`.
+- [ ] Añadir ejemplo de `RegisterAgent`.
+- [ ] Añadir ejemplo de `RegisterContract`.
+- [ ] Añadir ejemplo de `RunCouncilDecision`.
+- [ ] Añadir ejemplo de `Orchestrate`.
+- [ ] Verificar que un usuario nuevo puede obtener un resultado
+  validado sin leer código Rust.
+
+## Fase 2 - Separar Demos De Producción
+
+- [ ] Añadir selector de escenarios al e2e-runner.
+- [ ] Definir grupo `compose` para escenarios 1-9.
+- [ ] Definir grupo `cluster-connectivity` para escenarios 1-4.
+- [ ] Definir grupo `runtime-stub` para escenario 5.
+- [ ] Definir grupo `structured-output` para escenarios 6-9.
+- [ ] Actualizar `make e2e-compose` para usar el grupo completo.
+- [ ] Actualizar Kubernetes Job para no ejecutar por defecto escenarios
+  que requieren `stub.echo` o `stub-llm`.
+- [ ] Actualizar `docs/operations/deploy-kubernetes.md` con el nuevo
+  modo de smoke real.
+- [ ] Verificar que Kubernetes smoke pasa contra un deploy real.
+- [ ] Verificar que `make e2e-compose` sigue probando todo el stack con
+  fixtures.
+- [ ] Eliminar cualquier mención operativa a "fallos esperados" como
+  estado aceptable.
+
+## Fase 3 - Consumer Smoke Integrable
+
+- [ ] Añadir modo positive-path a `choreo-consumer-smoke`.
+- [ ] Permitir registrar un agent `openai` contra endpoint
+  OpenAI-compatible.
+- [ ] Permitir registrar un agent `vllm` contra endpoint
+  OpenAI-compatible.
+- [ ] Registrar el Report schema desde el smoke positivo.
+- [ ] Ejecutar `RunCouncilDecision` en Strict mode desde el smoke
+  positivo.
+- [ ] Validar `report_payload_validates = Passed`.
+- [ ] Mantener modo NoopAgent rejection-path.
+- [ ] Documentar modo rejection-path.
+- [ ] Documentar modo positive-path.
+- [ ] Documentar NATS opcional.
+- [ ] Documentar exit codes.
+- [ ] Añadir ejemplo de CI para consumidores.
+- [ ] Verificar que un consumidor puede comprobar API viva, rechazo de
+  output inválido, aceptación de JSON válido y propagación de
+  correlation/causation por NATS.
+
+## Fase 4 - Publicación Operativa
+
+- [ ] Completar guía Helm de instalación mínima.
+- [ ] Completar guía Helm con embedded NATS.
+- [ ] Completar guía Helm con Runtime executor opcional.
+- [ ] Completar guía Helm con TLS/mTLS.
+- [ ] Completar guía Helm con Postgres secret.
+- [ ] Completar guía Helm con provider env secrets.
+- [ ] Añadir `SECURITY.md`.
+- [ ] Añadir `CHANGELOG.md`.
+- [ ] Añadir `CONTRIBUTING.md`.
+- [ ] Añadir matriz de soporte de Rust version.
+- [ ] Añadir matriz de soporte de image tags.
+- [ ] Añadir matriz de soporte de chart versions.
+- [ ] Añadir matriz de soporte de providers.
+- [ ] Añadir matriz de soporte de postura Kubernetes.
+- [ ] Documentar rollback con ejemplo real.
+- [ ] Documentar upgrade con ejemplo real.
+- [ ] Verificar que un operador puede desplegar imagen pinneada, chart
+  OCI, secret refs y smoke post-deploy.
+
+## Fase 5 - Release Candidate
+
+- [ ] `just check` pasa.
+- [ ] `just helm-lint` pasa.
+- [ ] `just integration` pasa.
+- [ ] `make e2e-compose` pasa.
+- [ ] Kubernetes smoke con escenarios seleccionados pasa.
+- [ ] `make consumer-smoke` rejection-path pasa.
+- [ ] consumer-smoke positive-path contra `stub-llm` o provider
+  compatible pasa.
+- [ ] `make e2e-provider-vllm` pasa si se anuncia vLLM real.
+- [ ] `cargo publish --dry-run -p choreo-mcp-proto` pasa.
+- [ ] `cargo publish --dry-run -p choreo-mcp` pasa.
+- [ ] Dry run de build/push de imagen pasa.
+- [ ] Dry run de build/push de chart pasa.
+- [ ] Tag RC creado.
+- [ ] Imagen GHCR publicada.
+- [ ] Helm chart OCI publicado.
+- [ ] `choreo-mcp` instalable desde registry.
+- [ ] Release notes incluyen límites explícitos.
+
+## Fase 6 - Public Beta
+
+- [ ] Publicar como **Underpass Choreographer Public Beta**.
+- [ ] Descripción pública: generic agent council coordination plane.
+- [ ] Descripción pública: gRPC + MCP + Helm.
+- [ ] Descripción pública: caller-supplied context.
+- [ ] Descripción pública: Runtime executor opcional.
+- [ ] Descripción pública: structured outputs via JSON Schema.
+- [ ] Evitar claim "production-ready" sin downstream smoke real.
+- [ ] Evitar claim "KMP-integrated" si Choreographer no consulta KMP.
+- [ ] Evitar claim "durable eventing".
+- [ ] Evitar claim "real-time deliberation streaming" para turnos
+  internos.
+
+## Definición De Usable
+
+- [ ] Se puede instalar localmente.
+- [ ] Se puede instalar por Helm.
+- [ ] Se pueden crear o listar councils.
+- [ ] Se puede registrar un agent.
+- [ ] Se puede registrar un output contract.
+- [ ] Se puede ejecutar `RunCouncilDecision`.
+- [ ] Se recibe un resultado validado.
+- [ ] Se puede conectar por MCP.
+- [ ] Se puede ejecutar un smoke reproducible.
+
+## Definición De Publicable
+
+- [ ] Los límites están documentados sin contradicciones.
+- [ ] El quickstart funciona desde cero.
+- [ ] Los smoke tests no tienen "fallos esperados".
+- [ ] La release produce imagen versionada.
+- [ ] La release produce chart versionado.
+- [ ] La release produce binario MCP versionado.
+- [ ] Hay guía de seguridad.
+- [ ] Hay guía de contribución.
+- [ ] Hay changelog.
+- [ ] Hay documentación de rollback.
+- [ ] Las claims públicas están respaldadas por tests, E2E o docs de
+  operación reproducibles.
+
+## Notas De Avance
+
+Añadir entradas breves aquí cuando se completen bloques grandes.
+
+- 2026-05-18: checklist inicial creado a partir del plan de usabilidad
+  y publicación.

--- a/docs/product-usability-publication-plan.md
+++ b/docs/product-usability-publication-plan.md
@@ -1,0 +1,254 @@
+# Plan Para Tener El Producto Usable Y Publicable
+
+Fecha: 2026-05-18
+
+Este plan asume que el producto a publicar es **Underpass
+Choreographer como plano genérico de coordinación**, no PIR ni ningún
+producto downstream concreto.
+
+## Aclaración De Independencia
+
+Choreographer es agnóstico e independiente. PIR, KMP,
+`underpass-runtime` u otros repos aparecen en la documentación solo
+como referencias de estudio, integraciones posibles o casos de uso.
+No forman parte obligatoria del producto publicable.
+
+La frontera estable del producto es:
+
+- entrada de contexto: `ExternalContextBundle` suministrado por el
+  caller, venga de KMP, RAG, una aplicación propia o cualquier otra
+  fuente;
+- ejecución: opcional, mediante adaptadores como `RuntimeExecutor`;
+- dominio: siempre externo, expresado por configuración, atributos,
+  contratos y payloads.
+
+## Tesis
+
+El repositorio ya tiene una base técnica sólida: gRPC completo, MCP
+stdio, Runtime executor, contratos de salida con JSON Schema, NATS,
+Postgres, TLS/mTLS, Helm y E2E con stubs.
+
+Lo que falta para que sea usable y publicable no es más arquitectura.
+Falta cerrar los caminos de uso reales, separar demos de producción y
+convertir las pruebas actuales en una experiencia que un tercero pueda
+ejecutar sin leer el código fuente.
+
+## Promesa Pública
+
+### Se Puede Prometer
+
+- Coordina councils de agentes especializados.
+- Expone la API gRPC completa `underpass.choreo.v1`.
+- Expone MCP stdio para agentes como Codex y Claude Desktop.
+- Acepta contexto externo mediante `ExternalContextBundle`.
+- Puede ejecutar winners mediante `RuntimeExecutor`.
+- Soporta contratos de salida con JSON Schema.
+- Despliega mediante container + Helm.
+- Publica y consume eventos por core NATS pub/sub.
+- Tiene E2E reproducible con `stub-runtime` y `stub-llm`.
+
+### No Se Debe Prometer Todavía
+
+- Que Choreographer consulta KMP directamente o depende de KMP.
+- Que NATS tiene semántica durable, replay o ack tipo JetStream.
+- Que `StreamDeliberation` emite cada propuesta, crítica y revisión.
+- Que un provider real está validado en CI sin credenciales externas.
+- Que este repo implementa PIR o cualquier producto downstream.
+
+## Fase 1 - Camino Local Usable
+
+Objetivo: que alguien clone el repo y vea valor en menos de 15 minutos.
+
+Trabajo:
+
+- Crear `docs/operations/compose-e2e.md`.
+- Documentar los 9 escenarios de `make e2e-compose`.
+- Explicar `stub-runtime`, `stub-llm`, Report schema y los provider
+  shapes OpenAI/vLLM.
+- Añadir un quickstart local:
+  - sin externos: `CHOREO_NATS_ENABLED=false just run`
+  - demo completa: `make e2e-compose`
+  - MCP fixture: `CHOREO_MCP_BACKEND=fixture choreo-mcp`
+  - MCP live contra gRPC local.
+- Añadir ejemplos concretos de requests para:
+  - `CreateCouncil`
+  - `RegisterAgent`
+  - `RegisterContract`
+  - `RunCouncilDecision`
+  - `Orchestrate`
+
+Criterio de salida:
+
+- Un usuario nuevo puede ejecutar la demo, ver un council, registrar un
+  contrato y obtener un resultado validado sin leer Rust.
+
+## Fase 2 - Separar Demos De Producción
+
+Objetivo: que los smoke tests no fallen por mezclar stubs con Runtime
+real.
+
+Trabajo:
+
+- Hacer el e2e-runner seleccionable por escenarios:
+  - `compose`: escenarios 1-9.
+  - `cluster-connectivity`: escenarios 1-4.
+  - `runtime-stub`: escenario 5.
+  - `structured-output`: escenarios 6-9.
+- Cambiar el Job Kubernetes para no ejecutar por defecto escenarios que
+  requieren `stub.echo` o `stub-llm`.
+- Mantener `make e2e-compose` como prueba completa repo-owned.
+- Mantener `make e2e-provider-vllm` como prueba operator-run contra un
+  provider real.
+
+Criterio de salida:
+
+- Kubernetes smoke pasa contra un deploy real.
+- Compose E2E sigue probando todo el stack con fixtures.
+- No hay "fallos esperados" en documentación operativa.
+
+## Fase 3 - Consumer Smoke Integrable
+
+Objetivo: que un downstream pueda poner Choreographer en su CI.
+
+Trabajo:
+
+- Extender `choreo-consumer-smoke` con modo positivo:
+  - registrar agent `openai` o `vllm` contra un endpoint
+    OpenAI-compatible.
+  - registrar Report schema.
+  - ejecutar `RunCouncilDecision` en Strict mode.
+  - validar `report_payload_validates = Passed`.
+- Mantener el modo actual NoopAgent como rejection-path.
+- Documentar:
+  - modo rejection-path
+  - modo positive-path
+  - NATS opcional
+  - exit codes
+  - ejemplo de CI para consumidores.
+
+Criterio de salida:
+
+- Un consumidor puede comprobar:
+  - la API vive.
+  - output inválido se rechaza.
+  - output JSON válido se acepta.
+  - correlation/causation se propaga por NATS cuando NATS está
+    configurado.
+
+## Fase 4 - Publicación Operativa
+
+Objetivo: que un operador pueda instalarlo sin asistencia directa.
+
+Trabajo:
+
+- Completar guía Helm con:
+  - instalación mínima.
+  - instalación con embedded NATS.
+  - instalación con Runtime executor.
+  - instalación con TLS/mTLS.
+  - instalación con Postgres secret.
+  - instalación con provider env secrets.
+- Añadir `SECURITY.md`.
+- Añadir `CHANGELOG.md`.
+- Añadir `CONTRIBUTING.md` mínimo.
+- Añadir matriz de soporte:
+  - Rust version.
+  - image tags.
+  - chart versions.
+  - providers soportados.
+  - postura Kubernetes soportada.
+- Documentar rollback y upgrade con ejemplos reales.
+
+Criterio de salida:
+
+- Un operador puede desplegar imagen pinneada, chart OCI, secret refs y
+  smoke post-deploy.
+
+## Fase 5 - Release Candidate
+
+Objetivo: generar una RC publicable, no solo mergear código.
+
+Gates obligatorios:
+
+- `just check`
+- `just helm-lint`
+- `just integration`
+- `make e2e-compose`
+- Kubernetes smoke con escenarios seleccionados.
+- `make consumer-smoke` rejection-path.
+- consumer-smoke positive-path contra `stub-llm` o provider compatible.
+- `make e2e-provider-vllm` si se va a anunciar vLLM real.
+- `cargo publish --dry-run` para `choreo-mcp-proto` y `choreo-mcp`.
+- build/push dry run de imagen y chart.
+
+Criterio de salida:
+
+- Tag RC.
+- Imagen GHCR.
+- Helm chart OCI.
+- `choreo-mcp` instalable.
+- Release notes con límites explícitos.
+
+## Fase 6 - Public Beta
+
+Objetivo: publicarlo honestamente.
+
+Publicar como:
+
+- **Underpass Choreographer Public Beta**
+- Generic agent council coordination plane.
+- gRPC + MCP + Helm.
+- Caller-supplied context.
+- Runtime executor opcional.
+- Structured outputs via JSON Schema.
+
+No usar todavía:
+
+- "production-ready" sin downstream smoke real.
+- "KMP-integrated" si Choreographer no consulta KMP.
+- "durable eventing".
+- "real-time deliberation streaming" para turnos internos.
+
+## Orden Recomendado
+
+1. Crear `docs/operations/compose-e2e.md`.
+2. Añadir selector de escenarios al e2e-runner.
+3. Limpiar Kubernetes smoke para que pase contra un deploy real.
+4. Añadir consumer-smoke positive-path.
+5. Completar Helm/operator docs.
+6. Añadir `SECURITY.md`, `CHANGELOG.md`, `CONTRIBUTING.md`.
+7. Cortar release candidate.
+8. Publicar public beta.
+
+## No Hacer Ahora
+
+- No meter PIR en este repo.
+- No implementar JetStream hasta que un consumidor lo necesite.
+- No añadir un adapter KMP propio si `ExternalContextBundle` basta.
+- No priorizar streaming turn-level antes de cerrar instalación,
+  smoke y release.
+
+## Definición De Producto Usable
+
+El producto es usable cuando alguien externo puede:
+
+1. Instalarlo localmente o por Helm.
+2. Crear o listar councils.
+3. Registrar un agent.
+4. Registrar un output contract.
+5. Ejecutar `RunCouncilDecision`.
+6. Recibir un resultado validado.
+7. Conectarlo por MCP.
+8. Ejecutar un smoke reproducible.
+
+## Definición De Producto Publicable
+
+El producto es publicable cuando además:
+
+1. Los límites están documentados sin contradicciones.
+2. El quickstart funciona desde cero.
+3. Los smoke tests no tienen "fallos esperados".
+4. La release produce imagen, chart y binario MCP versionados.
+5. Hay guía de seguridad, contribución, changelog y rollback.
+6. Las claims públicas están respaldadas por tests, E2E o docs de
+   operación reproducibles.

--- a/docs/stack-gap-analysis.md
+++ b/docs/stack-gap-analysis.md
@@ -1,198 +1,140 @@
 # Stack Gap Analysis
 
-Snapshot date: 2026-04-25
+Snapshot date: 2026-05-18
 
-This document records the current gaps between the Choreographer and the
-role it aims to play in the Underpass platform alongside:
+This document records the remaining gaps for Choreographer as an
+independent, domain-agnostic coordination product. The following repos
+are referenced only as studied integrations and possible use cases:
 
 - [underpass-runtime](https://github.com/underpass-ai/underpass-runtime)
 - [rehydration-kernel](https://github.com/underpass-ai/rehydration-kernel)
 
-The goal is not to market readiness. The goal is to state what is wired,
-what is not, and what must change before this service can honestly be
-described as a production peer in that stack.
+The goal is not to market readiness. The goal is to state what is
+wired, what is intentionally out of scope, and what must still be
+proved by a downstream integration. Choreographer does not require
+KMP, PIR, or any specific downstream product to be usable.
 
 ## Scope
 
-This analysis is based on:
+This analysis is based on the local repository docs, chart, contracts,
+CI scripts, and source code in this checkout. It does not assert the
+current implementation state of sibling repositories.
 
-- the local `underpass-ai/underpass-choreographer` checkout
-- repository docs, chart, contracts, and CI scripts in this repo
-- the public README surfaces of `underpass-runtime` and
-  `rehydration-kernel`, fetched via `gh`
+## What Is Wired Today
 
-## What Is Healthy Today
+- The Rust workspace keeps the intended dependency direction:
+  `choreo-core` -> `choreo-app` -> `choreo-adapters` -> `choreo`.
+- The gRPC service exposes and implements the full
+  `underpass.choreo.v1` surface: the generic deliberation/orchestration
+  RPCs, council and agent registry RPCs, trigger ingest, status/metrics,
+  `RunCouncilDecision`, and contract CRUD.
+- Runtime execution is configurable: `CHOREO_EXECUTOR_KIND=noop|runtime`
+  selects either `NoopExecutor` or the gRPC `RuntimeExecutor`.
+- The context boundary is caller-materialized and agnostic.
+  Choreographer accepts a typed `ExternalContextBundle` on tasks and
+  triggers, regardless of whether the caller built it from KMP, RAG, a
+  database, static fixtures, or another source.
+- Structured council outputs are first-class through `OutputContract`,
+  JSON-object validation, required fields, allowed string values, JSON
+  Schema, bounded event-shape validation, and deterministic
+  `NoValidProposal` failure.
+- Provider-backed agent materialization is wired through
+  `DispatchingAgentFactory`. `noop` is always accepted; `anthropic`,
+  `openai`, and `vllm` require matching Cargo features and boot-time
+  provider configuration.
+- Broker semantics are declared honestly as plain core NATS pub/sub.
+  The adapter does not claim JetStream durability, acknowledgement, or
+  replay semantics.
+- Server TLS/mTLS and Runtime client TLS are wired and covered by
+  handshake-level integration tests.
+- The compose E2E runner covers nine scenarios: seeded council,
+  deliberation, missing-council delete, causal metadata over NATS,
+  `Orchestrate -> RuntimeExecutor -> stub-runtime`, strict schema
+  rejection, `ExternalContextBundle` round-trip, positive structured
+  output through a stub OpenAI-compatible agent, and the same Report
+  contract through the vLLM adapter shape.
+- The stdio MCP adapter exposes all 16 gRPC RPCs as `choreo_*` tools
+  and has fixture + live gRPC backends.
 
-- The Rust workspace shape is solid: `core` -> `app` -> `adapters` -> binary.
-- Unit and in-process tests pass locally on the full provider feature
-  matrix.
-- `cargo clippy` passes locally on the full provider feature matrix.
-- Criterion benches compile.
-- Helm lint passes.
-- The local fast-path now matches CI materially better:
-  `just check` includes the contract gate, `quality-gate.sh` uses the
-  same provider feature matrix as CI, and benches are compile-gated
-  locally too.
-- The container-backed integration scripts now fail fast with targeted
-  Docker/Podman socket guidance instead of surfacing an opaque
-  `SocketNotFoundError` from inside Rust.
-- The contract surface is honest about `task_description_template`:
-  it is currently literal producer-supplied text, not a rendered
-  template language.
-- The repo is disciplined about honest caveats in several places,
-  especially around provider wiring and streaming limitations.
+## Remaining Gaps
 
-Local commands validated on this workstation:
+### 1. No Choreographer-owned Context Transport
 
-```bash
-cargo test --workspace --locked
-cargo test --workspace --locked \
-  --features choreo-adapters/agent-anthropic \
-  --features choreo-adapters/agent-openai \
-  --features choreo-adapters/agent-vllm
-cargo clippy --workspace --all-targets --locked \
-  --features choreo-adapters/agent-anthropic \
-  --features choreo-adapters/agent-openai \
-  --features choreo-adapters/agent-vllm \
-  -- -D warnings
-bash scripts/ci/bench-compile.sh
-bash scripts/ci/helm-lint.sh
-```
+The current production boundary is explicit and domain-neutral:
+callers materialize context and pass an `ExternalContextBundle`.
+That keeps the core clean, but it also means the repo does not prove a
+direct transport integration to any specific context system.
 
-Local limitations of this snapshot:
+If a downstream product requires Choreographer to fetch context itself,
+that should be a new port, adapter, and E2E slice for that product.
+Until then, the honest claim is caller-supplied context, not KMP client
+ownership.
 
-- `bash scripts/ci/contract-gate.sh` could not complete here because the
-  AsyncAPI CLI was not installed on this workstation.
-- Container-backed integration suites were not validated end-to-end here
-  because `testcontainers` could not reach a working Docker-compatible
-  socket from the current environment.
+### 2. Real external provider validation is operator-run
 
-## High-Severity Gaps
+The repo-owned E2E path uses `stub-llm` so CI can prove provider-shaped
+adapter contracts without external credentials. A real vLLM endpoint is
+covered by the manual `make e2e-provider-vllm` flow.
 
-### 1. Stack integration is still conceptual, not wired
+That is sufficient for repository CI, but a product deployment still
+needs to run its own provider smoke with its model, credentials,
+network policy, TLS posture, and latency budget.
 
-The Choreographer README positions the service as the coordination plane
-between Kernel and Runtime. The architecture supports that direction, but
-the actual production wiring is not present yet.
+### 3. Consumer-smoke positive path is not the default path
 
-Current blockers:
+`choreo-consumer-smoke` exercises the public gRPC + optional NATS
+surface and proves the strict rejection path against a NoopAgent stack.
+The positive structured-output path exists in compose scenario 8, but
+the smoke harness does not yet ship a first-class mode that registers
+the stub-LLM-backed structured JSON agent and flips
+`report_payload_validates` to `Passed`.
 
-- The binary composes [`NoopExecutor`](../crates/choreo-adapters/src/noop/executor.rs)
-  unconditionally.
-- The binary composes [`NoopAgentFactory`](../crates/choreo-adapters/src/noop/agent_factory.rs)
-  unconditionally.
-- The only wired `AgentFactoryPort` accepts `kind == "noop"` and rejects
-  every real provider kind.
-- There is no Runtime gRPC executor adapter.
-- There is no Kernel adapter or context-rehydration path.
-- There is no end-to-end stack flow that proves:
-  trigger -> rehydrate context -> deliberate -> execute via Runtime.
+This is a harness ergonomics gap, not a missing Choreographer feature.
 
-Practical consequence: today this service is a well-structured
-deliberation service, not yet a fully integrated Underpass coordination
-plane.
+### 4. Compose E2E operations doc is missing
 
-## Medium-Severity Gaps
+The compose stack now includes both `stub-runtime` and `stub-llm`, but
+there is no dedicated operations document for:
 
-### 2. Event correlation is closed end-to-end
+- the nine scenarios and what each proves
+- the stub-LLM OpenAI-compatible surface
+- the hard-coded Report payload
+- `STUB_LLM_LISTEN`
+- when to use `make e2e-compose` versus `make e2e-provider-vllm`
 
-As of 2026-05-11, `EventEnvelope` carries both `correlation_id` and
-`causation_id`, and `TaskMetadata` preserves causal ids from inbound
-triggers through deliberation and orchestration lifecycle events.
-`TaskDispatchedEvent` now records the source trigger id when the task
-was built from an inbound trigger. The e2e-runner publishes a
-`TriggerEvent` on NATS with known causal ids and asserts the resulting
-`DeliberationCompleted` envelope on the outbound bus carries the same
-ids, proving the loop closes over a real stack (not only in unit
-tests).
+The backlog tracks this as `docs/operations/compose-e2e.md`.
 
-Relevant files:
+### 5. Streaming remains phase-level
 
-- [`crates/choreo-core/src/events/envelope.rs`](../crates/choreo-core/src/events/envelope.rs)
-- [`crates/choreo-app/src/usecases/deliberate.rs`](../crates/choreo-app/src/usecases/deliberate.rs)
-- [`crates/choreo-app/src/usecases/orchestrate.rs`](../crates/choreo-app/src/usecases/orchestrate.rs)
-- [`crates/choreo-adapters/src/grpc/mappers/event.rs`](../crates/choreo-adapters/src/grpc/mappers/event.rs)
-- [`crates/choreo-e2e-runner/src/main.rs`](../crates/choreo-e2e-runner/src/main.rs)
+`StreamDeliberation` emits phase transitions and a final winner frame.
+The proto shape reserves payload variants for proposal, critique, and
+revision frames, but those per-turn frames are not emitted yet.
 
-### 3. TLS appears in the chart surface but not in the server wiring
-
-The Helm chart exposes `tls.mode` and `existingSecret`, but the gRPC
-server currently starts with plain `tonic::transport::Server::builder()`
-and no TLS configuration path was found in the binary.
-
-Relevant files:
-
-- [`charts/choreographer/values.yaml`](../charts/choreographer/values.yaml)
-- [`crates/choreo/src/runtime.rs`](../crates/choreo/src/runtime.rs)
-
-Practical consequence: the repo exposes a deployment surface that is not
-backed by the binary yet. In a stack where Runtime and Kernel already
-lean on TLS/mTLS, this is a real operational gap.
-
-### 4. Broker semantics declared honestly as plain NATS
-
-As of 2026-05-11, AsyncAPI declares the broker as plain core NATS
-pub/sub. The adapter (`crates/choreo-adapters/src/nats`) is consistent:
-`client.publish_with_headers` for outbound events,
-`client.subscribe` for inbound triggers, no JetStream stream / durable
-consumer / acknowledgement / replay policy is used.
-
-PIR's first integration is expected to be direct gRPC, not the bus,
-so plain NATS is sufficient. If durable bus coupling becomes a
-requirement, the adapter will need to grow real JetStream semantics
-(stream + durable consumer + ack) and the spec re-declared accordingly.
-
-Relevant files:
-
-- [`specs/asyncapi/choreographer.asyncapi.yaml`](../specs/asyncapi/choreographer.asyncapi.yaml)
-- [`crates/choreo-adapters/src/nats/messaging.rs`](../crates/choreo-adapters/src/nats/messaging.rs)
-- [`crates/choreo-adapters/src/nats/subscriber.rs`](../crates/choreo-adapters/src/nats/subscriber.rs)
+That is an honest product limitation for live agent UIs; synchronous
+callers can use `Deliberate` or the buffered MCP wrapper today.
 
 ## Recommended Hardening Plan
 
-### Phase 2: Real stack integration
-
-Wire the service to the other two Underpass planes.
-
-1. Add a Runtime executor adapter over gRPC.
-2. Add TLS/mTLS-capable client wiring for that Runtime adapter.
-3. Add a dispatching `AgentFactoryPort` in the binary so provider-backed
-   agents can actually be materialized from descriptors.
-4. Define the Kernel integration boundary:
-   whether context is pulled synchronously before deliberation, attached
-   into task attributes upstream, or both.
-5. Add one reproducible stack test proving:
-   trigger -> optional context rehydration -> deliberate -> Runtime
-   execution -> outbound events.
-
-### Phase 3: Transport and operations hardening
-
-Bring the deployment surface up to the standard set by Runtime and
-Kernel.
-
-1. Either implement server TLS/mTLS in the binary and chart, or remove
-   the TLS values until they are real.
-2. Service is plain NATS today (declared 2026-05-11). If durable bus
-   coupling becomes a requirement, implement JetStream stream +
-   durable consumer + ack and re-declare in AsyncAPI.
-3. Propagate `correlation_id` and `trigger_event_id` through the full
-   event lifecycle.
-4. Add a container-backed test that exercises whichever NATS mode is
-   declared as supported.
-5. Add one release-gate stack smoke test that runs against deployed
-   Runtime and Kernel surfaces, not only the Choreographer in isolation.
+1. Add `docs/operations/compose-e2e.md` so operators can interpret the
+   repo-owned E2E stack without reading the runner source.
+2. Add a consumer-smoke positive-path mode that registers an
+   OpenAI-compatible structured JSON agent when a stub or provider
+   endpoint is available.
+3. Keep `make e2e-provider-vllm` as the explicit external-provider
+   validation path and require downstream deployments to run it, or an
+   equivalent provider smoke, before claiming provider readiness.
+4. Only add a Choreographer-owned context adapter if a concrete product
+   needs that ownership boundary. Otherwise keep caller-materialized
+   context as the documented contract.
+5. Treat per-proposal/per-critique/per-revision streaming as a separate
+   additive feature, with tests that prove frame ordering and backpressure.
 
 ## Honest Current Position
 
-As of this snapshot, the Choreographer is:
+The Choreographer is now a real gRPC + NATS + persistence + Runtime
+executor + MCP application with structured-output validation and
+repo-owned stack E2E over stubs.
 
-- a healthy Rust service
-- a credible coordination-plane skeleton
-- a real gRPC + NATS + persistence application
-- not yet an end-to-end integrated peer of Runtime and Kernel
-
-The shortest honest summary is:
-
-> The Choreographer is structurally ready for Underpass stack
-> integration, but the adapters and enforcement needed to make that
-> integration real are still incomplete.
+It is not a product integration by itself. Downstream products still
+own their context materialization, provider credentials, Runtime tool
+catalog, output contracts, and production smoke tests.

--- a/tests/cluster/e2e-job.yaml
+++ b/tests/cluster/e2e-job.yaml
@@ -10,14 +10,16 @@
 #   real deploy. They pass when the choreographer is wired correctly
 #   to its own NATS bus.
 #
-# - Scenarios 5–6 in the current e2e-runner are written for the
-#   compose stub-runtime (they expect a tool named `stub.echo` to
-#   succeed and free-form proposals to be rejected by a strict
-#   JSON Schema). Against the real `underpass-runtime`, the
-#   stub.echo tool is not in the catalog, so scenario 5 surfaces a
-#   `NotFound: runtime resource` from the runtime — proving the
-#   gRPC mTLS path is wired, but failing the assertion. Treat 5–6
-#   as design-for-stub when reading the Job's exit code.
+# - Scenarios 5-9 in the current e2e-runner are compose-shaped:
+#   scenario 5 expects a Runtime tool named `stub.echo`, scenarios
+#   8-9 expect the `stub-llm` OpenAI-compatible sidecar, and
+#   scenario 6 asserts strict rejection of free-form NoopAgent
+#   output. Against a real `underpass-runtime`, `stub.echo` is not
+#   normally in the catalog, so scenario 5 can surface
+#   `NotFound: runtime resource` — proving the gRPC mTLS path was
+#   reached, but failing the assertion. Treat this Job as a targeted
+#   connectivity smoke unless the namespace also provides equivalent
+#   test fixtures.
 #
 # Apply after `helm upgrade --install`. The Job's TTL cleans the
 # resource after 10 min.


### PR DESCRIPTION
## Summary
- Adds the Spanish publication-readiness plan and living checklist.
- Clarifies Choreographer as agnostic and independent from PIR, KMP, and downstream products.
- Updates README, backlog, stack analysis, and operations docs so public claims match current behavior.

## Validation
- git diff --cached --check
- Markdown relative-link check
