### PR TITLE
[codex] Publication readiness bundle

### DIFF
--- a/.github/workflows/publish-distribution.yml
+++ b/.github/workflows/publish-distribution.yml
@@ -1,5 +1,13 @@
 name: publish-distribution
 
+# The two `publish-crate-*` jobs at the bottom need the repo secret
+# `CARGO_REGISTRY_TOKEN` set; without it `cargo publish` fails at the
+# upload step. That is acceptable — the rest of the workflow (image
+# + chart push) still does its job. Tag pushes (`v*`) trigger the
+# crate publish; `workflow_dispatch` deliberately does NOT, so an
+# operator hitting "Run workflow" to re-roll an image cannot
+# accidentally publish to crates.io.
+
 on:
   push:
     branches:
@@ -18,7 +26,7 @@ env:
 
 jobs:
   # Tag-only smoke gate: builds the compose stack and runs the
-  # 8-scenario e2e-runner end-to-end before any image / chart push.
+  # full compose e2e-runner end-to-end before any image / chart push.
   # Plain `main` pushes (which roll the `latest` / `main` image tags)
   # skip this on purpose — GitHub Actions treats a skipped `needs` as
   # success, so `publish-image` / `publish-helm-chart` keep firing.
@@ -139,3 +147,71 @@ jobs:
           for archive in dist/*.tgz; do
             helm push "${archive}" "${CHART_REGISTRY}"
           done
+
+  # crates.io publish for the standalone proto crate. Must land before
+  # `publish-crate-mcp` so the registry index has the dep when the MCP
+  # crate publishes. Tag-only on purpose — `workflow_dispatch` re-rolls
+  # are not allowed to mutate the registry.
+  publish-crate-proto:
+    needs: [compose-smoke]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
+        with:
+          toolchain: 1.90.0
+
+      - name: Install protoc
+        run: bash scripts/ci/install-protoc.sh
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+        with:
+          shared-key: publish-crate
+
+      - name: Publish choreo-mcp-proto
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p choreo-mcp-proto --token "${CARGO_REGISTRY_TOKEN}"
+
+  publish-crate-mcp:
+    needs: [publish-crate-proto]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
+        with:
+          toolchain: 1.90.0
+
+      - name: Install protoc
+        run: bash scripts/ci/install-protoc.sh
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+        with:
+          shared-key: publish-crate
+
+      # Give the crates.io index time to propagate the new
+      # `choreo-mcp-proto` version before the MCP publish tries to
+      # resolve it from the registry.
+      - name: Wait for registry propagation
+        run: sleep 30
+
+      - name: Publish choreo-mcp
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p choreo-mcp --token "${CARGO_REGISTRY_TOKEN}"

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -167,6 +167,31 @@ jobs:
       - name: Compile benches
         run: bash scripts/ci/bench-compile.sh
 
+  publish-dry-run:
+    # Catches packaging regressions for the two crates that go to
+    # crates.io (`choreo-mcp-proto` + `choreo-mcp`) before they hit
+    # the publish-distribution workflow. No registry token is
+    # required — `cargo publish --dry-run` and `cargo package -l`
+    # only validate metadata and the file list.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: [contract]
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
+        with:
+          toolchain: 1.90.0
+      - name: Install protoc
+        run: bash scripts/ci/install-protoc.sh
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+      - name: Publish dry-run
+        run: bash scripts/ci/publish-dry-run.sh
+
   sonarcloud:
     runs-on: ubuntu-24.04
     timeout-minutes: 25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,99 @@
+# Changelog
+
+All notable changes to the Underpass Choreographer are tracked here.
+
+This repository has not cut a public `v*` tag yet. The workspace and
+Helm chart currently carry version `0.1.0`; keep entries under
+`Unreleased` until the release process in `docs/release.md` creates an
+immutable tag and published artifacts.
+
+The format follows the spirit of Keep a Changelog, with categories kept
+short and factual. Do not add claims here unless the behavior is
+implemented and covered by a committed gate, smoke test, or documented
+operator command.
+
+## Unreleased
+
+### Added
+
+- Product usability and publication planning:
+  `docs/product-usability-publication-plan.md` and
+  `docs/product-publication-checklist.md`.
+- Explicit documentation that Choreographer is agnostic and
+  independently usable; KMP, PIR, Runtime, and other projects are study
+  cases or optional integrations, not required dependencies.
+- Local no-external-service quickstart:
+  `CHOREO_NATS_ENABLED=false just run`.
+- MCP fixture and live-gRPC quickstarts, plus examples for
+  `CreateCouncil`, `RegisterAgent`, `RegisterContract`,
+  `RunCouncilDecision`, and `Orchestrate`.
+- Repo-owned compose E2E guide covering the nine scenarios, stubs,
+  Report schema, and provider-shaped OpenAI/vLLM paths.
+- E2E runner scenario selection through `CHOREO_E2E_SCENARIOS`, with
+  groups for `compose`, `cluster-connectivity`, `runtime-stub`, and
+  `structured-output`.
+- Consumer smoke `positive-path`, including Report contract
+  registration, Strict-mode `RunCouncilDecision`, provider-shaped
+  OpenAI/vLLM agents, and optional NATS causality assertions.
+- Helm install profiles for minimal standalone, embedded NATS,
+  Postgres DSN from Secret, provider environment Secret wiring, and the
+  Underpass Runtime executor profile.
+- Kubernetes deployment guide covering minimal install, embedded NATS,
+  gRPC TLS/mTLS, Postgres secret sourcing, provider environment
+  secrets, Runtime executor TLS, and operator smokes.
+- Support matrix covering Rust toolchain, image tags, chart versions,
+  provider adapters, and Kubernetes posture.
+- Upgrade, rollback, and operator deploy verification runbooks for
+  pinned images, Secret references, OCI chart installs, and smoke
+  checks.
+- Security policy covering supported scope, private vulnerability
+  reporting, coordinated disclosure, deployment hardening, and secret
+  containment.
+
+### Changed
+
+- Kubernetes E2E jobs default to cluster-connectivity scenarios instead
+  of running fixture-only stub scenarios against real deployments.
+- `make e2e-compose` keeps the full compose group as the fixture-backed
+  end-to-end path.
+- Helm render checks now cover pinned-image enforcement, TLS secret
+  validation, embedded NATS wiring, Runtime executor failure modes,
+  Postgres Secret rendering, and provider env Secret rendering.
+
+### Validation
+
+- MCP catalog parity is checked against the gRPC proto surface.
+- Compose E2E has been validated through all nine scenarios, including
+  structured Report output and provider-shaped paths.
+- Kubernetes smoke has been validated with the selected
+  cluster-connectivity group.
+- `choreo-consumer-smoke` has been validated for rejection-path and
+  positive-path behavior against local Choreographer, NATS, and
+  `choreo-stub-llm`.
+
+### Security
+
+- Provider credentials, Postgres DSNs, and TLS materials are documented
+  as secret-managed inputs, not values-file or descriptor content.
+- Chart gates assert hardened pod defaults and prevent accidental
+  rendering of literal Postgres DSNs in the Secret-backed profile.
+
+### Known Limits
+
+- No public immutable `v*` tag, release image, OCI chart, or crates.io
+  package has been cut yet; current published `sha-*` images are RC
+  smoke artifacts, not stable release artifacts.
+- `choreo-mcp` can only be published after `choreo-mcp-proto v0.1.0`
+  is available in crates.io.
+- Provider-backed positive smokes are validated with deterministic
+  OpenAI-compatible stubs unless a real provider is explicitly wired by
+  the operator.
+- The Helm chart does not manage Ingress, provider egress allow-lists,
+  or multi-replica/state coordination beyond the documented single
+  replica posture.
+
+## 0.1.0 - Pending
+
+- Initial pre-release version present in `Cargo.toml` and
+  `charts/choreographer/Chart.yaml`.
+- No immutable `v0.1.0` tag is present in this checkout yet.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,209 @@
+# Contributing
+
+This repository is the Underpass Choreographer. Contributions should
+keep it independently usable, use-case agnostic, provider-agnostic, and
+API-first.
+
+Start here:
+
+- `docs/PRINCIPLES.md` for the engineering rules this repo enforces.
+- `docs/dev-loop.md` for setup and local commands.
+- `.github/pull_request_template.md` for the PR checklist.
+- `SECURITY.md` for vulnerability reporting and secret handling.
+- `CHANGELOG.md` for unreleased release notes.
+
+## What Belongs Here
+
+Choreographer-owned work includes:
+
+- gRPC contracts under `crates/choreo-proto/proto/underpass/choreo/v1`;
+- AsyncAPI event contracts under `specs/asyncapi`;
+- council, agent, deliberation, output-contract, and orchestration
+  behavior;
+- MCP exposure of the Choreographer gRPC surface;
+- provider adapter boundaries that stay behind `AgentPort`;
+- Runtime executor integration as an optional executor adapter;
+- container image, Helm chart, and repo-owned smoke/E2E tooling.
+
+Work that belongs elsewhere:
+
+- KMP, PIR, Runtime, or product-specific business workflows;
+- domain vocabulary in core contracts or chart defaults;
+- provider-specific behavior in `choreo-core`;
+- deployment credentials, private endpoints, customer data, or secrets.
+
+Use `attributes`, `payload`, or `google.protobuf.Struct` for
+deployment-specific metadata. Do not add typed public contract fields
+for one product or one use case.
+
+## Local Setup
+
+Use the setup in `docs/dev-loop.md`. Minimum tools:
+
+- Rust `1.90.0`;
+- `just`;
+- `buf`;
+- AsyncAPI CLI;
+- `protoc`;
+- Docker or Podman for container-backed gates.
+
+The smallest local run has no external dependencies:
+
+```bash
+CHOREO_NATS_ENABLED=false just run
+```
+
+Without `just`:
+
+```bash
+CHOREO_NATS_ENABLED=false cargo run --locked -p choreo
+```
+
+## Development Workflow
+
+1. Sync from `main`.
+2. Create a branch with a narrow scope.
+3. Make the contract change first when public API or event shape
+   changes.
+4. Add or update tests before relying on the behavior in docs.
+5. Update docs and `CHANGELOG.md` when the user-facing surface changes.
+6. Run the relevant gates locally.
+7. Open a PR using `.github/pull_request_template.md`.
+
+Prefer small PRs. If a change touches contracts, runtime behavior, the
+Helm chart, and docs at once, explain why that coupling is necessary.
+
+## Required Gates
+
+Before opening a normal PR:
+
+```bash
+just check
+just helm-lint
+```
+
+Equivalent without `just`:
+
+```bash
+bash scripts/ci/quality-gate.sh
+bash scripts/ci/helm-lint.sh
+```
+
+Run container-backed integration when touching NATS, Postgres,
+persistence, messaging, container runtime behavior, or testcontainers
+setup:
+
+```bash
+just integration
+```
+
+Run full E2E before release work or when changing compose, Kubernetes
+jobs, Helm install behavior, provider-shaped E2E, or cross-service
+smoke paths:
+
+```bash
+make e2e-compose
+make e2e-kubernetes
+```
+
+Run consumer smoke when changing the public gRPC behavior that
+downstream consumers rely on:
+
+```bash
+cargo run -p choreo-consumer-smoke --locked -- \
+  --endpoint http://127.0.0.1:50055 \
+  --chain all
+```
+
+If a gate cannot be run locally, say so in the PR and explain what was
+run instead.
+
+## Contract Changes
+
+Choreographer is API-first:
+
+- gRPC source: `crates/choreo-proto/proto/underpass/choreo/v1/choreo.proto`;
+- AsyncAPI source: `specs/asyncapi/choreographer.asyncapi.yaml`.
+
+For public-surface changes:
+
+1. Update the spec first.
+2. Regenerate code if generated files are affected.
+3. Update MCP parity if the gRPC surface changes.
+4. Update docs and examples.
+5. Run `just contract` or `bash scripts/ci/contract-gate.sh`.
+
+Breaking changes must be intentional and called out in the PR. The
+contract gate compares against `origin/main` when available.
+
+## Testing Expectations
+
+Match test scope to risk:
+
+- Pure domain logic: unit tests in the owning crate.
+- Adapter logic: adapter tests plus integration tests where the external
+  boundary matters.
+- gRPC/MCP surface: proto/API tests and MCP parity tests.
+- Event shape: AsyncAPI validation and event-shape tests.
+- Helm changes: `bash scripts/ci/helm-lint.sh` plus render assertions
+  for any new hardening or failure path.
+- User workflows: consumer smoke, compose E2E, or Kubernetes E2E.
+
+Do not document a behavior as supported until a committed test, smoke,
+or operator command proves it.
+
+## Documentation
+
+Update docs in the same PR as behavior changes:
+
+- Add new operational docs to `docs/index.md`.
+- Add release-note entries to `CHANGELOG.md` under `Unreleased`.
+- Update `README.md` only for first-contact or product-surface changes.
+- Keep research and case-study docs clearly labeled as such.
+- Keep KMP, PIR, Runtime, and other project references framed as
+  optional use cases or integrations unless the code truly requires
+  them.
+
+Use factual language. Performance, coverage, quality, and hardening
+claims need a gate, experiment, benchmark, or reproducible command in
+the repository.
+
+## Security Rules
+
+- Never commit secrets, tokens, private keys, private endpoints, or
+  customer data.
+- Do not place provider credentials in agent descriptors or values
+  files.
+- Use Kubernetes Secrets, secret managers, or `valueFrom.secretKeyRef`
+  for sensitive deployment input.
+- Report vulnerabilities through `SECURITY.md`, not public issues with
+  exploit details.
+- If a change affects TLS/mTLS, secret rendering, provider credentials,
+  container hardening, or NetworkPolicy, add a chart/test gate that
+  would fail if the security property regressed.
+
+## Commit and PR Style
+
+Prefer concise, imperative commits. Existing history commonly uses:
+
+- `feat(scope): ...`
+- `fix(scope): ...`
+- `docs(scope): ...`
+- `test(scope): ...`
+- `chore: ...`
+
+PR descriptions should lead with what changed and why it belongs in the
+Choreographer. Include the gates run and any gate you could not run.
+
+## Release Work
+
+Releases are maintainer-owned and follow `docs/release.md`.
+
+Do not create or move `v*` tags manually. Use:
+
+```bash
+just version X.Y.Z
+just release X.Y.Z
+```
+
+Only release from merged `main` after the release checklist gates pass.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,17 +588,28 @@ name = "choreo-mcp"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "choreo-proto",
+ "choreo-mcp-proto",
  "futures",
  "opentelemetry",
  "prost-types",
  "serde_json",
  "sha2",
+ "testcontainers",
  "time",
  "tokio",
  "tonic",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "choreo-mcp-proto"
+version = "0.1.0"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/choreo-app",
     "crates/choreo-adapters",
     "crates/choreo-proto",
+    "crates/choreo-mcp-proto",
     "crates/choreo",
     "crates/choreo-tests-integration",
     "crates/choreo-e2e-runner",
@@ -105,11 +106,12 @@ sha2 = "0.10"
 jsonschema = { version = "0.17", default-features = false }
 
 # internal
-choreo-core = { path = "crates/choreo-core" }
-choreo-app = { path = "crates/choreo-app" }
-choreo-adapters = { path = "crates/choreo-adapters" }
-choreo-proto = { path = "crates/choreo-proto" }
-choreo-tests-integration = { path = "crates/choreo-tests-integration" }
+choreo-core = { path = "crates/choreo-core", version = "0.1.0" }
+choreo-app = { path = "crates/choreo-app", version = "0.1.0" }
+choreo-adapters = { path = "crates/choreo-adapters", version = "0.1.0" }
+choreo-proto = { path = "crates/choreo-proto", version = "0.1.0" }
+choreo-mcp-proto = { path = "crates/choreo-mcp-proto", version = "0.1.0" }
+choreo-tests-integration = { path = "crates/choreo-tests-integration", version = "0.1.0" }
 
 [profile.release]
 lto = "thin"

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ VERSION ?=
 	help \
 	contract fmt-check fmt clippy test bench-compile check \
 	integration-nats integration-postgres integration \
-	e2e-compose e2e-kubernetes e2e-provider-vllm \
+	e2e-compose e2e-kubernetes e2e-provider-vllm e2e-council-vllm \
 	consumer-smoke \
 	helm-lint build-image build-provider-image \
 	run run-otel \
@@ -24,6 +24,7 @@ help:
 		'  make e2e-compose            # manual E2E via docker/podman compose or podman-compose' \
 		'  make e2e-kubernetes         # manual E2E via Kubernetes Job' \
 		'  make e2e-provider-vllm      # provider-level vLLM E2E' \
+		'  make e2e-council-vllm       # Choreographer council E2E against real vLLM' \
 		'  make consumer-smoke         # drive the public RPC + bus surface as a consumer would' \
 		'  make helm-lint              # helm lint + hardened render assertions' \
 		'  make build-image            # production container image' \
@@ -69,6 +70,9 @@ e2e-kubernetes:
 
 e2e-provider-vllm:
 	bash scripts/ci/e2e-provider-vllm.sh
+
+e2e-council-vllm:
+	bash scripts/ci/e2e-council-vllm.sh
 
 consumer-smoke:
 	cargo run -p choreo-consumer-smoke -- \

--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ all that is injected via configuration and proto messages.
   every command mirrors a CI gate.
 - [`docs/release.md`](docs/release.md) — versioning + cut-a-release
   checklist.
+- [`CHANGELOG.md`](CHANGELOG.md) — unreleased changes and release-note
+  discipline.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — contribution workflow,
+  required gates, contract rules, and PR expectations.
+- [`SECURITY.md`](SECURITY.md) — supported security scope,
+  vulnerability reporting, and deployment hardening baseline.
+- [`docs/operations/deploy-kubernetes.md`](docs/operations/deploy-kubernetes.md)
+  — Helm install guide, including minimal standalone install and
+  embedded NATS, TLS/mTLS, Postgres secret, provider env secrets,
+  and Runtime executor options.
+- [`docs/operations/support-matrix.md`](docs/operations/support-matrix.md)
+  — supported Rust toolchain and release-support rules.
 - [`docs/PRINCIPLES.md`](docs/PRINCIPLES.md) — honesty discipline.
 - [`docs/experiments/`](docs/experiments/) — append-only lab
   notebook (baselines, scale sweeps, null results).
@@ -41,6 +53,40 @@ all that is injected via configuration and proto messages.
   status + session log.
 - `justfile` at the repo root — `just` lists every recipe.
 
+## Run Locally Without External Services
+
+```sh
+CHOREO_NATS_ENABLED=false just run
+```
+
+This starts the Choreographer binary with in-memory persistence,
+noop messaging, and the default noop executor. It serves the gRPC API
+on `localhost:50055` without requiring NATS, Postgres, Runtime, KMP,
+PIR, or provider credentials. For an immediately exercisable local
+council, add `CHOREO_SEED_SPECIALTIES=triage`.
+
+If `just` is not installed:
+
+```sh
+CHOREO_NATS_ENABLED=false cargo run --locked -p choreo
+```
+
+For MCP client wiring without a running Choreographer:
+
+```sh
+CHOREO_MCP_BACKEND=fixture choreo-mcp
+```
+
+That starts the stdio MCP adapter in fixture mode. See
+[`docs/operations/mcp-stdio.md`](docs/operations/mcp-stdio.md) for
+terminal smoke commands and live gRPC configuration.
+
+To point MCP at the local Choreographer from a second terminal:
+
+```sh
+CHOREO_MCP_GRPC_ENDPOINT=http://127.0.0.1:50055 choreo-mcp
+```
+
 ## Workspace
 
 | Crate | Purpose |
@@ -49,6 +95,7 @@ all that is injected via configuration and proto messages.
 | `choreo-app` | Use cases / application services. |
 | `choreo-adapters` | NATS, gRPC clients, config, external integrations. |
 | `choreo-proto` | Tonic-generated gRPC code (`underpass.choreo.v1`). |
+| `choreo-mcp-proto` | Vendored `underpass.choreo.v1` proto crate used to publish `choreo-mcp` independently. |
 | `choreo` | Binary: wires adapters, runs gRPC + NATS. |
 | `choreo-mcp` | Stdio MCP adapter that exposes every gRPC RPC as an MCP tool. |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,141 @@
+# Security Policy
+
+This repository is the security boundary for the Underpass
+Choreographer: the gRPC API, MCP adapter, event contracts, provider
+adapter wiring, container image, and Helm chart in this checkout.
+
+The Choreographer is product-agnostic and independently deployable. It
+does not require KMP, PIR, Runtime, or any downstream product to run.
+Security issues in sibling projects should be reported to those
+projects unless the impact crosses into this repository's code,
+protocols, images, or chart.
+
+## Supported Versions
+
+Until the first public stable release, security fixes are supported on:
+
+- `main`;
+- the current release-candidate branch, if one exists;
+- the latest published container image and Helm chart for the current
+  release candidate, when they exist.
+
+Older experiments, historical design documents, local-only demo
+profiles, and unpublished prototype branches are not maintained as
+security-supported versions.
+
+After the first stable release, this policy should be updated with an
+explicit version matrix before older release lines are promised support.
+
+## Reporting a Vulnerability
+
+Do not open a public issue with exploit details, credentials, private
+URLs, logs containing secrets, or proof-of-concept payloads that would
+let another party reproduce the issue.
+
+Preferred private channel:
+
+- GitHub private vulnerability reporting:
+  <https://github.com/underpass-ai/underpass-choreographer/security/advisories/new>
+
+If that channel is unavailable, contact the maintainers through the
+private project channel already used for the deployment or customer
+environment. Public issues may be used only for non-sensitive tracking
+after maintainers have acknowledged the report and agreed on wording.
+
+Include as much of this as you can safely share:
+
+- affected commit, tag, image digest, or chart version;
+- deployment profile (`values.minimal.yaml`, embedded NATS, Postgres,
+  TLS/mTLS, Runtime executor, provider adapters, or custom values);
+- the exact security impact and who can trigger it;
+- minimal reproduction steps;
+- relevant logs with secrets redacted;
+- whether the issue is already exploited or only theoretical.
+
+Until a formal commercial SLA exists, response is best-effort. Reports
+with credible secret exposure, remote code execution, authentication
+bypass, privilege escalation, or cross-tenant data exposure are treated
+as release-blocking work before feature work.
+
+## Coordinated Disclosure
+
+Maintainers will avoid publishing exploit details before a fix,
+mitigation, or clear non-impact conclusion is available. Reporters are
+asked to keep the issue private during triage and fix preparation.
+
+When a fix is released, the public advisory should include:
+
+- affected versions or commits;
+- fixed versions or image digests;
+- required operator action, such as key rotation or chart upgrade;
+- a concise impact statement;
+- credit if the reporter wants it.
+
+## Operational Security Baseline
+
+The project tries to keep security claims tied to code, chart render
+checks, or tests. Current baseline expectations:
+
+- Pin production images by digest. The chart refuses an unpinned default
+  image and refuses `latest` unless the development escape hatch is set.
+- Keep provider credentials, Postgres DSNs, TLS keys, and client certs
+  in a secret manager or Kubernetes Secret. Do not put credentials in
+  agent descriptors, output contracts, values files, examples, Git
+  history, or public issues.
+- Enable gRPC TLS or mTLS for non-local deployments that cross trust
+  boundaries. Plain gRPC profiles are for local smoke, isolated
+  in-cluster development, or environments protected by another trusted
+  transport layer.
+- Use NetworkPolicy or equivalent controls to restrict inbound gRPC and
+  HTTP health ports, and outbound DNS, NATS, Postgres, OTLP, Runtime,
+  and provider endpoints to the minimum required set.
+- Keep the default non-root container posture: read-only root
+  filesystem, all Linux capabilities dropped, `RuntimeDefault` seccomp,
+  and no mounted service account token unless a deployment has a
+  specific reason to change it.
+- Treat MCP clients as API clients. If MCP connects to a hardened
+  Choreographer deployment, configure the MCP gRPC backend with the
+  same TLS or mTLS posture.
+- Provider adapters are enabled only when the binary is built with the
+  relevant feature and the required environment variables are present.
+  Startup logs expose provider kinds, not secret values.
+
+## Secrets and Incident Containment
+
+If a Choreographer deployment may have exposed secrets:
+
+1. Revoke or rotate provider API keys and bearer tokens.
+2. Rotate Postgres DSNs, NATS credentials embedded in URLs, TLS
+   certificates, and MCP client certificates that could have been read.
+3. Redeploy with a pinned fixed image digest and reviewed Helm values.
+4. Check Choreographer logs, provider logs, Postgres access logs, NATS
+   logs, and Kubernetes audit logs for unexpected access.
+5. Re-register affected agents or contracts only after confirming they
+   do not contain credentials.
+
+Do not rely on agent descriptors as a secret store. Descriptors may be
+persisted and are part of the API surface.
+
+## What To Report
+
+Useful reports include:
+
+- secret leakage through logs, Debug output, events, MCP responses,
+  gRPC responses, rendered manifests, or persisted descriptors;
+- chart hardening regressions, such as dropped security contexts,
+  missing TLS secret validation, accidental plaintext DSN rendering, or
+  service account token mounting;
+- bypasses of output-contract validation in Strict mode;
+- unsafe provider credential handling;
+- unauthenticated access paths in a deployment mode that claims TLS or
+  mTLS protection;
+- dependency vulnerabilities with a reachable path in this repository.
+
+Expected behavior that is not a vulnerability by itself:
+
+- the minimal and embedded-NATS profiles use plaintext in-cluster gRPC
+  unless TLS is explicitly enabled;
+- fixture, noop, and stub components are not production provider
+  security boundaries;
+- legacy PIR or KMP study documents are not deployment requirements for
+  this repository.

--- a/charts/choreographer/templates/deployment.yaml
+++ b/charts/choreographer/templates/deployment.yaml
@@ -177,6 +177,13 @@ spec:
             {{- fail "persistence.postgres.enabled=true requires either persistence.postgres.url or persistence.postgres.urlFromSecret.{name,key}" }}
             {{- end }}
             {{- end }}
+            {{- with .Values.providerEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.providerEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.probes.liveness.enabled }}
           livenessProbe:
             httpGet:

--- a/charts/choreographer/templates/nats.yaml
+++ b/charts/choreographer/templates/nats.yaml
@@ -60,6 +60,7 @@ spec:
             capabilities:
               drop:
                 - ALL
+          {{- if or .Values.messaging.nats.embedded.jetstream.enabled .Values.messaging.nats.embedded.monitoring.enabled }}
           args:
             {{- if .Values.messaging.nats.embedded.jetstream.enabled }}
             - "-js"
@@ -69,6 +70,7 @@ spec:
             - "-m"
             - "8222"
             {{- end }}
+          {{- end }}
           ports:
             - name: client
               containerPort: 4222

--- a/charts/choreographer/values.embedded-nats.yaml
+++ b/charts/choreographer/values.embedded-nats.yaml
@@ -1,0 +1,44 @@
+# Standalone install profile with a release-local NATS bus.
+#
+# Use this when the Choreographer should publish/consume its event
+# surface but you do not want to provision an external NATS first.
+# Runtime, Postgres, provider secrets, and gRPC TLS stay off.
+
+config:
+  # Seed one NoopAgent + one single-agent council so a fresh install
+  # can answer RunCouncilDecision immediately.
+  seedSpecialties: triage
+
+messaging:
+  nats:
+    enabled: true
+    # Empty URL + embedded.enabled=true resolves to
+    # nats://<release-fullname>-nats:4222 at template time.
+    url: ""
+    publishPrefix: choreo
+    triggerSubject: choreo.trigger.>
+    embedded:
+      enabled: true
+      jetstream:
+        # Core NATS is enough for Choreographer's current fire-and-
+        # forget event surface.
+        enabled: false
+      monitoring:
+        enabled: false
+
+executor:
+  kind: noop
+
+persistence:
+  postgres:
+    enabled: false
+
+tls:
+  mode: none
+  existingSecret: ""
+
+pdb:
+  enabled: false
+
+networkPolicy:
+  enabled: false

--- a/charts/choreographer/values.minimal.yaml
+++ b/charts/choreographer/values.minimal.yaml
@@ -1,0 +1,34 @@
+# Minimal standalone install profile.
+#
+# This profile is intentionally dependency-free: no NATS, no Postgres,
+# no Runtime executor, and no gRPC TLS. It is meant for first install,
+# smoke testing, and demos where the operator only needs the public
+# gRPC/HTTP surface running inside Kubernetes.
+
+config:
+  # Seed one NoopAgent + one single-agent council so a fresh install
+  # can answer RunCouncilDecision immediately.
+  seedSpecialties: triage
+
+messaging:
+  nats:
+    enabled: false
+    embedded:
+      enabled: false
+
+executor:
+  kind: noop
+
+persistence:
+  postgres:
+    enabled: false
+
+tls:
+  mode: none
+  existingSecret: ""
+
+pdb:
+  enabled: false
+
+networkPolicy:
+  enabled: false

--- a/charts/choreographer/values.postgres-secret.yaml
+++ b/charts/choreographer/values.postgres-secret.yaml
@@ -1,0 +1,41 @@
+# Standalone persistent install profile.
+#
+# This profile keeps the Choreographer independent from Runtime and
+# provider credentials, but persists deliberations, councils, agents,
+# and statistics through a Postgres DSN read from a Kubernetes secret.
+# Output contracts are still registered/seeded separately.
+
+config:
+  seedSpecialties: triage
+
+messaging:
+  nats:
+    enabled: true
+    url: ""
+    publishPrefix: choreo
+    triggerSubject: choreo.trigger.>
+    embedded:
+      enabled: true
+      jetstream:
+        enabled: false
+
+executor:
+  kind: noop
+
+persistence:
+  postgres:
+    enabled: true
+    url: ""
+    urlFromSecret:
+      name: choreographer-postgres-dsn
+      key: url
+
+tls:
+  mode: none
+  existingSecret: ""
+
+pdb:
+  enabled: false
+
+networkPolicy:
+  enabled: false

--- a/charts/choreographer/values.provider-env-secrets.yaml
+++ b/charts/choreographer/values.provider-env-secrets.yaml
@@ -1,0 +1,28 @@
+# Overlay profile for provider adapter environment sourced from a
+# Kubernetes Secret.
+#
+# Use together with an install profile such as values.embedded-nats.yaml:
+#
+#   helm upgrade --install choreographer charts/choreographer \
+#     -f charts/choreographer/values.embedded-nats.yaml \
+#     -f charts/choreographer/values.provider-env-secrets.yaml \
+#     --set image.digest=sha256:REPLACE_ME
+#
+# The referenced Secret should expose CHOREO_* keys such as:
+#   CHOREO_OPENAI_API_KEY
+#   CHOREO_OPENAI_MODEL
+#   CHOREO_OPENAI_ENDPOINT
+#   CHOREO_OPENAI_MAX_TOKENS
+#   CHOREO_VLLM_MODEL
+#   CHOREO_VLLM_ENDPOINT
+#   CHOREO_VLLM_BEARER_TOKEN
+#   CHOREO_VLLM_MAX_TOKENS
+#   CHOREO_VLLM_TIMEOUT_SECS
+#   CHOREO_ANTHROPIC_API_KEY
+#   CHOREO_ANTHROPIC_MODEL
+#   CHOREO_ANTHROPIC_ENDPOINT
+#   CHOREO_ANTHROPIC_MAX_TOKENS
+
+providerEnvFrom:
+  - secretRef:
+      name: choreographer-provider-env

--- a/charts/choreographer/values.underpass-runtime.yaml
+++ b/charts/choreographer/values.underpass-runtime.yaml
@@ -8,12 +8,12 @@
 #   NAMESPACE=underpass-runtime \
 #   RELEASE_NAME=choreographer \
 #   VALUES_FILE=charts/choreographer/values.underpass-runtime.yaml \
-#   IMAGE_TAG=sha-<commit> \
+#   IMAGE_TAG=sha-COMMIT \
 #   ./scripts/ci/deploy-kubernetes.sh
 
 image:
   # Image tag is supplied at deploy time by the script (via
-  # `--set image.tag=sha-<commit>`); see `scripts/ci/deploy-kubernetes.sh`.
+  # `--set image.tag=sha-COMMIT`); see `scripts/ci/deploy-kubernetes.sh`.
   pullPolicy: Always
 
 imagePullSecrets:
@@ -77,7 +77,7 @@ tls:
 # Single replica; bump to 2 once we want PDB + rolling tolerance.
 replicaCount: 1
 
-# Allow `sha-<short>` image tags from CI — they are immutable per
+# Allow `sha-SHORT` image tags from CI — they are immutable per
 # commit, but the chart's default refuses any non-digest reference
 # unless this development knob opts in.
 development:

--- a/charts/choreographer/values.yaml
+++ b/charts/choreographer/values.yaml
@@ -93,6 +93,16 @@ config:
   # deployments register agents through other channels.
   seedSpecialties: ""
 
+# Extra env wiring for provider adapters. These fields are intentionally
+# generic because provider enablement is feature-gated in the binary
+# and env-gated at boot.
+#
+# Use `providerEnv` for individual vars, preferably with
+# `valueFrom.secretKeyRef` for credentials. Use `providerEnvFrom` when
+# an existing Secret or ConfigMap already exposes CHOREO_* keys.
+providerEnv: []
+providerEnvFrom: []
+
 messaging:
   nats:
     enabled: true

--- a/crates/choreo-adapters/src/agents/factory.rs
+++ b/crates/choreo-adapters/src/agents/factory.rs
@@ -18,19 +18,25 @@
 //!   `CHOREO_OPENAI_MAX_TOKENS` (optional)
 //! - `CHOREO_VLLM_MODEL` and `CHOREO_VLLM_ENDPOINT` (both required to
 //!   enable kind=`vllm`); `CHOREO_VLLM_BEARER_TOKEN`,
-//!   `CHOREO_VLLM_MAX_TOKENS` (optional)
+//!   `CHOREO_VLLM_MAX_TOKENS`, `CHOREO_VLLM_TIMEOUT_SECS` (optional)
 //!
 //! Per-descriptor attributes recognised on `create`:
 //!
 //! - `provider.model` (string)
 //! - `provider.endpoint` (string)
 //! - `provider.max_tokens` (number, ≤ `u32::MAX`)
+//! - `provider.timeout_secs` (number, ≤ `u32::MAX`; vLLM only)
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use choreo_core::error::DomainError;
 use choreo_core::ports::{AgentDescriptor, AgentFactoryPort, AgentPort};
+#[cfg(any(
+    feature = "agent-anthropic",
+    feature = "agent-openai",
+    feature = "agent-vllm"
+))]
 use choreo_core::value_objects::Attributes;
 
 use crate::noop::{NoopAgent, NOOP_AGENT_KIND};
@@ -48,9 +54,26 @@ pub const ANTHROPIC_AGENT_KIND: &str = "anthropic";
 pub const OPENAI_AGENT_KIND: &str = "openai";
 pub const VLLM_AGENT_KIND: &str = "vllm";
 
+#[cfg(any(
+    feature = "agent-anthropic",
+    feature = "agent-openai",
+    feature = "agent-vllm"
+))]
 const ATTR_MODEL: &str = "provider.model";
+#[cfg(any(
+    feature = "agent-anthropic",
+    feature = "agent-openai",
+    feature = "agent-vllm"
+))]
 const ATTR_ENDPOINT: &str = "provider.endpoint";
+#[cfg(any(
+    feature = "agent-anthropic",
+    feature = "agent-openai",
+    feature = "agent-vllm"
+))]
 const ATTR_MAX_TOKENS: &str = "provider.max_tokens";
+#[cfg(feature = "agent-vllm")]
+const ATTR_TIMEOUT_SECS: &str = "provider.timeout_secs";
 
 /// Composes provider-specific factories behind a single
 /// [`AgentFactoryPort`].
@@ -81,22 +104,38 @@ impl DispatchingAgentFactory {
     /// strings count as unset so operators can clear a variable without
     /// deleting it.
     pub fn from_env() -> Result<Self, DomainError> {
-        let mut factory = Self::new();
-
-        #[cfg(feature = "agent-anthropic")]
+        #[cfg(not(any(
+            feature = "agent-anthropic",
+            feature = "agent-openai",
+            feature = "agent-vllm"
+        )))]
         {
-            factory.anthropic = load_anthropic_from_env()?;
-        }
-        #[cfg(feature = "agent-openai")]
-        {
-            factory.openai = load_openai_from_env()?;
-        }
-        #[cfg(feature = "agent-vllm")]
-        {
-            factory.vllm = load_vllm_from_env()?;
+            Ok(Self::new())
         }
 
-        Ok(factory)
+        #[cfg(any(
+            feature = "agent-anthropic",
+            feature = "agent-openai",
+            feature = "agent-vllm"
+        ))]
+        {
+            let mut factory = Self::new();
+
+            #[cfg(feature = "agent-anthropic")]
+            {
+                factory.anthropic = load_anthropic_from_env()?;
+            }
+            #[cfg(feature = "agent-openai")]
+            {
+                factory.openai = load_openai_from_env()?;
+            }
+            #[cfg(feature = "agent-vllm")]
+            {
+                factory.vllm = load_vllm_from_env()?;
+            }
+
+            Ok(factory)
+        }
     }
 
     #[cfg(feature = "agent-anthropic")]
@@ -127,20 +166,36 @@ impl DispatchingAgentFactory {
     /// env or builder). Useful for honest startup logging.
     #[must_use]
     pub fn supported_kinds(&self) -> Vec<&'static str> {
-        let mut kinds = vec![NOOP_AGENT_KIND];
-        #[cfg(feature = "agent-anthropic")]
-        if self.anthropic.is_some() {
-            kinds.push(ANTHROPIC_AGENT_KIND);
+        #[cfg(not(any(
+            feature = "agent-anthropic",
+            feature = "agent-openai",
+            feature = "agent-vllm"
+        )))]
+        {
+            vec![NOOP_AGENT_KIND]
         }
-        #[cfg(feature = "agent-openai")]
-        if self.openai.is_some() {
-            kinds.push(OPENAI_AGENT_KIND);
+
+        #[cfg(any(
+            feature = "agent-anthropic",
+            feature = "agent-openai",
+            feature = "agent-vllm"
+        ))]
+        {
+            let mut kinds = vec![NOOP_AGENT_KIND];
+            #[cfg(feature = "agent-anthropic")]
+            if self.anthropic.is_some() {
+                kinds.push(ANTHROPIC_AGENT_KIND);
+            }
+            #[cfg(feature = "agent-openai")]
+            if self.openai.is_some() {
+                kinds.push(OPENAI_AGENT_KIND);
+            }
+            #[cfg(feature = "agent-vllm")]
+            if self.vllm.is_some() {
+                kinds.push(VLLM_AGENT_KIND);
+            }
+            kinds
         }
-        #[cfg(feature = "agent-vllm")]
-        if self.vllm.is_some() {
-            kinds.push(VLLM_AGENT_KIND);
-        }
-        kinds
     }
 }
 
@@ -206,6 +261,11 @@ impl AgentFactoryPort for DispatchingAgentFactory {
 // Env helpers
 // ---------------------------------------------------------------------------
 
+#[cfg(any(
+    feature = "agent-anthropic",
+    feature = "agent-openai",
+    feature = "agent-vllm"
+))]
 fn env_nonempty(key: &str) -> Option<String> {
     std::env::var(key).ok().and_then(|value| {
         let trimmed = value.trim();
@@ -217,6 +277,11 @@ fn env_nonempty(key: &str) -> Option<String> {
     })
 }
 
+#[cfg(any(
+    feature = "agent-anthropic",
+    feature = "agent-openai",
+    feature = "agent-vllm"
+))]
 fn env_u32(key: &str, field: &'static str) -> Result<Option<u32>, DomainError> {
     let Some(raw) = env_nonempty(key) else {
         return Ok(None);
@@ -224,6 +289,24 @@ fn env_u32(key: &str, field: &'static str) -> Result<Option<u32>, DomainError> {
     raw.parse::<u32>()
         .map(Some)
         .map_err(|_| DomainError::InvariantViolated { reason: field })
+}
+
+#[cfg(any(
+    feature = "agent-anthropic",
+    feature = "agent-openai",
+    feature = "agent-vllm"
+))]
+fn env_duration_secs(key: &str, field: &'static str) -> Result<Option<Duration>, DomainError> {
+    let Some(raw) = env_nonempty(key) else {
+        return Ok(None);
+    };
+    let secs = raw
+        .parse::<u64>()
+        .map_err(|_| DomainError::InvariantViolated { reason: field })?;
+    if secs == 0 {
+        return Err(DomainError::MustBeNonZero { field });
+    }
+    Ok(Some(Duration::from_secs(secs)))
 }
 
 #[cfg(feature = "agent-anthropic")]
@@ -279,6 +362,9 @@ fn load_vllm_from_env() -> Result<Option<VllmConfig>, DomainError> {
     if let Some(max_tokens) = env_u32("CHOREO_VLLM_MAX_TOKENS", "vllm.max_tokens")? {
         config = config.with_max_tokens(max_tokens)?;
     }
+    if let Some(timeout) = env_duration_secs("CHOREO_VLLM_TIMEOUT_SECS", "vllm.timeout_secs")? {
+        config = config.with_timeout(timeout);
+    }
     Ok(Some(config))
 }
 
@@ -286,6 +372,11 @@ fn load_vllm_from_env() -> Result<Option<VllmConfig>, DomainError> {
 // Per-descriptor attribute overrides
 // ---------------------------------------------------------------------------
 
+#[cfg(any(
+    feature = "agent-anthropic",
+    feature = "agent-openai",
+    feature = "agent-vllm"
+))]
 fn attr_string<'a>(
     attrs: &'a Attributes,
     key: &'static str,
@@ -307,6 +398,11 @@ fn attr_string<'a>(
     }
 }
 
+#[cfg(any(
+    feature = "agent-anthropic",
+    feature = "agent-openai",
+    feature = "agent-vllm"
+))]
 fn attr_u32(attrs: &Attributes, key: &'static str) -> Result<Option<u32>, DomainError> {
     let Some(value) = attrs.get(key) else {
         return Ok(None);
@@ -314,11 +410,21 @@ fn attr_u32(attrs: &Attributes, key: &'static str) -> Result<Option<u32>, Domain
     if value.is_null() {
         return Ok(None);
     }
-    let n = value.as_u64().and_then(|n| u32::try_from(n).ok()).ok_or(
-        DomainError::InvariantViolated {
-            reason: "agent factory: provider.max_tokens must be a non-negative u32",
-        },
-    )?;
+    let n = value
+        .as_u64()
+        .and_then(|n| u32::try_from(n).ok())
+        .or_else(|| {
+            value.as_f64().and_then(|n| {
+                if n.is_finite() && n >= 0.0 && n.fract() == 0.0 && n <= u32::MAX as f64 {
+                    Some(n as u32)
+                } else {
+                    None
+                }
+            })
+        })
+        .ok_or(DomainError::InvariantViolated {
+            reason: "agent factory: provider numeric override must be a non-negative u32",
+        })?;
     Ok(Some(n))
 }
 
@@ -361,15 +467,23 @@ fn apply_vllm_attributes(
     mut config: VllmConfig,
     attrs: &Attributes,
 ) -> Result<VllmConfig, DomainError> {
+    if let Some(model) = attr_string(attrs, ATTR_MODEL)? {
+        config = config.with_model(model)?;
+    }
     if let Some(endpoint) = attr_string(attrs, ATTR_ENDPOINT)? {
         config = config.with_endpoint(endpoint)?;
     }
     if let Some(max_tokens) = attr_u32(attrs, ATTR_MAX_TOKENS)? {
         config = config.with_max_tokens(max_tokens)?;
     }
-    // VllmConfig has no `with_model`; the model is baked into the
-    // base config at boot. Descriptor overrides for model would
-    // require an explicit setter — out of scope for this slice.
+    if let Some(timeout_secs) = attr_u32(attrs, ATTR_TIMEOUT_SECS)? {
+        if timeout_secs == 0 {
+            return Err(DomainError::MustBeNonZero {
+                field: "vllm.timeout_secs",
+            });
+        }
+        config = config.with_timeout(Duration::from_secs(timeout_secs.into()));
+    }
     Ok(config)
 }
 
@@ -377,8 +491,10 @@ fn apply_vllm_attributes(
 mod tests {
     use super::*;
 
-    use choreo_core::value_objects::{AgentId, AgentKind, Specialty};
+    use choreo_core::value_objects::{AgentId, AgentKind, Attributes, Specialty};
+    #[cfg(any(feature = "agent-anthropic", feature = "agent-vllm"))]
     use serde_json::json;
+    #[cfg(any(feature = "agent-anthropic", feature = "agent-vllm"))]
     use std::collections::BTreeMap;
 
     // Tests touch process-wide env vars. Serialize them with a local
@@ -408,6 +524,7 @@ mod tests {
             "CHOREO_VLLM_ENDPOINT",
             "CHOREO_VLLM_BEARER_TOKEN",
             "CHOREO_VLLM_MAX_TOKENS",
+            "CHOREO_VLLM_TIMEOUT_SECS",
         ] {
             std::env::remove_var(key);
         }
@@ -552,6 +669,69 @@ mod tests {
         std::env::set_var("CHOREO_VLLM_ENDPOINT", "https://vllm.example/v1");
         let factory = DispatchingAgentFactory::from_env().unwrap();
         assert!(factory.supported_kinds().contains(&"vllm"));
+        clear_provider_env();
+    }
+
+    #[cfg(feature = "agent-vllm")]
+    #[tokio::test]
+    async fn vllm_kind_accepts_protobuf_numeric_overrides() {
+        let factory = DispatchingAgentFactory::new().with_vllm(
+            VllmConfig::new("Qwen3.5-9B")
+                .unwrap()
+                .with_endpoint("https://vllm.example")
+                .unwrap(),
+        );
+        let attrs = Attributes::new(BTreeMap::from([
+            (ATTR_MAX_TOKENS.to_owned(), json!(512.0)),
+            (ATTR_TIMEOUT_SECS.to_owned(), json!(300.0)),
+        ]))
+        .unwrap();
+
+        factory
+            .create(descriptor("a-vllm", "vllm", attrs))
+            .await
+            .unwrap();
+    }
+
+    #[cfg(feature = "agent-vllm")]
+    #[tokio::test]
+    async fn vllm_kind_rejects_fractional_numeric_override() {
+        let factory = DispatchingAgentFactory::new().with_vllm(
+            VllmConfig::new("Qwen3.5-9B")
+                .unwrap()
+                .with_endpoint("https://vllm.example")
+                .unwrap(),
+        );
+        let attrs =
+            Attributes::new(BTreeMap::from([(ATTR_MAX_TOKENS.to_owned(), json!(512.5))])).unwrap();
+
+        let err = factory
+            .create(descriptor("a-vllm", "vllm", attrs))
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::InvariantViolated {
+                reason: "agent factory: provider numeric override must be a non-negative u32"
+            }
+        ));
+    }
+
+    #[cfg(feature = "agent-vllm")]
+    #[tokio::test]
+    async fn vllm_kind_rejects_invalid_timeout_env() {
+        let _guard = ENV_LOCK.lock().await;
+        clear_provider_env();
+        std::env::set_var("CHOREO_VLLM_MODEL", "Qwen3.5-9B");
+        std::env::set_var("CHOREO_VLLM_ENDPOINT", "https://vllm.example/v1");
+        std::env::set_var("CHOREO_VLLM_TIMEOUT_SECS", "slow");
+        let err = DispatchingAgentFactory::from_env().unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::InvariantViolated {
+                reason: "vllm.timeout_secs"
+            }
+        ));
         clear_provider_env();
     }
 }

--- a/crates/choreo-adapters/src/agents/factory.rs
+++ b/crates/choreo-adapters/src/agents/factory.rs
@@ -415,7 +415,7 @@ fn attr_u32(attrs: &Attributes, key: &'static str) -> Result<Option<u32>, Domain
         .and_then(|n| u32::try_from(n).ok())
         .or_else(|| {
             value.as_f64().and_then(|n| {
-                if n.is_finite() && n >= 0.0 && n.fract() == 0.0 && n <= u32::MAX as f64 {
+                if n.is_finite() && n >= 0.0 && n.fract() == 0.0 && n <= f64::from(u32::MAX) {
                     Some(n as u32)
                 } else {
                     None

--- a/crates/choreo-adapters/src/agents/prompts.rs
+++ b/crates/choreo-adapters/src/agents/prompts.rs
@@ -60,7 +60,9 @@ pub(super) fn system_prompt_revise(id: &str, specialty: &str) -> String {
          - Address the concrete points raised; keep what already works.\n\
          \n\
          Output contract:\n\
-         - Answer only with the revised proposal body. No preamble."
+         - Answer only with the revised proposal body. No preamble.\n\
+         - If the previous proposal is a JSON object, answer only with a revised JSON object.\n\
+         - Do not wrap JSON in markdown fences, and do not add prose outside the JSON object."
     )
 }
 
@@ -107,7 +109,9 @@ pub(super) fn user_prompt_critique(peer_content: &str, constraints: &TaskConstra
     if let Some(output_contract) = serialize_output_contract(constraints.output_contract()) {
         let _ = write!(
             prompt,
-            "\n\nStructured output contract to enforce while critiquing:\n{output_contract}"
+            "\n\nStructured output contract to enforce while critiquing:\n{output_contract}\n\n\
+             In your critique, explicitly tell the peer to keep the revision as a JSON object only, \
+             preserve required fields, remove fields not allowed by the contract, and avoid markdown fences."
         );
     }
 
@@ -119,6 +123,9 @@ pub(super) fn user_prompt_revise(own_content: &str, critique: &Critique) -> Stri
     format!(
         "Your previous proposal:\n---\n{own_content}\n---\n\n\
          Critique to address:\n---\n{feedback}\n---\n\n\
+         Formatting rule:\n\
+         If the previous proposal is JSON, produce only the revised JSON object. \
+         Do not include analysis, markdown, or text before or after the JSON.\n\n\
          Produce the revised proposal now.",
         feedback = critique.feedback,
     )
@@ -286,6 +293,7 @@ mod tests {
         let s = user_prompt_critique(r#"{"decision":"emit_event"}"#, &constraints);
         assert!(s.contains("Structured output contract"));
         assert!(s.contains("decision-contract"));
+        assert!(s.contains("JSON object only"));
     }
 
     #[test]
@@ -298,6 +306,7 @@ mod tests {
         );
         assert!(s.contains("v1 body"));
         assert!(s.contains("tighten the rubric"));
+        assert!(s.contains("produce only the revised JSON object"));
     }
 
     fn sample_external_context() -> ExternalContextBundle {

--- a/crates/choreo-adapters/src/agents/vllm.rs
+++ b/crates/choreo-adapters/src/agents/vllm.rs
@@ -180,6 +180,17 @@ impl VllmConfig {
         Ok(self)
     }
 
+    pub fn with_model(mut self, model: impl Into<String>) -> Result<Self, DomainError> {
+        let value = model.into().trim().to_owned();
+        if value.is_empty() {
+            return Err(DomainError::EmptyField {
+                field: "vllm.model",
+            });
+        }
+        self.model = value;
+        Ok(self)
+    }
+
     #[must_use]
     pub fn with_bearer(mut self, bearer: VllmBearerToken) -> Self {
         self.bearer = Some(bearer);
@@ -468,6 +479,17 @@ mod tests {
     }
 
     #[test]
+    fn empty_model_override_is_rejected() {
+        let cfg = VllmConfig::new("m").unwrap();
+        assert!(matches!(
+            cfg.with_model("  ").unwrap_err(),
+            DomainError::EmptyField {
+                field: "vllm.model"
+            }
+        ));
+    }
+
+    #[test]
     fn zero_max_tokens_is_rejected() {
         let cfg = VllmConfig::new("m").unwrap();
         assert!(matches!(
@@ -670,6 +692,35 @@ mod tests {
             .await;
 
         test_agent(&server).generate(draft()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn request_body_honors_model_override() {
+        use wiremock::matchers::body_string_contains;
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .and(body_string_contains(r#""model":"google/gemma-4-31B-it""#))
+            .respond_with(ResponseTemplate::new(200).set_body_json(chat_response("ok")))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let config = VllmConfig::new("base-model")
+            .unwrap()
+            .with_model("google/gemma-4-31B-it")
+            .unwrap()
+            .with_endpoint(server.uri())
+            .unwrap();
+        let agent = VllmAgent::new(
+            AgentId::new("vllm-1").unwrap(),
+            Specialty::new("triage").unwrap(),
+            config,
+        )
+        .unwrap();
+
+        agent.generate(draft()).await.unwrap();
     }
 
     // --- error handling -------------------------------------------------

--- a/crates/choreo-adapters/src/grpc/mappers/proposal.rs
+++ b/crates/choreo-adapters/src/grpc/mappers/proposal.rs
@@ -12,6 +12,7 @@ pub fn proposal_to_proto(p: &Proposal) -> pb::Proposal {
         author_agent_id: p.author().as_str().to_owned(),
         content: p.content().to_owned(),
         metadata: Some(attributes_to_struct(p.attributes())),
+        revision_count: p.revision_count(),
     }
 }
 
@@ -37,5 +38,6 @@ mod tests {
         assert_eq!(pb.author_agent_id, "a1");
         assert_eq!(pb.content, "hello");
         assert!(pb.metadata.is_some());
+        assert_eq!(pb.revision_count, 0);
     }
 }

--- a/crates/choreo-adapters/src/grpc/mappers/run_council_decision.rs
+++ b/crates/choreo-adapters/src/grpc/mappers/run_council_decision.rs
@@ -165,6 +165,7 @@ fn candidate_summary_from_ranked(outcome: &RankedOutcome) -> pb::CandidateSummar
             .collect(),
         rank: outcome.rank(),
         passed: outcome.outcome().all_passed(),
+        revision_count: outcome.proposal().revision_count(),
     }
 }
 

--- a/crates/choreo-consumer-smoke/src/chain2.rs
+++ b/crates/choreo-consumer-smoke/src/chain2.rs
@@ -30,7 +30,8 @@ use crate::bundle::deterministic_bundle;
 use crate::outcome::{AssertionRecord, ChainOutcome};
 use crate::{Harness, HarnessConfig};
 
-const DEFAULT_REPORT_SCHEMA_PATH: &str = "api/examples/output-contracts/report.schema.json";
+pub(crate) const DEFAULT_REPORT_SCHEMA_PATH: &str =
+    "api/examples/output-contracts/report.schema.json";
 
 /// Read the Report schema from the path given by
 /// `CHOREO_REPORT_SCHEMA_PATH` (falling back to the in-repo default)
@@ -259,7 +260,7 @@ pub async fn run_chain_2_with_schema(
 /// scope; that keeps the API of this helper simple (just `&str` in,
 /// `AssertionRecord` out) at the cost of a slightly nested control
 /// flow.
-fn validate_payload_against_schema(
+pub(crate) fn validate_payload_against_schema(
     schema_json: &str,
     content: &str,
     duration: Duration,

--- a/crates/choreo-consumer-smoke/src/lib.rs
+++ b/crates/choreo-consumer-smoke/src/lib.rs
@@ -1,7 +1,7 @@
 //! Generic consumer-smoke harness for the Choreographer's public
 //! surface (Epic 12).
 //!
-//! Two chains live here. Both drive the choreographer through its
+//! Three chains live here. They drive the choreographer through its
 //! supported APIs (`tonic` gRPC client + `async-nats` core publisher
 //! and subscriber) and report a typed [`ChainOutcome`] so callers can
 //! assert against structured fields rather than parse strings.
@@ -16,8 +16,12 @@
 //!   (the JSON Schema lives at
 //!   `api/examples/output-contracts/report.schema.json`),
 //!   run a Strict deliberation, assert the rejection path against
-//!   the compose stack's `NoopAgent` (the positive path remains
-//!   `Skipped` until a stub-LLM that emits structured JSON ships).
+//!   the compose stack's `NoopAgent`.
+//!
+//! - [`positive`] — opt-in provider-backed positive path. Register an
+//!   `openai` or `vllm` agent against an OpenAI-compatible endpoint,
+//!   create a council, run `RunCouncilDecision` in Strict mode, and
+//!   validate that the winner satisfies the canonical Report schema.
 //!
 //! The crate is also a thin binary (`bin/choreo-consumer-smoke`)
 //! that a consumer can run against a live cluster.
@@ -27,8 +31,10 @@ pub mod chain1;
 pub mod chain2;
 pub mod harness;
 pub mod outcome;
+pub mod positive;
 
 pub use chain1::run_chain_1;
 pub use chain2::{run_chain_2, run_chain_2_with_schema};
 pub use harness::{Harness, HarnessConfig};
 pub use outcome::{AssertionRecord, AssertionStatus, BusEnvelopeRecord, ChainOutcome};
+pub use positive::{run_positive_path, PositivePathConfig};

--- a/crates/choreo-consumer-smoke/src/main.rs
+++ b/crates/choreo-consumer-smoke/src/main.rs
@@ -15,7 +15,10 @@
 use std::time::Duration;
 
 use choreo_consumer_smoke::outcome::AssertionStatus;
-use choreo_consumer_smoke::{run_chain_1, run_chain_2, ChainOutcome, Harness, HarnessConfig};
+use choreo_consumer_smoke::{
+    run_chain_1, run_chain_2, run_positive_path, ChainOutcome, Harness, HarnessConfig,
+    PositivePathConfig,
+};
 use clap::{Parser, ValueEnum};
 use tracing_subscriber::EnvFilter;
 
@@ -39,6 +42,23 @@ struct Args {
     contract_id: String,
     #[arg(long, value_enum, default_value_t = ChainSelector::All)]
     chain: ChainSelector,
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = ProviderKind::Openai,
+        env = "CONSUMER_SMOKE_PROVIDER_KIND"
+    )]
+    provider_kind: ProviderKind,
+    #[arg(long, env = "CONSUMER_SMOKE_PROVIDER_ENDPOINT")]
+    provider_endpoint: Option<String>,
+    #[arg(
+        long,
+        env = "CONSUMER_SMOKE_PROVIDER_MODEL",
+        default_value = "stub-report-v1"
+    )]
+    provider_model: String,
+    #[arg(long, env = "CONSUMER_SMOKE_POSITIVE_SPECIALTY")]
+    positive_specialty: Option<String>,
     #[arg(long, default_value_t = 30)]
     connect_budget_secs: u64,
 }
@@ -47,7 +67,24 @@ struct Args {
 enum ChainSelector {
     One,
     Two,
+    #[value(name = "positive-path", alias = "positive", alias = "three")]
+    PositivePath,
     All,
+}
+
+#[derive(ValueEnum, Clone, Debug, PartialEq, Eq)]
+enum ProviderKind {
+    Openai,
+    Vllm,
+}
+
+impl ProviderKind {
+    const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Openai => "openai",
+            Self::Vllm => "vllm",
+        }
+    }
 }
 
 #[tokio::main]
@@ -83,21 +120,57 @@ async fn run() -> i32 {
     };
 
     let mut outcomes: Vec<ChainOutcome> = Vec::new();
-    if args.chain == ChainSelector::One || args.chain == ChainSelector::All {
-        match run_chain_1(&mut harness, &cfg).await {
-            Ok(o) => outcomes.push(o),
-            Err(err) => {
-                eprintln!("error: chain1 failed to run: {err:#}");
+    match args.chain {
+        ChainSelector::One => {
+            if run_chain_one(&mut harness, &cfg, &mut outcomes)
+                .await
+                .is_err()
+            {
                 return 2;
             }
         }
-    }
-    if args.chain == ChainSelector::Two || args.chain == ChainSelector::All {
-        match run_chain_2(&mut harness, &cfg).await {
-            Ok(o) => outcomes.push(o),
-            Err(err) => {
-                eprintln!("error: chain2 failed to run: {err:#}");
+        ChainSelector::Two => {
+            if run_chain_two(&mut harness, &cfg, &mut outcomes)
+                .await
+                .is_err()
+            {
                 return 2;
+            }
+        }
+        ChainSelector::All => {
+            // Chain 2 registers the Report contract. Running it first
+            // makes the default smoke usable against a fresh registry
+            // before Chain 1 consumes the same contract in Warn mode.
+            if run_chain_two(&mut harness, &cfg, &mut outcomes)
+                .await
+                .is_err()
+            {
+                return 2;
+            }
+            if run_chain_one(&mut harness, &cfg, &mut outcomes)
+                .await
+                .is_err()
+            {
+                return 2;
+            }
+        }
+        ChainSelector::PositivePath => {
+            let provider_kind = args.provider_kind.as_str().to_owned();
+            let positive_cfg = PositivePathConfig {
+                specialty: args
+                    .positive_specialty
+                    .clone()
+                    .unwrap_or_else(|| format!("consumer-smoke-report-{provider_kind}")),
+                agent_kind: provider_kind,
+                agent_endpoint: args.provider_endpoint.clone(),
+                agent_model: args.provider_model.clone(),
+            };
+            match run_positive_path(&mut harness, &cfg, &positive_cfg).await {
+                Ok(o) => outcomes.push(o),
+                Err(err) => {
+                    eprintln!("error: positive-path failed to run: {err:#}");
+                    return 2;
+                }
             }
         }
     }
@@ -106,6 +179,40 @@ async fn run() -> i32 {
     print_summary(&outcomes);
 
     i32::from(outcomes.iter().any(|o| o.failed_count() > 0))
+}
+
+async fn run_chain_one(
+    harness: &mut Harness,
+    cfg: &HarnessConfig,
+    outcomes: &mut Vec<ChainOutcome>,
+) -> Result<(), ()> {
+    match run_chain_1(harness, cfg).await {
+        Ok(o) => {
+            outcomes.push(o);
+            Ok(())
+        }
+        Err(err) => {
+            eprintln!("error: chain1 failed to run: {err:#}");
+            Err(())
+        }
+    }
+}
+
+async fn run_chain_two(
+    harness: &mut Harness,
+    cfg: &HarnessConfig,
+    outcomes: &mut Vec<ChainOutcome>,
+) -> Result<(), ()> {
+    match run_chain_2(harness, cfg).await {
+        Ok(o) => {
+            outcomes.push(o);
+            Ok(())
+        }
+        Err(err) => {
+            eprintln!("error: chain2 failed to run: {err:#}");
+            Err(())
+        }
+    }
 }
 
 fn print_table(outcomes: &[ChainOutcome]) {
@@ -187,5 +294,31 @@ mod tests {
     fn args_parse_chain_two() {
         let args = Args::try_parse_from(["choreo-consumer-smoke", "--chain", "two"]).unwrap();
         assert_eq!(args.chain, ChainSelector::Two);
+    }
+
+    #[test]
+    fn args_parse_positive_path_provider_options() {
+        let args = Args::try_parse_from([
+            "choreo-consumer-smoke",
+            "--chain",
+            "positive-path",
+            "--provider-kind",
+            "vllm",
+            "--provider-endpoint",
+            "http://stub-llm:8000",
+            "--provider-model",
+            "stub-report-vllm-v1",
+            "--positive-specialty",
+            "report-vllm",
+        ])
+        .unwrap();
+        assert_eq!(args.chain, ChainSelector::PositivePath);
+        assert_eq!(args.provider_kind, ProviderKind::Vllm);
+        assert_eq!(
+            args.provider_endpoint.as_deref(),
+            Some("http://stub-llm:8000")
+        );
+        assert_eq!(args.provider_model, "stub-report-vllm-v1");
+        assert_eq!(args.positive_specialty.as_deref(), Some("report-vllm"));
     }
 }

--- a/crates/choreo-consumer-smoke/src/positive.rs
+++ b/crates/choreo-consumer-smoke/src/positive.rs
@@ -1,0 +1,605 @@
+//! Positive path — register a provider-backed agent and require a
+//! schema-valid Report winner.
+//!
+//! This chain is opt-in because it requires the target Choreographer
+//! to have a provider kind enabled at boot (`openai` or `vllm`) and
+//! the supplied endpoint must speak the OpenAI-compatible
+//! `/v1/chat/completions` shape. The default `--chain all` remains the
+//! provider-free rejection smoke.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use choreo_proto::v1 as pb;
+use choreo_proto::v1::run_council_decision_request::Selector;
+use futures::StreamExt;
+use prost_types::{value::Kind as PbKind, Struct as PbStruct, Value as PbValue};
+use tonic::Code;
+use tracing::{debug, info};
+
+use crate::chain2::{validate_payload_against_schema, DEFAULT_REPORT_SCHEMA_PATH};
+use crate::outcome::{AssertionRecord, BusEnvelopeRecord, ChainOutcome};
+use crate::{Harness, HarnessConfig};
+
+const DELIBERATION_COMPLETED_SUBJECT: &str = "choreo.deliberation.completed";
+const BUS_WAIT_BUDGET: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PositivePathConfig {
+    pub agent_kind: String,
+    pub agent_endpoint: Option<String>,
+    pub agent_model: String,
+    pub specialty: String,
+}
+
+impl Default for PositivePathConfig {
+    fn default() -> Self {
+        Self {
+            agent_kind: "openai".to_owned(),
+            agent_endpoint: None,
+            agent_model: "stub-report-v1".to_owned(),
+            specialty: "consumer-smoke-report-openai".to_owned(),
+        }
+    }
+}
+
+/// Run the positive Report path against a connected [`Harness`].
+///
+/// The function never returns provider or schema mismatches as
+/// `Err`; those become typed failed assertions so the CLI can print a
+/// useful table and exit `1`. `Err` remains reserved for unexpected
+/// infrastructure faults in the harness itself.
+#[allow(clippy::too_many_lines)] // one linear consumer transaction is easier to audit than fragments
+pub async fn run_positive_path(
+    h: &mut Harness,
+    cfg: &HarnessConfig,
+    positive: &PositivePathConfig,
+) -> Result<ChainOutcome> {
+    let start = Instant::now();
+    let mut assertions = Vec::new();
+    let mut bus_envelopes = Vec::new();
+    let agent_id = agent_id_for_specialty(&positive.specialty);
+
+    let endpoint = match positive.agent_endpoint.as_deref() {
+        Some(endpoint) if !endpoint.trim().is_empty() => {
+            assertions.push(AssertionRecord::passed(
+                "positive_provider_endpoint_configured",
+                Duration::ZERO,
+            ));
+            endpoint.trim().to_owned()
+        }
+        _ => {
+            assertions.push(AssertionRecord::failed(
+                "positive_provider_endpoint_configured",
+                "positive path requires --provider-endpoint or CONSUMER_SMOKE_PROVIDER_ENDPOINT",
+                Duration::ZERO,
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "report_schema_registered",
+                "provider endpoint missing; downstream assertions did not run",
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "positive_agent_registered",
+                "provider endpoint missing; downstream assertions did not run",
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "positive_council_created",
+                "provider endpoint missing; downstream assertions did not run",
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "run_council_decision_strict",
+                "provider endpoint missing; downstream assertions did not run",
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "report_payload_validates",
+                "provider endpoint missing; downstream assertions did not run",
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "report_validation_summary_passed",
+                "provider endpoint missing; downstream assertions did not run",
+            ));
+            return Ok(outcome(
+                cfg,
+                None,
+                None,
+                None,
+                assertions,
+                bus_envelopes,
+                start.elapsed(),
+            ));
+        }
+    };
+
+    let schema_path = std::env::var("CHOREO_REPORT_SCHEMA_PATH")
+        .unwrap_or_else(|_| DEFAULT_REPORT_SCHEMA_PATH.to_owned());
+    let schema_body = match std::fs::read_to_string(&schema_path) {
+        Ok(schema) => schema,
+        Err(err) => {
+            assertions.push(AssertionRecord::failed(
+                "report_schema_registered",
+                format!("schema not found at {schema_path}: {err}"),
+                Duration::ZERO,
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "positive_agent_registered",
+                "schema-registration step failed; downstream assertions did not run",
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "positive_council_created",
+                "schema-registration step failed; downstream assertions did not run",
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "run_council_decision_strict",
+                "schema-registration step failed; downstream assertions did not run",
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "report_payload_validates",
+                "schema-registration step failed; downstream assertions did not run",
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "report_validation_summary_passed",
+                "schema-registration step failed; downstream assertions did not run",
+            ));
+            return Ok(outcome(
+                cfg,
+                None,
+                None,
+                None,
+                assertions,
+                bus_envelopes,
+                start.elapsed(),
+            ));
+        }
+    };
+
+    let register_start = Instant::now();
+    let register_contract = h
+        .grpc
+        .register_contract(pb::RegisterContractRequest {
+            contract: Some(pb::OutputContract {
+                contract_id: cfg.contract_id.clone(),
+                format: pb::OutputFormat::JsonObject as i32,
+                fields: HashMap::new(),
+                json_schema: schema_body.clone(),
+            }),
+        })
+        .await;
+    let register_elapsed = register_start.elapsed();
+    match register_contract {
+        Ok(_) => assertions.push(AssertionRecord::passed(
+            "report_schema_registered",
+            register_elapsed,
+        )),
+        Err(status)
+            if matches!(
+                status.code(),
+                Code::AlreadyExists | Code::FailedPrecondition
+            ) =>
+        {
+            assertions.push(AssertionRecord::passed(
+                "report_schema_registered",
+                register_elapsed,
+            ));
+        }
+        Err(status) => {
+            assertions.push(AssertionRecord::failed(
+                "report_schema_registered",
+                format!("RegisterContract returned {status:?}"),
+                register_elapsed,
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "positive_agent_registered",
+                "schema-registration step failed; downstream assertions did not run",
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "positive_council_created",
+                "schema-registration step failed; downstream assertions did not run",
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "run_council_decision_strict",
+                "schema-registration step failed; downstream assertions did not run",
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "report_payload_validates",
+                "schema-registration step failed; downstream assertions did not run",
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "report_validation_summary_passed",
+                "schema-registration step failed; downstream assertions did not run",
+            ));
+            return Ok(outcome(
+                cfg,
+                None,
+                None,
+                None,
+                assertions,
+                bus_envelopes,
+                start.elapsed(),
+            ));
+        }
+    }
+
+    let register_agent_start = Instant::now();
+    let register_agent = h
+        .grpc
+        .register_agent(pb::RegisterAgentRequest {
+            specialty: positive.specialty.clone(),
+            agent: Some(pb::AgentSummary {
+                agent_id: agent_id.clone(),
+                specialty: positive.specialty.clone(),
+                kind: positive.agent_kind.clone(),
+                attributes: None,
+            }),
+            agent_config: Some(provider_attrs(&endpoint, &positive.agent_model)),
+        })
+        .await;
+    let register_agent_elapsed = register_agent_start.elapsed();
+    match register_agent {
+        Ok(_) => assertions.push(AssertionRecord::passed(
+            "positive_agent_registered",
+            register_agent_elapsed,
+        )),
+        Err(status) if status.code() == Code::AlreadyExists => assertions.push(
+            AssertionRecord::passed("positive_agent_registered", register_agent_elapsed),
+        ),
+        Err(status) => {
+            assertions.push(AssertionRecord::failed(
+                "positive_agent_registered",
+                format!("RegisterAgent returned {status:?}"),
+                register_agent_elapsed,
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "positive_council_created",
+                "agent-registration step failed; downstream assertions did not run",
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "run_council_decision_strict",
+                "agent-registration step failed; downstream assertions did not run",
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "report_payload_validates",
+                "agent-registration step failed; downstream assertions did not run",
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "report_validation_summary_passed",
+                "agent-registration step failed; downstream assertions did not run",
+            ));
+            return Ok(outcome(
+                cfg,
+                None,
+                None,
+                None,
+                assertions,
+                bus_envelopes,
+                start.elapsed(),
+            ));
+        }
+    }
+
+    let create_start = Instant::now();
+    let create_council = h
+        .grpc
+        .create_council(pb::CreateCouncilRequest {
+            specialty: positive.specialty.clone(),
+            num_agents: 1,
+            agent_config: None,
+        })
+        .await;
+    let create_elapsed = create_start.elapsed();
+    match create_council {
+        Ok(_) => assertions.push(AssertionRecord::passed(
+            "positive_council_created",
+            create_elapsed,
+        )),
+        Err(status) if status.code() == Code::AlreadyExists => assertions.push(
+            AssertionRecord::passed("positive_council_created", create_elapsed),
+        ),
+        Err(status) => {
+            assertions.push(AssertionRecord::failed(
+                "positive_council_created",
+                format!("CreateCouncil returned {status:?}"),
+                create_elapsed,
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "run_council_decision_strict",
+                "council-create step failed; downstream assertions did not run",
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "report_payload_validates",
+                "council-create step failed; downstream assertions did not run",
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "report_validation_summary_passed",
+                "council-create step failed; downstream assertions did not run",
+            ));
+            return Ok(outcome(
+                cfg,
+                None,
+                None,
+                None,
+                assertions,
+                bus_envelopes,
+                start.elapsed(),
+            ));
+        }
+    }
+
+    let mut subscription = match h.nats.as_ref() {
+        Some(client) => match client.subscribe(DELIBERATION_COMPLETED_SUBJECT).await {
+            Ok(sub) => {
+                if let Err(err) = client.flush().await {
+                    debug!(error = %err, "flush after positive-path subscribe failed");
+                }
+                Some(sub)
+            }
+            Err(err) => {
+                debug!(error = %err, "positive-path subscribe failed");
+                None
+            }
+        },
+        None => None,
+    };
+
+    let rpc_start = Instant::now();
+    let response = h
+        .grpc
+        .run_council_decision(pb::RunCouncilDecisionRequest {
+            contract_id: cfg.contract_id.clone(),
+            external_context: None,
+            validation_mode: pb::ValidationMode::Strict as i32,
+            metadata: None,
+            description: "consumer-smoke positive Report path".to_owned(),
+            selector: Some(Selector::Specialty(positive.specialty.clone())),
+        })
+        .await;
+    let rpc_elapsed = rpc_start.elapsed();
+
+    let (task_id, winner_proposal_id, validation_passed) = match response {
+        Ok(resp) => {
+            let resp = resp.into_inner();
+            let task_id = if resp.task_id.is_empty() {
+                None
+            } else {
+                Some(resp.task_id.clone())
+            };
+            let winner_proposal_id = resp
+                .winner
+                .as_ref()
+                .and_then(|d| d.proposal.as_ref())
+                .map(|p| p.proposal_id.clone());
+            let validation_passed = resp.validation.as_ref().map(|v| v.passed);
+
+            let content = resp
+                .winner
+                .as_ref()
+                .and_then(|d| d.proposal.as_ref())
+                .map(|p| p.content.clone());
+            if content.is_some() {
+                assertions.push(AssertionRecord::passed(
+                    "run_council_decision_strict",
+                    rpc_elapsed,
+                ));
+            } else {
+                assertions.push(AssertionRecord::failed(
+                    "run_council_decision_strict",
+                    "RunCouncilDecision returned no winner proposal",
+                    rpc_elapsed,
+                ));
+            }
+            assertions.push(validate_payload_against_schema(
+                &schema_body,
+                content.as_deref().unwrap_or_default(),
+                rpc_elapsed,
+            ));
+            match resp.validation.as_ref() {
+                Some(v) if v.passed => assertions.push(AssertionRecord::passed(
+                    "report_validation_summary_passed",
+                    Duration::ZERO,
+                )),
+                Some(v) => assertions.push(AssertionRecord::failed(
+                    "report_validation_summary_passed",
+                    format!(
+                        "validation.passed=false candidates_passed={} candidates_total={}",
+                        v.candidates_passed, v.candidates_total
+                    ),
+                    Duration::ZERO,
+                )),
+                None => assertions.push(AssertionRecord::failed(
+                    "report_validation_summary_passed",
+                    "response has no validation summary",
+                    Duration::ZERO,
+                )),
+            }
+            (task_id, winner_proposal_id, validation_passed)
+        }
+        Err(status) => {
+            let detail = format!("{status:?}");
+            assertions.push(AssertionRecord::failed(
+                "run_council_decision_strict",
+                detail.clone(),
+                rpc_elapsed,
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "report_payload_validates",
+                "RunCouncilDecision failed; no payload to validate",
+            ));
+            assertions.push(AssertionRecord::skipped(
+                "report_validation_summary_passed",
+                "RunCouncilDecision failed; no validation summary returned",
+            ));
+            (None, None, None)
+        }
+    };
+
+    match (subscription.as_mut(), task_id.as_deref()) {
+        (None, _) => assertions.push(AssertionRecord::skipped(
+            "positive_completion_envelope_observed",
+            "no NATS configured; bus-coupled assertion disabled",
+        )),
+        (Some(_), None) => assertions.push(AssertionRecord::skipped(
+            "positive_completion_envelope_observed",
+            "RunCouncilDecision did not return task_id",
+        )),
+        (Some(sub), Some(task_id)) => {
+            let wait_start = Instant::now();
+            let matched = wait_for_completion(sub, task_id, &mut bus_envelopes).await;
+            let wait_elapsed = wait_start.elapsed();
+            if matched {
+                assertions.push(AssertionRecord::passed(
+                    "positive_completion_envelope_observed",
+                    wait_elapsed,
+                ));
+            } else {
+                assertions.push(AssertionRecord::failed(
+                    "positive_completion_envelope_observed",
+                    format!(
+                        "no deliberation.completed envelope for task_id={task_id:?} \
+                         observed within {BUS_WAIT_BUDGET:?}"
+                    ),
+                    wait_elapsed,
+                ));
+            }
+        }
+    }
+
+    let outcome = outcome(
+        cfg,
+        task_id,
+        winner_proposal_id,
+        validation_passed,
+        assertions,
+        bus_envelopes,
+        start.elapsed(),
+    );
+    info!(
+        chain = outcome.chain,
+        passed = outcome.passed(),
+        passed_count = outcome.passed_count(),
+        failed_count = outcome.failed_count(),
+        skipped_count = outcome.skipped_count(),
+        provider_kind = positive.agent_kind,
+        specialty = positive.specialty,
+        "consumer-smoke positive path finished"
+    );
+    Ok(outcome)
+}
+
+fn outcome(
+    cfg: &HarnessConfig,
+    task_id: Option<String>,
+    winner_proposal_id: Option<String>,
+    validation_passed: Option<bool>,
+    assertions: Vec<AssertionRecord>,
+    bus_envelopes: Vec<BusEnvelopeRecord>,
+    total_duration: Duration,
+) -> ChainOutcome {
+    ChainOutcome {
+        chain: "positive-path",
+        contract_id: cfg.contract_id.clone(),
+        task_id,
+        winner_proposal_id,
+        validation_passed,
+        assertions,
+        bus_envelopes,
+        total_duration,
+    }
+}
+
+fn provider_attrs(endpoint: &str, model: &str) -> PbStruct {
+    PbStruct {
+        fields: [
+            (
+                "provider.endpoint".to_owned(),
+                PbValue {
+                    kind: Some(PbKind::StringValue(endpoint.to_owned())),
+                },
+            ),
+            (
+                "provider.model".to_owned(),
+                PbValue {
+                    kind: Some(PbKind::StringValue(model.to_owned())),
+                },
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    }
+}
+
+fn agent_id_for_specialty(specialty: &str) -> String {
+    format!("agent-{specialty}-0")
+}
+
+async fn wait_for_completion(
+    subscription: &mut async_nats::Subscriber,
+    task_id: &str,
+    bus_envelopes: &mut Vec<BusEnvelopeRecord>,
+) -> bool {
+    let deadline = Instant::now() + BUS_WAIT_BUDGET;
+    while Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let next = tokio::time::timeout(remaining, subscription.next()).await;
+        let Ok(Some(msg)) = next else {
+            break;
+        };
+        let value: serde_json::Value = match serde_json::from_slice(&msg.payload) {
+            Ok(v) => v,
+            Err(err) => {
+                debug!(error = %err, "non-JSON deliberation.completed payload; skipping");
+                continue;
+            }
+        };
+        let envelope_record = BusEnvelopeRecord {
+            subject: msg.subject.to_string(),
+            event_id: value
+                .get("event_id")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_owned(),
+            correlation_id: value
+                .get("correlation_id")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned),
+            causation_id: value
+                .get("causation_id")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned),
+        };
+        bus_envelopes.push(envelope_record);
+        if value.get("task_id").and_then(serde_json::Value::as_str) == Some(task_id) {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_positive_path_config_is_openai_shaped() {
+        let cfg = PositivePathConfig::default();
+        assert_eq!(cfg.agent_kind, "openai");
+        assert_eq!(cfg.agent_model, "stub-report-v1");
+        assert_eq!(cfg.specialty, "consumer-smoke-report-openai");
+        assert!(cfg.agent_endpoint.is_none());
+    }
+
+    #[test]
+    fn agent_id_matches_create_council_convention() {
+        assert_eq!(
+            agent_id_for_specialty("consumer-smoke-report-openai"),
+            "agent-consumer-smoke-report-openai-0"
+        );
+    }
+
+    #[test]
+    fn provider_attrs_carry_endpoint_and_model() {
+        let attrs = provider_attrs("http://stub-llm:8000", "stub-report-v1");
+        assert_eq!(attrs.fields.len(), 2);
+        assert!(attrs.fields.contains_key("provider.endpoint"));
+        assert!(attrs.fields.contains_key("provider.model"));
+    }
+}

--- a/crates/choreo-e2e-runner/src/main.rs
+++ b/crates/choreo-e2e-runner/src/main.rs
@@ -1,34 +1,33 @@
 //! End-to-end runner.
 //!
 //! Connects to a running Choreographer over gRPC and executes a
-//! sequence of scenarios that only pass if the entire stack
-//! (bin + in-memory adapters + gRPC surface + seeding) is wired
-//! correctly. Intended to run either inside the docker-compose stack
-//! or as a Kubernetes Job against a Helm-installed release.
+//! selectable sequence of scenarios that only pass if the stack is
+//! wired correctly. Intended to run either inside the docker-compose
+//! stack or as a Kubernetes Job against a Helm-installed release.
 //!
 //! Exits 0 on success, non-zero on the first failed assertion.
 
 use std::time::Duration;
 
-use anyhow::{anyhow, bail, Context, Result};
-use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
-use choreo_proto::v1::{run_council_decision_request::Selector as RunCouncilSelector, Constraints};
-use choreo_proto::v1::{
-    AgentSummary, CreateCouncilRequest, DeleteCouncilRequest, DeliberateRequest,
-    ExternalContextBundle, ListCouncilsRequest, OrchestrateRequest, OutputContract, OutputFormat,
-    RegisterAgentRequest, RegisterContractRequest, RunCouncilDecisionRequest, Task, ValidationMode,
+use anyhow::{Context, Result};
+use scenario_selection::{
+    parse_scenario_selection, scenario_selection_summary, E2eScenario, SCENARIO_SELECTION_ENV,
 };
-use futures::StreamExt;
-use prost_types::{value::Kind as PbKind, Struct as PbStruct, Value as PbValue};
-use time::format_description::well_known::Rfc3339;
-use time::OffsetDateTime;
-use tonic::transport::{Channel, Endpoint};
-use tonic::Code;
-use tracing::{info, warn};
+use scenarios::{
+    connect_with_retry, verify_causal_metadata_propagates_over_nats,
+    verify_delete_missing_council_returns_false, verify_deliberate_returns_winner,
+    verify_external_context_bundle_round_trips, verify_multi_agent_council_against_real_vllm,
+    verify_orchestrate_invokes_runtime_executor,
+    verify_orchestrate_rejects_proposal_violating_json_schema, verify_seeded_council_visible,
+    verify_structured_output_against_stub_llm, verify_structured_output_against_vllm_kind,
+};
+use tracing::info;
 use tracing_subscriber::EnvFilter;
 
+mod scenario_selection;
+mod scenarios;
+
 #[tokio::main]
-#[allow(clippy::too_many_lines)] // linear narrative of nine scenarios; splitting fragments the story
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -41,1004 +40,93 @@ async fn main() -> Result<()> {
         .unwrap_or_else(|_| "http://choreographer:50055".to_owned());
     let seed_specialty =
         std::env::var("CHOREO_SEED_SPECIALTY").unwrap_or_else(|_| "triage".to_owned());
+    let scenario_selection_raw = std::env::var(SCENARIO_SELECTION_ENV).ok();
+    let selected_scenarios = parse_scenario_selection(scenario_selection_raw.as_deref())?;
+
+    info!(
+        env = SCENARIO_SELECTION_ENV,
+        selected = scenario_selection_summary(&selected_scenarios),
+        "selected E2E scenarios"
+    );
 
     let mut client = connect_with_retry(&endpoint, Duration::from_secs(30)).await?;
 
-    info!("scenario 1: seeded council is visible");
-    let councils = client
-        .list_councils(ListCouncilsRequest {
-            include_agents: false,
-        })
-        .await
-        .context("ListCouncils failed")?
-        .into_inner()
-        .councils;
-    if councils.is_empty() {
-        bail!(
-            "expected at least one seeded council — did the choreographer start with CHOREO_SEED_SPECIALTIES?"
+    if selected_scenarios.contains(&E2eScenario::SeededCouncil) {
+        info!("scenario 1: seeded council is visible");
+        verify_seeded_council_visible(&mut client, &seed_specialty)
+            .await
+            .context("scenario 1 failed")?;
+    }
+
+    if selected_scenarios.contains(&E2eScenario::Deliberate) {
+        info!("scenario 2: Deliberate on the seeded specialty returns a winner");
+        verify_deliberate_returns_winner(&mut client, &seed_specialty)
+            .await
+            .context("scenario 2 failed")?;
+    }
+
+    if selected_scenarios.contains(&E2eScenario::DeleteMissingCouncil) {
+        info!("scenario 3: DeleteCouncil on a missing specialty returns deleted=false");
+        verify_delete_missing_council_returns_false(&mut client)
+            .await
+            .context("scenario 3 failed")?;
+    }
+
+    if selected_scenarios.contains(&E2eScenario::CausalMetadata) {
+        info!("scenario 4: causal metadata propagates from inbound trigger to outbound bus event");
+        verify_causal_metadata_propagates_over_nats(&seed_specialty)
+            .await
+            .context("scenario 4 failed")?;
+    }
+
+    if selected_scenarios.contains(&E2eScenario::RuntimeExecutor) {
+        info!("scenario 5: Orchestrate routes the winner through the configured Runtime executor");
+        verify_orchestrate_invokes_runtime_executor(&mut client, &seed_specialty)
+            .await
+            .context("scenario 5 failed")?;
+    }
+
+    if selected_scenarios.contains(&E2eScenario::StrictSchemaRejection) {
+        info!("scenario 6: Orchestrate with a strict JSON Schema output contract rejects free-form proposals");
+        verify_orchestrate_rejects_proposal_violating_json_schema(&mut client, &seed_specialty)
+            .await
+            .context("scenario 6 failed")?;
+    }
+
+    if selected_scenarios.contains(&E2eScenario::ExternalContextBundle) {
+        info!(
+            "scenario 7: ExternalContextBundle round-trips to the outbound DeliberationCompleted envelope"
         );
+        verify_external_context_bundle_round_trips(&mut client, &seed_specialty)
+            .await
+            .context("scenario 7 failed")?;
     }
-    if !councils.iter().any(|c| c.specialty == seed_specialty) {
-        bail!(
-            "seeded specialty {seed_specialty} not found among {:?}",
-            councils.iter().map(|c| &c.specialty).collect::<Vec<_>>()
+
+    if selected_scenarios.contains(&E2eScenario::OpenAiStructuredOutput) {
+        info!(
+            "scenario 8: structured-output Report contract passes against a stub OpenAI-shaped agent"
         );
+        verify_structured_output_against_stub_llm(&mut client)
+            .await
+            .context("scenario 8 failed")?;
     }
 
-    info!("scenario 2: Deliberate on the seeded specialty returns a winner");
-    let response = client
-        .deliberate(DeliberateRequest {
-            task: Some(Task {
-                task_id: "e2e-task-1".to_owned(),
-                specialty: seed_specialty.clone(),
-                description: "End-to-end test: describe the situation.".to_owned(),
-                constraints: None,
-                attributes: None,
-                external_context: None,
-                metadata: None,
-            }),
-        })
-        .await
-        .context("Deliberate failed")?
-        .into_inner();
-
-    if response.task_id != "e2e-task-1" {
-        bail!("response.task_id = {:?}", response.task_id);
-    }
-    if response.winner_proposal_id.is_empty() {
-        bail!("winner_proposal_id is empty");
-    }
-    if response.results.is_empty() {
-        bail!("results[] is empty");
-    }
-    let winner = response
-        .results
-        .iter()
-        .find(|r| r.rank == 0)
-        .ok_or_else(|| anyhow!("no result with rank=0"))?;
-    let winner_id = winner
-        .proposal
-        .as_ref()
-        .map(|p| p.proposal_id.clone())
-        .ok_or_else(|| anyhow!("rank=0 result has no proposal"))?;
-    if winner_id != response.winner_proposal_id {
-        bail!(
-            "rank=0 proposal id {} disagrees with winner_proposal_id {}",
-            winner_id,
-            response.winner_proposal_id
+    if selected_scenarios.contains(&E2eScenario::VllmStructuredOutput) {
+        info!(
+            "scenario 9: structured-output Report contract passes against the stub-llm via the vllm adapter"
         );
+        verify_structured_output_against_vllm_kind(&mut client)
+            .await
+            .context("scenario 9 failed")?;
     }
 
-    info!("scenario 3: DeleteCouncil on a missing specialty returns deleted=false");
-    let delete = client
-        .delete_council(DeleteCouncilRequest {
-            specialty: "unknown-specialty".to_owned(),
-        })
-        .await
-        .context("DeleteCouncil(unknown) failed")?
-        .into_inner();
-    if delete.deleted {
-        bail!("DeleteCouncil on an unknown specialty must return deleted=false");
+    if selected_scenarios.contains(&E2eScenario::VllmRealMultiAgent) {
+        info!("scenario 10: real vLLM multi-agent council returns a schema-valid Report winner");
+        verify_multi_agent_council_against_real_vllm(&mut client)
+            .await
+            .context("scenario 10 failed")?;
     }
-
-    info!("scenario 4: causal metadata propagates from inbound trigger to outbound bus event");
-    verify_causal_metadata_propagates_over_nats(&seed_specialty)
-        .await
-        .context("scenario 4 failed")?;
-
-    info!("scenario 5: Orchestrate routes the winner through the configured Runtime executor");
-    verify_orchestrate_invokes_runtime_executor(&mut client, &seed_specialty)
-        .await
-        .context("scenario 5 failed")?;
-
-    info!("scenario 6: Orchestrate with a strict JSON Schema output contract rejects free-form proposals");
-    verify_orchestrate_rejects_proposal_violating_json_schema(&mut client, &seed_specialty)
-        .await
-        .context("scenario 6 failed")?;
-
-    info!(
-        "scenario 7: ExternalContextBundle round-trips to the outbound DeliberationCompleted envelope"
-    );
-    verify_external_context_bundle_round_trips(&mut client, &seed_specialty)
-        .await
-        .context("scenario 7 failed")?;
-
-    info!(
-        "scenario 8: structured-output Report contract passes against a stub OpenAI-shaped agent"
-    );
-    verify_structured_output_against_stub_llm(&mut client)
-        .await
-        .context("scenario 8 failed")?;
-
-    info!(
-        "scenario 9: structured-output Report contract passes against the stub-llm via the vllm adapter"
-    );
-    verify_structured_output_against_vllm_kind(&mut client)
-        .await
-        .context("scenario 9 failed")?;
 
     info!("E2E scenarios passed");
     Ok(())
-}
-
-/// Drives `Orchestrate` on the seeded council with a task that carries
-/// a `runtime.tool_name` attribute. The compose stack wires
-/// `CHOREO_EXECUTOR_KIND=runtime` pointing at the in-stack
-/// `stub-runtime` sidecar, so a successful outcome here proves the
-/// full chain — Deliberate -> winner -> RuntimeExecutor -> gRPC to
-/// `underpass.runtime.v1.{SessionService,InvocationService}` -> back
-/// up the use-case -> `TaskCompleted`.
-async fn verify_orchestrate_invokes_runtime_executor(
-    client: &mut ChoreographerServiceClient<Channel>,
-    specialty: &str,
-) -> Result<()> {
-    let attributes = pb_struct_from_pairs([(
-        "runtime.tool_name",
-        PbKind::StringValue("stub.echo".to_owned()),
-    )]);
-
-    let response = client
-        .orchestrate(OrchestrateRequest {
-            task: Some(Task {
-                task_id: "e2e-task-5".to_owned(),
-                specialty: specialty.to_owned(),
-                description: "End-to-end test: route winner through the Runtime executor."
-                    .to_owned(),
-                // No output_contract: NoopAgent emits free-form text,
-                // and a structured-output contract would force the
-                // proposal to be a JSON object. Validators stay no-op
-                // without a contract.
-                constraints: None,
-                attributes: Some(attributes),
-                external_context: None,
-                metadata: None,
-            }),
-            execution_options: None,
-        })
-        .await
-        .context("Orchestrate failed")?
-        .into_inner();
-
-    if response.task_id != "e2e-task-5" {
-        bail!("response.task_id = {:?}", response.task_id);
-    }
-    if response.execution_id != "stub-invocation-1" {
-        bail!(
-            "execution_id should be the stub-runtime's canned value, got {:?}",
-            response.execution_id
-        );
-    }
-    let winner = response
-        .winner
-        .ok_or_else(|| anyhow!("Orchestrate returned no winner"))?;
-    let winner_proposal = winner
-        .proposal
-        .ok_or_else(|| anyhow!("winner has no proposal"))?;
-    if winner_proposal.content.trim().is_empty() {
-        bail!("winner proposal content is empty");
-    }
-    info!(
-        execution_id = response.execution_id.as_str(),
-        winner_id = winner_proposal.proposal_id.as_str(),
-        "Orchestrate routed through stub-runtime"
-    );
-    Ok(())
-}
-
-fn pb_struct_from_pairs<'a>(pairs: impl IntoIterator<Item = (&'a str, PbKind)>) -> PbStruct {
-    PbStruct {
-        fields: pairs
-            .into_iter()
-            .map(|(k, kind)| (k.to_owned(), PbValue { kind: Some(kind) }))
-            .collect(),
-    }
-}
-
-/// Drives `Orchestrate` on the seeded council with a strict
-/// JSON-Schema output contract. `NoopAgent` emits free-form text, so
-/// the proposal cannot satisfy `{"type": "object", "required": [...]}`
-/// — the deliberation must fail with `NoValidProposal` and the
-/// orchestrator must publish a `TaskFailed` event whose envelope
-/// carries `error_kind = "deliberation.no_valid_proposal"`.
-///
-/// This is the negative half of Epic 11's structured-output stack
-/// proof. A positive scenario requires an agent that emits structured
-/// JSON; that lands once a stub-LLM provider sidecar ships, or once a
-/// real provider council is wired into this compose stack.
-#[allow(clippy::too_many_lines)] // single end-to-end scenario; splitting fragments the assertion
-async fn verify_orchestrate_rejects_proposal_violating_json_schema(
-    client: &mut ChoreographerServiceClient<Channel>,
-    specialty: &str,
-) -> Result<()> {
-    // Pre-subscribe so the published TaskFailed envelope cannot land
-    // before we are watching for it.
-    let nats_url =
-        std::env::var("CHOREO_NATS_URL").unwrap_or_else(|_| "nats://nats:4222".to_owned());
-    let nats = async_nats::connect(&nats_url)
-        .await
-        .with_context(|| format!("connect NATS at {nats_url}"))?;
-    let mut subscription = nats
-        .subscribe("choreo.task.failed".to_owned())
-        .await
-        .context("subscribe choreo.task.failed")?;
-    nats.flush().await.context("flush NATS subscribe")?;
-
-    let attributes = pb_struct_from_pairs([(
-        "runtime.tool_name",
-        PbKind::StringValue("stub.echo".to_owned()),
-    )]);
-    let constraints = Constraints {
-        rubric: None,
-        rounds: 0,
-        num_agents: 0,
-        deadline_ms: 0,
-        output_contract: Some(OutputContract {
-            contract_id: "scenario-6-strict".to_owned(),
-            format: OutputFormat::JsonObject as i32,
-            fields: std::collections::HashMap::new(),
-            json_schema: r#"{
-                "type": "object",
-                "additionalProperties": false,
-                "required": ["decision", "reason"],
-                "properties": {
-                    "decision": { "type": "string", "enum": ["emit_event", "escalate"] },
-                    "reason":   { "type": "string", "minLength": 1 }
-                }
-            }"#
-            .to_owned(),
-        }),
-    };
-
-    let result = client
-        .orchestrate(OrchestrateRequest {
-            task: Some(Task {
-                task_id: "e2e-task-6".to_owned(),
-                specialty: specialty.to_owned(),
-                description:
-                    "End-to-end test: strict structured-output contract must reject free-form text."
-                        .to_owned(),
-                constraints: Some(constraints),
-                attributes: Some(attributes),
-                external_context: None,
-                metadata: None,
-            }),
-            execution_options: None,
-        })
-        .await;
-
-    let Err(status) = result else {
-        bail!(
-            "Orchestrate unexpectedly succeeded — NoopAgent should have failed the JSON Schema contract"
-        );
-    };
-    info!(
-        code = ?status.code(),
-        message = status.message(),
-        "Orchestrate returned the expected error"
-    );
-
-    // The use case publishes `TaskFailed` BEFORE returning the error,
-    // so the envelope should already be on the bus.
-    let deadline = std::time::Instant::now() + Duration::from_secs(10);
-    while std::time::Instant::now() < deadline {
-        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-        let chunk = remaining.min(Duration::from_secs(2));
-        match tokio::time::timeout(chunk, subscription.next()).await {
-            Ok(Some(msg)) => {
-                let payload: serde_json::Value =
-                    serde_json::from_slice(&msg.payload).context("task.failed payload not JSON")?;
-                let task_id = payload
-                    .get("task_id")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                let error_kind = payload
-                    .get("error_kind")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                if task_id == "e2e-task-6" && error_kind == "deliberation.no_valid_proposal" {
-                    info!(
-                        out_event_id = payload
-                            .get("event_id")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or(""),
-                        error_kind, "TaskFailed carried the expected NoValidProposal kind"
-                    );
-                    return Ok(());
-                }
-                warn!(
-                    task_id,
-                    error_kind,
-                    "TaskFailed seen but task_id / error_kind did not match; continuing"
-                );
-            }
-            Ok(None) => {
-                bail!("NATS subscription closed before a matching TaskFailed envelope arrived");
-            }
-            Err(_) => {}
-        }
-    }
-
-    bail!(
-        "no TaskFailed envelope with task_id=e2e-task-6 and error_kind=deliberation.no_valid_proposal arrived within 10s"
-    )
-}
-
-/// Publishes a `TriggerEvent` on NATS with known `correlation_id` and
-/// `causation_id`, then asserts that the resulting
-/// `DeliberationCompleted` envelope on the outbound bus carries the
-/// same causal ids. Closes the stack-E2E loose end of Epic 5.
-async fn verify_causal_metadata_propagates_over_nats(specialty: &str) -> Result<()> {
-    let nats_url =
-        std::env::var("CHOREO_NATS_URL").unwrap_or_else(|_| "nats://nats:4222".to_owned());
-    let client = async_nats::connect(&nats_url)
-        .await
-        .with_context(|| format!("connect NATS at {nats_url}"))?;
-    info!(nats_url, "connected to NATS for causal metadata assertion");
-
-    let mut subscription = client
-        .subscribe("choreo.deliberation.completed".to_owned())
-        .await
-        .context("subscribe choreo.deliberation.completed")?;
-    // Flush so the SUB is acked by the server before we publish the
-    // trigger that should fan out into the event we're waiting for.
-    client.flush().await.context("flush NATS subscribe")?;
-
-    let event_id = "stack-e2e-trigger-1";
-    let correlation_id = "stack-e2e-corr";
-    let causation_id = "stack-e2e-cause";
-    let emitted_at = OffsetDateTime::now_utc()
-        .format(&Rfc3339)
-        .context("format emitted_at as RFC 3339")?;
-    let trigger = serde_json::json!({
-        "event_id": event_id,
-        "emitted_at": emitted_at,
-        "source": "stack-e2e-runner",
-        "correlation_id": correlation_id,
-        "causation_id": causation_id,
-        "kind": "stack.e2e.trigger",
-        "requested_specialties": [specialty],
-    });
-    let subject = format!("choreo.trigger.{specialty}");
-    let payload = serde_json::to_vec(&trigger).context("serialize trigger payload")?;
-    client
-        .publish(subject.clone(), payload.into())
-        .await
-        .with_context(|| format!("publish trigger to {subject}"))?;
-    client.flush().await.context("flush NATS publish")?;
-    info!(subject, correlation_id, causation_id, "trigger published");
-
-    let deadline = std::time::Instant::now() + Duration::from_secs(15);
-    while std::time::Instant::now() < deadline {
-        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-        let chunk = remaining.min(Duration::from_secs(2));
-        match tokio::time::timeout(chunk, subscription.next()).await {
-            Ok(Some(msg)) => {
-                let payload: serde_json::Value = serde_json::from_slice(&msg.payload)
-                    .context("DeliberationCompleted payload not JSON")?;
-                let got_corr = payload.get("correlation_id").and_then(|v| v.as_str());
-                let got_cause = payload.get("causation_id").and_then(|v| v.as_str());
-                if got_corr == Some(correlation_id) && got_cause == Some(causation_id) {
-                    info!(
-                        out_event_id = payload
-                            .get("event_id")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or(""),
-                        correlation_id,
-                        causation_id,
-                        "DeliberationCompleted carried our causal ids"
-                    );
-                    return Ok(());
-                }
-                warn!(
-                    ?got_corr,
-                    ?got_cause,
-                    "DeliberationCompleted seen but causal ids did not match; continuing"
-                );
-            }
-            Ok(None) => {
-                bail!("NATS subscription closed before a matching DeliberationCompleted arrived");
-            }
-            Err(_) => {}
-        }
-    }
-
-    bail!("no DeliberationCompleted with the expected causal ids arrived within 15s")
-}
-
-async fn connect_with_retry(
-    endpoint: &str,
-    total_budget: Duration,
-) -> Result<ChoreographerServiceClient<Channel>> {
-    let deadline = std::time::Instant::now() + total_budget;
-    let endpoint_parsed: Endpoint = endpoint
-        .parse()
-        .with_context(|| format!("invalid gRPC endpoint: {endpoint}"))?;
-
-    let mut last_err: Option<tonic::transport::Error> = None;
-    while std::time::Instant::now() < deadline {
-        match ChoreographerServiceClient::connect(endpoint_parsed.clone()).await {
-            Ok(c) => {
-                info!(endpoint, "connected");
-                return Ok(c);
-            }
-            Err(err) => {
-                warn!(endpoint, error = %err, "not ready yet; will retry");
-                last_err = Some(err);
-                tokio::time::sleep(Duration::from_secs(1)).await;
-            }
-        }
-    }
-    Err(anyhow!(
-        "could not connect to {endpoint} within {total_budget:?}: {last_err:?}"
-    ))
-}
-
-/// Drives `Deliberate` with an `ExternalContextBundle` attached and
-/// asserts that the outbound `choreo.deliberation.completed` envelope
-/// carries the bundle id back. Closes the round-trip gap that
-/// scenario 4 leaves open (scenario 4 covers causal ids; this one
-/// covers the bundle pointer the kernel-shaped consumer would feed
-/// in).
-async fn verify_external_context_bundle_round_trips(
-    client: &mut ChoreographerServiceClient<Channel>,
-    specialty: &str,
-) -> Result<()> {
-    const BUNDLE_ID: &str = "scenario-7-bundle";
-
-    let nats_url =
-        std::env::var("CHOREO_NATS_URL").unwrap_or_else(|_| "nats://nats:4222".to_owned());
-    let nats = async_nats::connect(&nats_url)
-        .await
-        .with_context(|| format!("connect NATS at {nats_url}"))?;
-    let mut subscription = nats
-        .subscribe("choreo.deliberation.completed".to_owned())
-        .await
-        .context("subscribe choreo.deliberation.completed for scenario 7")?;
-    nats.flush()
-        .await
-        .context("flush NATS subscribe (scenario 7)")?;
-
-    let task_id = "e2e-task-7";
-    let external_context = ExternalContextBundle {
-        bundle_id: BUNDLE_ID.to_owned(),
-        schema_version: "v1".to_owned(),
-        summary: None,
-        items: vec![],
-        references: vec![],
-        metadata: None,
-    };
-
-    let response = client
-        .deliberate(DeliberateRequest {
-            task: Some(Task {
-                task_id: task_id.to_owned(),
-                description: "scenario 7 ExternalContextBundle round-trip".to_owned(),
-                specialty: specialty.to_owned(),
-                constraints: None,
-                attributes: None,
-                external_context: Some(external_context),
-                metadata: None,
-            }),
-        })
-        .await
-        .context("Deliberate (scenario 7) failed")?
-        .into_inner();
-    if response.winner_proposal_id.is_empty() {
-        bail!("Deliberate did not return a winner for scenario 7");
-    }
-
-    let deadline = std::time::Instant::now() + Duration::from_secs(15);
-    while std::time::Instant::now() < deadline {
-        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-        let chunk = remaining.min(Duration::from_secs(2));
-        match tokio::time::timeout(chunk, subscription.next()).await {
-            Ok(Some(msg)) => {
-                let payload: serde_json::Value = serde_json::from_slice(&msg.payload)
-                    .context("DeliberationCompleted (scenario 7) payload not JSON")?;
-                let got_task = payload.get("task_id").and_then(|v| v.as_str());
-                let got_bundle = payload
-                    .get("external_context_bundle_id")
-                    .and_then(|v| v.as_str());
-                if got_task == Some(task_id) {
-                    if got_bundle == Some(BUNDLE_ID) {
-                        info!(
-                            out_event_id = payload
-                                .get("event_id")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or(""),
-                            bundle_id = BUNDLE_ID,
-                            "DeliberationCompleted carried the external_context_bundle_id"
-                        );
-                        return Ok(());
-                    }
-                    bail!(
-                        "DeliberationCompleted for {task_id} missing external_context_bundle_id (got {got_bundle:?})"
-                    );
-                }
-                warn!(
-                    ?got_task,
-                    "DeliberationCompleted seen for a different task_id; continuing"
-                );
-            }
-            Ok(None) => {
-                bail!("NATS subscription closed before scenario 7 envelope arrived");
-            }
-            Err(_) => {}
-        }
-    }
-    bail!("no DeliberationCompleted for {task_id} arrived within 15s")
-}
-
-/// Drives `RunCouncilDecision` end-to-end against a stub OpenAI-shaped
-/// agent that always emits a JSON Report payload satisfying
-/// `api/examples/output-contracts/report.schema.json`. Closes the
-/// positive structured-output gap left by scenario 6 (which only
-/// proves the rejection path against `NoopAgent`).
-///
-/// Steps:
-///
-/// 1. Read the Report JSON Schema from
-///    `CHOREO_REPORT_SCHEMA_PATH` (compose pins it to
-///    `/etc/choreo/report.schema.json`).
-/// 2. Register the contract via `RegisterContract`. Tolerate the
-///    `AlreadyExists` and `FailedPrecondition` codes so a re-run
-///    against the same compose stack does not flake.
-/// 3. Register an `openai`-kind agent that points at `http://stub-llm:8000`.
-/// 4. Create a council with that single agent under specialty
-///    `"report"`.
-/// 5. Pre-subscribe to `choreo.deliberation.completed` so the bus
-///    envelope assertion cannot race.
-/// 6. Call `RunCouncilDecision` in `STRICT` mode bound to the
-///    contract.
-/// 7. Assert the response carries a winner whose proposal content
-///    parses as JSON and satisfies the Report schema; assert
-///    `validation.passed == true`.
-/// 8. Assert the outbound envelope carries the same task id and
-///    OMITS the `external_context_bundle_id` field (no bundle was
-///    passed — the field is `skip_serializing_if = Option::is_none`,
-///    so an absence is the contract, not an empty string).
-#[allow(clippy::too_many_lines)] // single end-to-end scenario; splitting fragments the assertion
-async fn verify_structured_output_against_stub_llm(
-    client: &mut ChoreographerServiceClient<Channel>,
-) -> Result<()> {
-    const CONTRACT_ID: &str = "scenario-8-report";
-    // Must match the id pattern the CreateCouncil handler mints
-    // (`agent-{specialty}-{i}`); without that pairing the council
-    // create step fails resolving the agent.
-    const AGENT_ID: &str = "agent-report-0";
-    const SPECIALTY: &str = "report";
-    const STUB_ENDPOINT: &str = "http://stub-llm:8000";
-
-    let schema_path = std::env::var("CHOREO_REPORT_SCHEMA_PATH")
-        .unwrap_or_else(|_| "/etc/choreo/report.schema.json".to_owned());
-    let schema_body = std::fs::read_to_string(&schema_path)
-        .with_context(|| format!("read Report schema at {schema_path}"))?;
-    let schema_value: serde_json::Value =
-        serde_json::from_str(&schema_body).context("Report schema must parse as JSON")?;
-    let compiled_schema = jsonschema::JSONSchema::compile(&schema_value)
-        .map_err(|err| anyhow!("Report schema must compile: {err}"))?;
-
-    // 2. Register the contract. Tolerate AlreadyExists /
-    // FailedPrecondition so a re-run against the same compose stack
-    // does not flake.
-    let register_contract = client
-        .register_contract(RegisterContractRequest {
-            contract: Some(OutputContract {
-                contract_id: CONTRACT_ID.to_owned(),
-                format: OutputFormat::JsonObject as i32,
-                fields: std::collections::HashMap::new(),
-                json_schema: schema_body.clone(),
-            }),
-        })
-        .await;
-    match register_contract {
-        Ok(_) => info!(contract_id = CONTRACT_ID, "RegisterContract ok"),
-        Err(status)
-            if matches!(
-                status.code(),
-                Code::AlreadyExists | Code::FailedPrecondition
-            ) =>
-        {
-            info!(
-                code = ?status.code(),
-                contract_id = CONTRACT_ID,
-                "RegisterContract tolerated (contract already present)"
-            );
-        }
-        Err(status) => bail!("RegisterContract failed unexpectedly: {status}"),
-    }
-
-    // 3. Register the openai-kind agent pointing at the stub-llm
-    // sidecar. The attribute keys mirror `DispatchingAgentFactory`'s
-    // recognised overrides (`provider.endpoint`, `provider.model`).
-    // The api_key attribute is NOT consumed by the factory (which
-    // demands a base config from env) — it's carried purely as a
-    // forward-compatible marker. compose sets a dummy
-    // `CHOREO_OPENAI_API_KEY` so the factory has a base config.
-    let agent_attrs = pb_struct_from_pairs([
-        (
-            "provider.endpoint",
-            PbKind::StringValue(STUB_ENDPOINT.to_owned()),
-        ),
-        (
-            "provider.model",
-            PbKind::StringValue("stub-report-v1".to_owned()),
-        ),
-        (
-            "provider.api_key",
-            PbKind::StringValue("stub-key-not-used".to_owned()),
-        ),
-    ]);
-    let register_agent = client
-        .register_agent(RegisterAgentRequest {
-            specialty: SPECIALTY.to_owned(),
-            agent: Some(AgentSummary {
-                agent_id: AGENT_ID.to_owned(),
-                specialty: SPECIALTY.to_owned(),
-                kind: "openai".to_owned(),
-                // The RegisterAgent mapper reads `agent_config`
-                // (NOT this nested attributes field) to feed the
-                // descriptor passed to the factory. Carrying the
-                // attributes here would silently drop them.
-                attributes: None,
-            }),
-            // `provider.endpoint` + `provider.model` must travel here
-            // for the factory to apply them as overrides.
-            agent_config: Some(agent_attrs),
-        })
-        .await;
-    match register_agent {
-        Ok(_) => info!(agent_id = AGENT_ID, "RegisterAgent ok"),
-        Err(status) if status.code() == Code::AlreadyExists => {
-            info!(
-                agent_id = AGENT_ID,
-                "RegisterAgent tolerated (agent already present)"
-            );
-        }
-        Err(status) => bail!("RegisterAgent failed unexpectedly: {status}"),
-    }
-
-    // 4. Create a council under specialty `report`. Tolerate
-    // AlreadyExists so a re-run against the same compose stack does
-    // not flake.
-    let create_council = client
-        .create_council(CreateCouncilRequest {
-            specialty: SPECIALTY.to_owned(),
-            num_agents: 1,
-            agent_config: None,
-        })
-        .await;
-    match create_council {
-        Ok(_) => info!(specialty = SPECIALTY, "CreateCouncil ok"),
-        Err(status) if status.code() == Code::AlreadyExists => {
-            info!(
-                specialty = SPECIALTY,
-                "CreateCouncil tolerated (council already present)"
-            );
-        }
-        Err(status) => bail!("CreateCouncil failed unexpectedly: {status}"),
-    }
-
-    // 5. Pre-subscribe so the published envelope cannot race the
-    // RPC.
-    let nats_url =
-        std::env::var("CHOREO_NATS_URL").unwrap_or_else(|_| "nats://nats:4222".to_owned());
-    let nats = async_nats::connect(&nats_url)
-        .await
-        .with_context(|| format!("connect NATS at {nats_url}"))?;
-    let mut subscription = nats
-        .subscribe("choreo.deliberation.completed".to_owned())
-        .await
-        .context("subscribe choreo.deliberation.completed for scenario 8")?;
-    nats.flush()
-        .await
-        .context("flush NATS subscribe (scenario 8)")?;
-
-    // 6. Call RunCouncilDecision.
-    let response = client
-        .run_council_decision(RunCouncilDecisionRequest {
-            contract_id: CONTRACT_ID.to_owned(),
-            external_context: None,
-            validation_mode: ValidationMode::Strict as i32,
-            metadata: None,
-            description: "scenario 8 structured-output positive path".to_owned(),
-            selector: Some(RunCouncilSelector::Specialty(SPECIALTY.to_owned())),
-        })
-        .await
-        .context("RunCouncilDecision failed (scenario 8)")?
-        .into_inner();
-
-    // 7. Assertions on the response.
-    let winner = response
-        .winner
-        .ok_or_else(|| anyhow!("RunCouncilDecision returned no winner"))?;
-    let proposal = winner
-        .proposal
-        .ok_or_else(|| anyhow!("winner has no proposal"))?;
-    let proposal_id = proposal.proposal_id.clone();
-    let parsed: serde_json::Value =
-        serde_json::from_str(proposal.content.trim()).with_context(|| {
-            format!(
-                "winner proposal content must parse as JSON; got: {}",
-                proposal.content
-            )
-        })?;
-    if let Err(errors) = compiled_schema.validate(&parsed) {
-        let messages: Vec<String> = errors.map(|e| e.to_string()).collect();
-        bail!(
-            "winner proposal content failed Report schema: {}",
-            messages.join("; ")
-        );
-    }
-    let validation = response
-        .validation
-        .as_ref()
-        .ok_or_else(|| anyhow!("response has no validation summary"))?;
-    if !validation.passed {
-        bail!("validation.passed should be true on the positive path");
-    }
-    info!(
-        proposal_id = proposal_id.as_str(),
-        task_id = response.task_id.as_str(),
-        candidates_passed = validation.candidates_passed,
-        candidates_total = validation.candidates_total,
-        "RunCouncilDecision succeeded with Report-shaped winner"
-    );
-
-    // 8. Bus envelope assertion. The task did NOT carry an
-    // ExternalContextBundle, so the JSON envelope MUST omit the
-    // `external_context_bundle_id` field (the field is annotated
-    // `skip_serializing_if = Option::is_none`). Asserting absence —
-    // not "empty string" — is the contract.
-    let task_id = response.task_id.clone();
-    let deadline = std::time::Instant::now() + Duration::from_secs(15);
-    while std::time::Instant::now() < deadline {
-        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-        let chunk = remaining.min(Duration::from_secs(2));
-        match tokio::time::timeout(chunk, subscription.next()).await {
-            Ok(Some(msg)) => {
-                let payload: serde_json::Value = serde_json::from_slice(&msg.payload)
-                    .context("DeliberationCompleted (scenario 8) payload not JSON")?;
-                let got_task = payload.get("task_id").and_then(|v| v.as_str());
-                if got_task == Some(task_id.as_str()) {
-                    if payload.get("external_context_bundle_id").is_some() {
-                        bail!(
-                            "scenario 8 envelope must omit external_context_bundle_id (no bundle was sent), got {payload}"
-                        );
-                    }
-                    info!(
-                        out_event_id = payload
-                            .get("event_id")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or(""),
-                        task_id = task_id.as_str(),
-                        "DeliberationCompleted carried the expected task id and no bundle id"
-                    );
-                    return Ok(());
-                }
-                warn!(
-                    ?got_task,
-                    "DeliberationCompleted seen for a different task_id; continuing"
-                );
-            }
-            Ok(None) => {
-                bail!("NATS subscription closed before scenario 8 envelope arrived");
-            }
-            Err(_) => {}
-        }
-    }
-    bail!("no DeliberationCompleted for {task_id} arrived within 15s (scenario 8)")
-}
-
-/// Same end-to-end Report-contract success path as scenario 8, but
-/// the council's agent is registered with `kind=vllm`. The vLLM
-/// adapter sends the same `POST /v1/chat/completions` body shape the
-/// OpenAI adapter does, so we point it at the existing `stub-llm`
-/// sidecar — no second sidecar needed. Proves the vllm-shaped path
-/// works in the same compose run that scenario 8 covers for the
-/// openai-shaped path, closing Epic 11's provider-runner-merge
-/// follow-up.
-#[allow(clippy::too_many_lines)] // single end-to-end scenario; splitting fragments the assertion
-async fn verify_structured_output_against_vllm_kind(
-    client: &mut ChoreographerServiceClient<Channel>,
-) -> Result<()> {
-    const CONTRACT_ID: &str = "scenario-9-report-vllm";
-    // Must match the id pattern the CreateCouncil handler mints
-    // (`agent-{specialty}-{i}`).
-    const AGENT_ID: &str = "agent-report-vllm-0";
-    const SPECIALTY: &str = "report-vllm";
-    const STUB_ENDPOINT: &str = "http://stub-llm:8000";
-
-    let schema_path = std::env::var("CHOREO_REPORT_SCHEMA_PATH")
-        .unwrap_or_else(|_| "/etc/choreo/report.schema.json".to_owned());
-    let schema_body = std::fs::read_to_string(&schema_path)
-        .with_context(|| format!("read Report schema at {schema_path}"))?;
-    let schema_value: serde_json::Value =
-        serde_json::from_str(&schema_body).context("Report schema must parse as JSON")?;
-    let compiled_schema = jsonschema::JSONSchema::compile(&schema_value)
-        .map_err(|err| anyhow!("Report schema must compile: {err}"))?;
-
-    let register_contract = client
-        .register_contract(RegisterContractRequest {
-            contract: Some(OutputContract {
-                contract_id: CONTRACT_ID.to_owned(),
-                format: OutputFormat::JsonObject as i32,
-                fields: std::collections::HashMap::new(),
-                json_schema: schema_body.clone(),
-            }),
-        })
-        .await;
-    match register_contract {
-        Ok(_) => info!(
-            contract_id = CONTRACT_ID,
-            "RegisterContract ok (scenario 9)"
-        ),
-        Err(status)
-            if matches!(
-                status.code(),
-                Code::AlreadyExists | Code::FailedPrecondition
-            ) =>
-        {
-            info!(
-                code = ?status.code(),
-                contract_id = CONTRACT_ID,
-                "RegisterContract tolerated (contract already present)"
-            );
-        }
-        Err(status) => bail!("RegisterContract failed unexpectedly (scenario 9): {status}"),
-    }
-
-    // The vllm adapter does NOT read `provider.api_key`; only the
-    // endpoint + model overrides are meaningful.
-    let agent_attrs = pb_struct_from_pairs([
-        (
-            "provider.endpoint",
-            PbKind::StringValue(STUB_ENDPOINT.to_owned()),
-        ),
-        (
-            "provider.model",
-            PbKind::StringValue("stub-report-vllm-v1".to_owned()),
-        ),
-    ]);
-    let register_agent = client
-        .register_agent(RegisterAgentRequest {
-            specialty: SPECIALTY.to_owned(),
-            agent: Some(AgentSummary {
-                agent_id: AGENT_ID.to_owned(),
-                specialty: SPECIALTY.to_owned(),
-                kind: "vllm".to_owned(),
-                attributes: None,
-            }),
-            agent_config: Some(agent_attrs),
-        })
-        .await;
-    match register_agent {
-        Ok(_) => info!(agent_id = AGENT_ID, "RegisterAgent ok (scenario 9)"),
-        Err(status) if status.code() == Code::AlreadyExists => {
-            info!(
-                agent_id = AGENT_ID,
-                "RegisterAgent tolerated (agent already present)"
-            );
-        }
-        Err(status) => bail!("RegisterAgent failed unexpectedly (scenario 9): {status}"),
-    }
-
-    let create_council = client
-        .create_council(CreateCouncilRequest {
-            specialty: SPECIALTY.to_owned(),
-            num_agents: 1,
-            agent_config: None,
-        })
-        .await;
-    match create_council {
-        Ok(_) => info!(specialty = SPECIALTY, "CreateCouncil ok (scenario 9)"),
-        Err(status) if status.code() == Code::AlreadyExists => {
-            info!(
-                specialty = SPECIALTY,
-                "CreateCouncil tolerated (council already present)"
-            );
-        }
-        Err(status) => bail!("CreateCouncil failed unexpectedly (scenario 9): {status}"),
-    }
-
-    let nats_url =
-        std::env::var("CHOREO_NATS_URL").unwrap_or_else(|_| "nats://nats:4222".to_owned());
-    let nats = async_nats::connect(&nats_url)
-        .await
-        .with_context(|| format!("connect NATS at {nats_url}"))?;
-    let mut subscription = nats
-        .subscribe("choreo.deliberation.completed".to_owned())
-        .await
-        .context("subscribe choreo.deliberation.completed for scenario 9")?;
-    nats.flush()
-        .await
-        .context("flush NATS subscribe (scenario 9)")?;
-
-    let response = client
-        .run_council_decision(RunCouncilDecisionRequest {
-            contract_id: CONTRACT_ID.to_owned(),
-            external_context: None,
-            validation_mode: ValidationMode::Strict as i32,
-            metadata: None,
-            description: "scenario 9 structured-output positive path (vllm)".to_owned(),
-            selector: Some(RunCouncilSelector::Specialty(SPECIALTY.to_owned())),
-        })
-        .await
-        .context("RunCouncilDecision failed (scenario 9)")?
-        .into_inner();
-
-    let winner = response
-        .winner
-        .ok_or_else(|| anyhow!("RunCouncilDecision returned no winner (scenario 9)"))?;
-    let proposal = winner
-        .proposal
-        .ok_or_else(|| anyhow!("winner has no proposal (scenario 9)"))?;
-    let proposal_id = proposal.proposal_id.clone();
-    let parsed: serde_json::Value =
-        serde_json::from_str(proposal.content.trim()).with_context(|| {
-            format!(
-                "winner proposal content must parse as JSON (scenario 9); got: {}",
-                proposal.content
-            )
-        })?;
-    if let Err(errors) = compiled_schema.validate(&parsed) {
-        let messages: Vec<String> = errors.map(|e| e.to_string()).collect();
-        bail!(
-            "winner proposal content failed Report schema (scenario 9): {}",
-            messages.join("; ")
-        );
-    }
-    let validation = response
-        .validation
-        .as_ref()
-        .ok_or_else(|| anyhow!("response has no validation summary (scenario 9)"))?;
-    if !validation.passed {
-        bail!("validation.passed should be true on the positive path (scenario 9)");
-    }
-    info!(
-        proposal_id = proposal_id.as_str(),
-        task_id = response.task_id.as_str(),
-        candidates_passed = validation.candidates_passed,
-        candidates_total = validation.candidates_total,
-        "RunCouncilDecision succeeded with Report-shaped winner via vllm kind"
-    );
-
-    let task_id = response.task_id.clone();
-    let deadline = std::time::Instant::now() + Duration::from_secs(15);
-    while std::time::Instant::now() < deadline {
-        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-        let chunk = remaining.min(Duration::from_secs(2));
-        match tokio::time::timeout(chunk, subscription.next()).await {
-            Ok(Some(msg)) => {
-                let payload: serde_json::Value = serde_json::from_slice(&msg.payload)
-                    .context("DeliberationCompleted (scenario 9) payload not JSON")?;
-                let got_task = payload.get("task_id").and_then(|v| v.as_str());
-                if got_task == Some(task_id.as_str()) {
-                    if payload.get("external_context_bundle_id").is_some() {
-                        bail!(
-                            "scenario 9 envelope must omit external_context_bundle_id (no bundle was sent), got {payload}"
-                        );
-                    }
-                    info!(
-                        out_event_id = payload
-                            .get("event_id")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or(""),
-                        task_id = task_id.as_str(),
-                        "DeliberationCompleted carried the expected task id (scenario 9)"
-                    );
-                    return Ok(());
-                }
-                warn!(
-                    ?got_task,
-                    "DeliberationCompleted seen for a different task_id; continuing"
-                );
-            }
-            Ok(None) => {
-                bail!("NATS subscription closed before scenario 9 envelope arrived");
-            }
-            Err(_) => {}
-        }
-    }
-    bail!("no DeliberationCompleted for {task_id} arrived within 15s (scenario 9)")
 }

--- a/crates/choreo-e2e-runner/src/scenario_selection.rs
+++ b/crates/choreo-e2e-runner/src/scenario_selection.rs
@@ -1,0 +1,212 @@
+use std::collections::BTreeSet;
+
+use anyhow::{bail, Result};
+
+pub(crate) const SCENARIO_SELECTION_ENV: &str = "CHOREO_E2E_SCENARIOS";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum E2eScenario {
+    SeededCouncil,
+    Deliberate,
+    DeleteMissingCouncil,
+    CausalMetadata,
+    RuntimeExecutor,
+    StrictSchemaRejection,
+    ExternalContextBundle,
+    OpenAiStructuredOutput,
+    VllmStructuredOutput,
+    VllmRealMultiAgent,
+}
+
+impl E2eScenario {
+    // Repo-owned compose scenarios only. Real provider scenarios stay
+    // opt-in because they require external infrastructure.
+    const ALL: [Self; 9] = [
+        Self::SeededCouncil,
+        Self::Deliberate,
+        Self::DeleteMissingCouncil,
+        Self::CausalMetadata,
+        Self::RuntimeExecutor,
+        Self::StrictSchemaRejection,
+        Self::ExternalContextBundle,
+        Self::OpenAiStructuredOutput,
+        Self::VllmStructuredOutput,
+    ];
+
+    const VLLM_REAL: [Self; 1] = [Self::VllmRealMultiAgent];
+
+    const CLUSTER_CONNECTIVITY: [Self; 4] = [
+        Self::SeededCouncil,
+        Self::Deliberate,
+        Self::DeleteMissingCouncil,
+        Self::CausalMetadata,
+    ];
+
+    const RUNTIME_STUB: [Self; 1] = [Self::RuntimeExecutor];
+
+    const STRUCTURED_OUTPUT: [Self; 4] = [
+        Self::StrictSchemaRejection,
+        Self::ExternalContextBundle,
+        Self::OpenAiStructuredOutput,
+        Self::VllmStructuredOutput,
+    ];
+
+    const fn number(self) -> u8 {
+        match self {
+            Self::SeededCouncil => 1,
+            Self::Deliberate => 2,
+            Self::DeleteMissingCouncil => 3,
+            Self::CausalMetadata => 4,
+            Self::RuntimeExecutor => 5,
+            Self::StrictSchemaRejection => 6,
+            Self::ExternalContextBundle => 7,
+            Self::OpenAiStructuredOutput => 8,
+            Self::VllmStructuredOutput => 9,
+            Self::VllmRealMultiAgent => 10,
+        }
+    }
+}
+
+pub(crate) fn parse_scenario_selection(raw: Option<&str>) -> Result<BTreeSet<E2eScenario>> {
+    let raw = raw
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("compose");
+    let mut selected = BTreeSet::new();
+    for token in raw
+        .split(|ch: char| ch == ',' || ch.is_whitespace())
+        .filter(|token| !token.is_empty())
+    {
+        add_scenario_token(token, &mut selected)?;
+    }
+    if selected.is_empty() {
+        bail!("scenario selection is empty");
+    }
+    Ok(selected)
+}
+
+fn add_scenario_token(token: &str, selected: &mut BTreeSet<E2eScenario>) -> Result<()> {
+    let normalized = token.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "compose" | "all" => {
+            selected.extend(E2eScenario::ALL);
+            return Ok(());
+        }
+        "cluster-connectivity" => {
+            selected.extend(E2eScenario::CLUSTER_CONNECTIVITY);
+            return Ok(());
+        }
+        "runtime-stub" => {
+            selected.extend(E2eScenario::RUNTIME_STUB);
+            return Ok(());
+        }
+        "structured-output" => {
+            selected.extend(E2eScenario::STRUCTURED_OUTPUT);
+            return Ok(());
+        }
+        "vllm-real" | "vllm-real-multi-agent" | "council-vllm" => {
+            selected.extend(E2eScenario::VLLM_REAL);
+            return Ok(());
+        }
+        _ => {}
+    }
+
+    if let Some((start, end)) = normalized.split_once('-') {
+        if let (Ok(start), Ok(end)) = (start.parse::<u8>(), end.parse::<u8>()) {
+            if start > end {
+                bail!("invalid scenario range `{token}`: start is greater than end");
+            }
+            for number in start..=end {
+                selected.insert(scenario_from_number(number)?);
+            }
+            return Ok(());
+        }
+    }
+
+    let numeric = normalized
+        .strip_prefix("scenario-")
+        .or_else(|| normalized.strip_prefix('s'))
+        .unwrap_or(&normalized);
+    if let Ok(number) = numeric.parse::<u8>() {
+        selected.insert(scenario_from_number(number)?);
+        return Ok(());
+    }
+
+    bail!(
+        "unknown scenario selector `{token}`; expected compose, cluster-connectivity, runtime-stub, structured-output, vllm-real-multi-agent, 1-10, or a range like 1-4"
+    )
+}
+
+fn scenario_from_number(number: u8) -> Result<E2eScenario> {
+    match number {
+        1 => Ok(E2eScenario::SeededCouncil),
+        2 => Ok(E2eScenario::Deliberate),
+        3 => Ok(E2eScenario::DeleteMissingCouncil),
+        4 => Ok(E2eScenario::CausalMetadata),
+        5 => Ok(E2eScenario::RuntimeExecutor),
+        6 => Ok(E2eScenario::StrictSchemaRejection),
+        7 => Ok(E2eScenario::ExternalContextBundle),
+        8 => Ok(E2eScenario::OpenAiStructuredOutput),
+        9 => Ok(E2eScenario::VllmStructuredOutput),
+        10 => Ok(E2eScenario::VllmRealMultiAgent),
+        _ => bail!("scenario number {number} is out of range; expected 1-10"),
+    }
+}
+
+pub(crate) fn scenario_selection_summary(selected: &BTreeSet<E2eScenario>) -> String {
+    selected
+        .iter()
+        .map(|scenario| scenario.number().to_string())
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn numbers(raw: Option<&str>) -> Vec<u8> {
+        parse_scenario_selection(raw)
+            .unwrap()
+            .iter()
+            .map(|scenario| scenario.number())
+            .collect()
+    }
+
+    #[test]
+    fn default_selection_is_full_compose_suite() {
+        assert_eq!(numbers(None), vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        assert_eq!(numbers(Some("")), vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        assert_eq!(
+            scenario_selection_summary(&parse_scenario_selection(None).unwrap()),
+            "1,2,3,4,5,6,7,8,9"
+        );
+    }
+
+    #[test]
+    fn named_groups_expand_to_expected_scenarios() {
+        assert_eq!(numbers(Some("compose")), vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        assert_eq!(numbers(Some("cluster-connectivity")), vec![1, 2, 3, 4]);
+        assert_eq!(numbers(Some("runtime-stub")), vec![5]);
+        assert_eq!(numbers(Some("structured-output")), vec![6, 7, 8, 9]);
+        assert_eq!(numbers(Some("vllm-real-multi-agent")), vec![10]);
+        assert_eq!(numbers(Some("council-vllm")), vec![10]);
+    }
+
+    #[test]
+    fn selection_accepts_numbers_ranges_and_mixed_tokens() {
+        assert_eq!(numbers(Some("1,3,scenario-5,s8")), vec![1, 3, 5, 8]);
+        assert_eq!(
+            numbers(Some("1-4 structured-output")),
+            vec![1, 2, 3, 4, 6, 7, 8, 9]
+        );
+        assert_eq!(numbers(Some("s10")), vec![10]);
+    }
+
+    #[test]
+    fn invalid_selection_is_rejected() {
+        assert!(parse_scenario_selection(Some("11")).is_err());
+        assert!(parse_scenario_selection(Some("4-1")).is_err());
+        assert!(parse_scenario_selection(Some("unknown")).is_err());
+    }
+}

--- a/crates/choreo-e2e-runner/src/scenarios/connectivity.rs
+++ b/crates/choreo-e2e-runner/src/scenarios/connectivity.rs
@@ -1,0 +1,183 @@
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Context, Result};
+use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
+use choreo_proto::v1::{DeleteCouncilRequest, DeliberateRequest, ListCouncilsRequest, Task};
+use futures::StreamExt;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+use tonic::transport::Channel;
+use tracing::{info, warn};
+
+pub(crate) async fn verify_seeded_council_visible(
+    client: &mut ChoreographerServiceClient<Channel>,
+    seed_specialty: &str,
+) -> Result<()> {
+    let councils = client
+        .list_councils(ListCouncilsRequest {
+            include_agents: false,
+        })
+        .await
+        .context("ListCouncils failed")?
+        .into_inner()
+        .councils;
+    if councils.is_empty() {
+        bail!(
+            "expected at least one seeded council — did the choreographer start with CHOREO_SEED_SPECIALTIES?"
+        );
+    }
+    if !councils.iter().any(|c| c.specialty == seed_specialty) {
+        bail!(
+            "seeded specialty {seed_specialty} not found among {:?}",
+            councils.iter().map(|c| &c.specialty).collect::<Vec<_>>()
+        );
+    }
+    Ok(())
+}
+
+pub(crate) async fn verify_deliberate_returns_winner(
+    client: &mut ChoreographerServiceClient<Channel>,
+    seed_specialty: &str,
+) -> Result<()> {
+    let response = client
+        .deliberate(DeliberateRequest {
+            task: Some(Task {
+                task_id: "e2e-task-1".to_owned(),
+                specialty: seed_specialty.to_owned(),
+                description: "End-to-end test: describe the situation.".to_owned(),
+                constraints: None,
+                attributes: None,
+                external_context: None,
+                metadata: None,
+            }),
+        })
+        .await
+        .context("Deliberate failed")?
+        .into_inner();
+
+    if response.task_id != "e2e-task-1" {
+        bail!("response.task_id = {:?}", response.task_id);
+    }
+    if response.winner_proposal_id.is_empty() {
+        bail!("winner_proposal_id is empty");
+    }
+    if response.results.is_empty() {
+        bail!("results[] is empty");
+    }
+    let winner = response
+        .results
+        .iter()
+        .find(|r| r.rank == 0)
+        .ok_or_else(|| anyhow!("no result with rank=0"))?;
+    let winner_id = winner
+        .proposal
+        .as_ref()
+        .map(|p| p.proposal_id.clone())
+        .ok_or_else(|| anyhow!("rank=0 result has no proposal"))?;
+    if winner_id != response.winner_proposal_id {
+        bail!(
+            "rank=0 proposal id {} disagrees with winner_proposal_id {}",
+            winner_id,
+            response.winner_proposal_id
+        );
+    }
+    Ok(())
+}
+
+pub(crate) async fn verify_delete_missing_council_returns_false(
+    client: &mut ChoreographerServiceClient<Channel>,
+) -> Result<()> {
+    let delete = client
+        .delete_council(DeleteCouncilRequest {
+            specialty: "unknown-specialty".to_owned(),
+        })
+        .await
+        .context("DeleteCouncil(unknown) failed")?
+        .into_inner();
+    if delete.deleted {
+        bail!("DeleteCouncil on an unknown specialty must return deleted=false");
+    }
+    Ok(())
+}
+
+/// Publishes a `TriggerEvent` on NATS with known `correlation_id` and
+/// `causation_id`, then asserts that the resulting
+/// `DeliberationCompleted` envelope on the outbound bus carries the
+/// same causal ids. Closes the stack-E2E loose end of Epic 5.
+pub(crate) async fn verify_causal_metadata_propagates_over_nats(specialty: &str) -> Result<()> {
+    let nats_url =
+        std::env::var("CHOREO_NATS_URL").unwrap_or_else(|_| "nats://nats:4222".to_owned());
+    let client = async_nats::connect(&nats_url)
+        .await
+        .with_context(|| format!("connect NATS at {nats_url}"))?;
+    info!(nats_url, "connected to NATS for causal metadata assertion");
+
+    let mut subscription = client
+        .subscribe("choreo.deliberation.completed".to_owned())
+        .await
+        .context("subscribe choreo.deliberation.completed")?;
+    // Flush so the SUB is acked by the server before we publish the
+    // trigger that should fan out into the event we're waiting for.
+    client.flush().await.context("flush NATS subscribe")?;
+
+    let event_id = "stack-e2e-trigger-1";
+    let correlation_id = "stack-e2e-corr";
+    let causation_id = "stack-e2e-cause";
+    let emitted_at = OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .context("format emitted_at as RFC 3339")?;
+    let trigger = serde_json::json!({
+        "event_id": event_id,
+        "emitted_at": emitted_at,
+        "source": "stack-e2e-runner",
+        "correlation_id": correlation_id,
+        "causation_id": causation_id,
+        "kind": "stack.e2e.trigger",
+        "requested_specialties": [specialty],
+    });
+    let subject = format!("choreo.trigger.{specialty}");
+    let payload = serde_json::to_vec(&trigger).context("serialize trigger payload")?;
+    client
+        .publish(subject.clone(), payload.into())
+        .await
+        .with_context(|| format!("publish trigger to {subject}"))?;
+    client.flush().await.context("flush NATS publish")?;
+    info!(subject, correlation_id, causation_id, "trigger published");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    while std::time::Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        let chunk = remaining.min(Duration::from_secs(2));
+        match tokio::time::timeout(chunk, subscription.next()).await {
+            Ok(Some(msg)) => {
+                let payload: serde_json::Value = serde_json::from_slice(&msg.payload)
+                    .context("DeliberationCompleted payload not JSON")?;
+                let got_corr = payload.get("correlation_id").and_then(|v| v.as_str());
+                let got_cause = payload.get("causation_id").and_then(|v| v.as_str());
+                if got_corr == Some(correlation_id) && got_cause == Some(causation_id) {
+                    info!(
+                        out_event_id = payload
+                            .get("event_id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or(""),
+                        correlation_id,
+                        causation_id,
+                        "DeliberationCompleted carried our causal ids"
+                    );
+                    return Ok(());
+                }
+                warn!(
+                    ?got_corr,
+                    ?got_cause,
+                    "DeliberationCompleted seen but causal ids did not match; continuing"
+                );
+            }
+            Ok(None) => {
+                bail!("NATS subscription closed before a matching DeliberationCompleted arrived");
+            }
+            Err(_) => {}
+        }
+    }
+
+    bail!("no DeliberationCompleted with the expected causal ids arrived within 15s")
+}

--- a/crates/choreo-e2e-runner/src/scenarios/mod.rs
+++ b/crates/choreo-e2e-runner/src/scenarios/mod.rs
@@ -1,0 +1,59 @@
+mod connectivity;
+mod runtime;
+mod structured_output;
+
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
+use prost_types::{value::Kind as PbKind, Struct as PbStruct, Value as PbValue};
+use tonic::transport::{Channel, Endpoint};
+use tracing::{info, warn};
+
+pub(crate) use connectivity::{
+    verify_causal_metadata_propagates_over_nats, verify_delete_missing_council_returns_false,
+    verify_deliberate_returns_winner, verify_seeded_council_visible,
+};
+pub(crate) use runtime::verify_orchestrate_invokes_runtime_executor;
+pub(crate) use structured_output::{
+    verify_external_context_bundle_round_trips, verify_multi_agent_council_against_real_vllm,
+    verify_orchestrate_rejects_proposal_violating_json_schema,
+    verify_structured_output_against_stub_llm, verify_structured_output_against_vllm_kind,
+};
+
+pub(crate) async fn connect_with_retry(
+    endpoint: &str,
+    total_budget: Duration,
+) -> Result<ChoreographerServiceClient<Channel>> {
+    let deadline = std::time::Instant::now() + total_budget;
+    let endpoint_parsed: Endpoint = endpoint
+        .parse()
+        .with_context(|| format!("invalid gRPC endpoint: {endpoint}"))?;
+
+    let mut last_err: Option<tonic::transport::Error> = None;
+    while std::time::Instant::now() < deadline {
+        match ChoreographerServiceClient::connect(endpoint_parsed.clone()).await {
+            Ok(c) => {
+                info!(endpoint, "connected");
+                return Ok(c);
+            }
+            Err(err) => {
+                warn!(endpoint, error = %err, "not ready yet; will retry");
+                last_err = Some(err);
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        }
+    }
+    Err(anyhow!(
+        "could not connect to {endpoint} within {total_budget:?}: {last_err:?}"
+    ))
+}
+
+fn pb_struct_from_pairs<'a>(pairs: impl IntoIterator<Item = (&'a str, PbKind)>) -> PbStruct {
+    PbStruct {
+        fields: pairs
+            .into_iter()
+            .map(|(k, kind)| (k.to_owned(), PbValue { kind: Some(kind) }))
+            .collect(),
+    }
+}

--- a/crates/choreo-e2e-runner/src/scenarios/runtime.rs
+++ b/crates/choreo-e2e-runner/src/scenarios/runtime.rs
@@ -1,0 +1,72 @@
+use anyhow::{anyhow, bail, Context, Result};
+use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
+use choreo_proto::v1::{OrchestrateRequest, Task};
+use prost_types::value::Kind as PbKind;
+use tonic::transport::Channel;
+use tracing::info;
+
+use super::pb_struct_from_pairs;
+
+/// Drives `Orchestrate` on the seeded council with a task that carries
+/// a `runtime.tool_name` attribute. The compose stack wires
+/// `CHOREO_EXECUTOR_KIND=runtime` pointing at the in-stack
+/// `stub-runtime` sidecar, so a successful outcome here proves the
+/// full chain — Deliberate -> winner -> RuntimeExecutor -> gRPC to
+/// `underpass.runtime.v1.{SessionService,InvocationService}` -> back
+/// up the use-case -> `TaskCompleted`.
+pub(crate) async fn verify_orchestrate_invokes_runtime_executor(
+    client: &mut ChoreographerServiceClient<Channel>,
+    specialty: &str,
+) -> Result<()> {
+    let attributes = pb_struct_from_pairs([(
+        "runtime.tool_name",
+        PbKind::StringValue("stub.echo".to_owned()),
+    )]);
+
+    let response = client
+        .orchestrate(OrchestrateRequest {
+            task: Some(Task {
+                task_id: "e2e-task-5".to_owned(),
+                specialty: specialty.to_owned(),
+                description: "End-to-end test: route winner through the Runtime executor."
+                    .to_owned(),
+                // No output_contract: NoopAgent emits free-form text,
+                // and a structured-output contract would force the
+                // proposal to be a JSON object. Validators stay no-op
+                // without a contract.
+                constraints: None,
+                attributes: Some(attributes),
+                external_context: None,
+                metadata: None,
+            }),
+            execution_options: None,
+        })
+        .await
+        .context("Orchestrate failed")?
+        .into_inner();
+
+    if response.task_id != "e2e-task-5" {
+        bail!("response.task_id = {:?}", response.task_id);
+    }
+    if response.execution_id != "stub-invocation-1" {
+        bail!(
+            "execution_id should be the stub-runtime's canned value, got {:?}",
+            response.execution_id
+        );
+    }
+    let winner = response
+        .winner
+        .ok_or_else(|| anyhow!("Orchestrate returned no winner"))?;
+    let winner_proposal = winner
+        .proposal
+        .ok_or_else(|| anyhow!("winner has no proposal"))?;
+    if winner_proposal.content.trim().is_empty() {
+        bail!("winner proposal content is empty");
+    }
+    info!(
+        execution_id = response.execution_id.as_str(),
+        winner_id = winner_proposal.proposal_id.as_str(),
+        "Orchestrate routed through stub-runtime"
+    );
+    Ok(())
+}

--- a/crates/choreo-e2e-runner/src/scenarios/structured_output/external_context.rs
+++ b/crates/choreo-e2e-runner/src/scenarios/structured_output/external_context.rs
@@ -1,0 +1,104 @@
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
+use choreo_proto::v1::{DeliberateRequest, ExternalContextBundle, Task};
+use futures::StreamExt;
+use tonic::transport::Channel;
+use tracing::{info, warn};
+
+/// Drives `Deliberate` with an `ExternalContextBundle` attached and
+/// asserts that the outbound `choreo.deliberation.completed` envelope
+/// carries the bundle id back. Closes the round-trip gap that
+/// scenario 4 leaves open (scenario 4 covers causal ids; this one
+/// covers the bundle pointer the kernel-shaped consumer would feed
+/// in).
+pub(crate) async fn verify_external_context_bundle_round_trips(
+    client: &mut ChoreographerServiceClient<Channel>,
+    specialty: &str,
+) -> Result<()> {
+    const BUNDLE_ID: &str = "scenario-7-bundle";
+
+    let nats_url =
+        std::env::var("CHOREO_NATS_URL").unwrap_or_else(|_| "nats://nats:4222".to_owned());
+    let nats = async_nats::connect(&nats_url)
+        .await
+        .with_context(|| format!("connect NATS at {nats_url}"))?;
+    let mut subscription = nats
+        .subscribe("choreo.deliberation.completed".to_owned())
+        .await
+        .context("subscribe choreo.deliberation.completed for scenario 7")?;
+    nats.flush()
+        .await
+        .context("flush NATS subscribe (scenario 7)")?;
+
+    let task_id = "e2e-task-7";
+    let external_context = ExternalContextBundle {
+        bundle_id: BUNDLE_ID.to_owned(),
+        schema_version: "v1".to_owned(),
+        summary: None,
+        items: vec![],
+        references: vec![],
+        metadata: None,
+    };
+
+    let response = client
+        .deliberate(DeliberateRequest {
+            task: Some(Task {
+                task_id: task_id.to_owned(),
+                description: "scenario 7 ExternalContextBundle round-trip".to_owned(),
+                specialty: specialty.to_owned(),
+                constraints: None,
+                attributes: None,
+                external_context: Some(external_context),
+                metadata: None,
+            }),
+        })
+        .await
+        .context("Deliberate (scenario 7) failed")?
+        .into_inner();
+    if response.winner_proposal_id.is_empty() {
+        bail!("Deliberate did not return a winner for scenario 7");
+    }
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    while std::time::Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        let chunk = remaining.min(Duration::from_secs(2));
+        match tokio::time::timeout(chunk, subscription.next()).await {
+            Ok(Some(msg)) => {
+                let payload: serde_json::Value = serde_json::from_slice(&msg.payload)
+                    .context("DeliberationCompleted (scenario 7) payload not JSON")?;
+                let got_task = payload.get("task_id").and_then(|v| v.as_str());
+                let got_bundle = payload
+                    .get("external_context_bundle_id")
+                    .and_then(|v| v.as_str());
+                if got_task == Some(task_id) {
+                    if got_bundle == Some(BUNDLE_ID) {
+                        info!(
+                            out_event_id = payload
+                                .get("event_id")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or(""),
+                            bundle_id = BUNDLE_ID,
+                            "DeliberationCompleted carried the external_context_bundle_id"
+                        );
+                        return Ok(());
+                    }
+                    bail!(
+                        "DeliberationCompleted for {task_id} missing external_context_bundle_id (got {got_bundle:?})"
+                    );
+                }
+                warn!(
+                    ?got_task,
+                    "DeliberationCompleted seen for a different task_id; continuing"
+                );
+            }
+            Ok(None) => {
+                bail!("NATS subscription closed before scenario 7 envelope arrived");
+            }
+            Err(_) => {}
+        }
+    }
+    bail!("no DeliberationCompleted for {task_id} arrived within 15s")
+}

--- a/crates/choreo-e2e-runner/src/scenarios/structured_output/mod.rs
+++ b/crates/choreo-e2e-runner/src/scenarios/structured_output/mod.rs
@@ -1,0 +1,11 @@
+mod external_context;
+mod real_vllm_multi_agent;
+mod report_openai;
+mod report_vllm;
+mod strict_schema;
+
+pub(crate) use external_context::verify_external_context_bundle_round_trips;
+pub(crate) use real_vllm_multi_agent::verify_multi_agent_council_against_real_vllm;
+pub(crate) use report_openai::verify_structured_output_against_stub_llm;
+pub(crate) use report_vllm::verify_structured_output_against_vllm_kind;
+pub(crate) use strict_schema::verify_orchestrate_rejects_proposal_violating_json_schema;

--- a/crates/choreo-e2e-runner/src/scenarios/structured_output/real_vllm_multi_agent.rs
+++ b/crates/choreo-e2e-runner/src/scenarios/structured_output/real_vllm_multi_agent.rs
@@ -1,0 +1,438 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{anyhow, bail, Context, Result};
+use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
+use choreo_proto::v1::run_council_decision_request::Selector as RunCouncilSelector;
+use choreo_proto::v1::{
+    AgentSummary, CreateCouncilRequest, OutputContract, OutputFormat, RegisterAgentRequest,
+    RegisterContractRequest, RunCouncilDecisionRequest, ValidationMode,
+};
+use prost_types::value::Kind as PbKind;
+use tonic::transport::Channel;
+use tonic::Code;
+use tracing::info;
+
+use super::super::pb_struct_from_pairs;
+
+const VLLM_ENDPOINT_ENV: &str = "CHOREO_VLLM_ENDPOINT";
+const VLLM_MODEL_ENV: &str = "CHOREO_VLLM_MODEL";
+const VLLM_AGENT_COUNT_ENV: &str = "CHOREO_VLLM_AGENT_COUNT";
+const VLLM_MAX_TOKENS_ENV: &str = "CHOREO_VLLM_MAX_TOKENS";
+const VLLM_TIMEOUT_SECS_ENV: &str = "CHOREO_VLLM_TIMEOUT_SECS";
+const RUN_ID_ENV: &str = "CHOREO_E2E_RUN_ID";
+
+/// Full Choreographer E2E against a real vLLM provider.
+///
+/// This differs from the provider-level runner: it registers multiple
+/// `kind=vllm` agents through the public gRPC surface, creates a real
+/// council, then runs `RunCouncilDecision` in Strict mode and asserts
+/// that more than one candidate was considered and revised by the
+/// peer-review ceremony.
+pub(crate) async fn verify_multi_agent_council_against_real_vllm(
+    client: &mut ChoreographerServiceClient<Channel>,
+) -> Result<()> {
+    let endpoint = required_env(VLLM_ENDPOINT_ENV)?;
+    let model = required_env(VLLM_MODEL_ENV)?;
+    let agent_count = env_u32(VLLM_AGENT_COUNT_ENV, 3)?;
+    let max_tokens = env_u32(VLLM_MAX_TOKENS_ENV, 512)?;
+    let timeout_secs = env_u32(VLLM_TIMEOUT_SECS_ENV, 300)?;
+    if agent_count < 2 {
+        bail!("{VLLM_AGENT_COUNT_ENV} must be >= 2 for the multi-agent vLLM E2E");
+    }
+    let run_id = std::env::var(RUN_ID_ENV)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(default_run_id);
+    let specialty = format!("report-vllm-real-{run_id}");
+    let contract_id = format!("scenario-10-report-vllm-real-{run_id}");
+
+    let schema_body = e2e_report_schema();
+    let schema_value: serde_json::Value =
+        serde_json::from_str(&schema_body).context("Report schema must parse as JSON")?;
+    let compiled_schema = jsonschema::JSONSchema::compile(&schema_value)
+        .map_err(|err| anyhow!("Report schema must compile: {err}"))?;
+
+    register_contract(client, &contract_id, &schema_body).await?;
+
+    for i in 0..agent_count {
+        let agent_id = format!("agent-{specialty}-{i}");
+        register_vllm_agent(
+            client,
+            &agent_id,
+            &specialty,
+            &endpoint,
+            &model,
+            max_tokens,
+            timeout_secs,
+        )
+        .await?;
+    }
+
+    create_council(client, &specialty, agent_count).await?;
+
+    let response = client
+        .run_council_decision(RunCouncilDecisionRequest {
+            contract_id: contract_id.clone(),
+            external_context: None,
+            validation_mode: ValidationMode::Strict as i32,
+            metadata: None,
+            description: format!(
+                "E2E run {run_id}: produce a concise incident-style Report JSON. \
+                 Return only a JSON object, with no markdown and no explanatory text. \
+                 Use exactly this minimal shape: \
+                 {{\"report_id\":\"{run_id}\",\"executive_summary\":\"one concise paragraph\",\
+                 \"findings\":[{{\"id\":\"finding-1\",\"summary\":\"one concrete finding\",\
+                 \"confidence\":\"medium\"}}],\"recommended_actions\":[{{\"id\":\"action-1\",\
+                 \"summary\":\"one concrete action\",\"approval_required\":false}}]}}. \
+                 You may change string values to fit the task, but do not add top-level fields \
+                 and do not add object fields that are not present in the JSON Schema."
+            ),
+            selector: Some(RunCouncilSelector::Specialty(specialty.clone())),
+        })
+        .await
+        .with_context(|| {
+            format!("RunCouncilDecision failed for multi-agent real vLLM council `{specialty}`")
+        })?
+        .into_inner();
+
+    let winner = response
+        .winner
+        .ok_or_else(|| anyhow!("RunCouncilDecision returned no winner"))?;
+    let proposal = winner
+        .proposal
+        .ok_or_else(|| anyhow!("winner has no proposal"))?;
+    let validation = response
+        .validation
+        .as_ref()
+        .ok_or_else(|| anyhow!("response has no validation summary"))?;
+    if !validation.passed {
+        bail!(
+            "expected the Strict-mode vLLM council decision to pass the Report contract; candidate reports: {}",
+            summarize_candidate_reports(&response.candidates)
+        );
+    }
+    if proposal.revision_count == 0 {
+        bail!(
+            "winner proposal was not revised; expected peer-review interaction before validation"
+        );
+    }
+    let parsed: serde_json::Value =
+        serde_json::from_str(proposal.content.trim()).with_context(|| {
+            format!(
+                "winner proposal content must parse as JSON; got: {}",
+                proposal.content
+            )
+        })?;
+    if let Err(errors) = compiled_schema.validate(&parsed) {
+        let messages: Vec<String> = errors.map(|e| e.to_string()).collect();
+        bail!(
+            "winner proposal content failed Report schema: {}",
+            messages.join("; ")
+        );
+    }
+
+    if validation.candidates_total < agent_count {
+        bail!(
+            "expected at least {agent_count} candidates from the vLLM council, got {}",
+            validation.candidates_total
+        );
+    }
+    if validation.candidates_passed == 0 {
+        bail!("expected at least one schema-valid candidate from the vLLM council");
+    }
+    let unrevised: Vec<String> = response
+        .candidates
+        .iter()
+        .filter(|candidate| candidate.revision_count == 0)
+        .map(|candidate| candidate.proposal_id.clone())
+        .collect();
+    if !unrevised.is_empty() {
+        bail!(
+            "expected every vLLM candidate to have peer-review revisions; unrevised proposal ids: {}",
+            unrevised.join(", ")
+        );
+    }
+    let distinct_authors = response
+        .candidates
+        .iter()
+        .map(|candidate| candidate.author_agent_id.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    if distinct_authors.len() < agent_count as usize {
+        bail!(
+            "expected candidates from {agent_count} distinct vLLM agents, got {}",
+            distinct_authors.len()
+        );
+    }
+
+    info!(
+        task_id = response.task_id.as_str(),
+        specialty,
+        contract_id,
+        endpoint,
+        model,
+        agent_count,
+        max_tokens,
+        timeout_secs,
+        winner_revision_count = proposal.revision_count,
+        candidates_passed = validation.candidates_passed,
+        candidates_total = validation.candidates_total,
+        "multi-agent real vLLM peer-review ceremony produced a schema-valid winner"
+    );
+    Ok(())
+}
+
+fn e2e_report_schema() -> String {
+    serde_json::json!({
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "https://underpass.ai/choreographer/e2e/report-minimal.schema.json",
+        "title": "Minimal Report Output Contract for real vLLM E2E",
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+            "report_id",
+            "executive_summary",
+            "findings",
+            "recommended_actions"
+        ],
+        "properties": {
+            "report_id": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128
+            },
+            "executive_summary": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 1024
+            },
+            "findings": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 3,
+                "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["id", "summary", "confidence"],
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 64
+                        },
+                        "summary": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 512
+                        },
+                        "confidence": {
+                            "type": "string",
+                            "enum": ["high", "medium", "low", "unknown"]
+                        }
+                    }
+                }
+            },
+            "recommended_actions": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 3,
+                "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["id", "summary", "approval_required"],
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 64
+                        },
+                        "summary": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 512
+                        },
+                        "approval_required": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        }
+    })
+    .to_string()
+}
+
+fn summarize_candidate_reports(candidates: &[choreo_proto::v1::CandidateSummary]) -> String {
+    candidates
+        .iter()
+        .map(|candidate| {
+            let reports = candidate
+                .reports
+                .iter()
+                .map(|report| {
+                    format!(
+                        "{}:{}:{}",
+                        report.kind,
+                        if report.passed { "passed" } else { "failed" },
+                        report.summary
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("|");
+            format!(
+                "{} rank={} score={} revised={} reports=[{}]",
+                candidate.proposal_id,
+                candidate.rank,
+                candidate.score,
+                candidate.revision_count,
+                reports
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+async fn register_contract(
+    client: &mut ChoreographerServiceClient<Channel>,
+    contract_id: &str,
+    schema_body: &str,
+) -> Result<()> {
+    let result = client
+        .register_contract(RegisterContractRequest {
+            contract: Some(OutputContract {
+                contract_id: contract_id.to_owned(),
+                format: OutputFormat::JsonObject as i32,
+                fields: std::collections::HashMap::new(),
+                json_schema: schema_body.to_owned(),
+            }),
+        })
+        .await;
+    match result {
+        Ok(_) => {
+            info!(contract_id, "RegisterContract ok (real vLLM multi-agent)");
+            Ok(())
+        }
+        Err(status)
+            if matches!(
+                status.code(),
+                Code::AlreadyExists | Code::FailedPrecondition
+            ) =>
+        {
+            info!(
+                code = ?status.code(),
+                contract_id,
+                "RegisterContract tolerated (contract already present)"
+            );
+            Ok(())
+        }
+        Err(status) => bail!("RegisterContract failed unexpectedly: {status}"),
+    }
+}
+
+async fn register_vllm_agent(
+    client: &mut ChoreographerServiceClient<Channel>,
+    agent_id: &str,
+    specialty: &str,
+    endpoint: &str,
+    model: &str,
+    max_tokens: u32,
+    timeout_secs: u32,
+) -> Result<()> {
+    let attrs = pb_struct_from_pairs([
+        (
+            "provider.endpoint",
+            PbKind::StringValue(endpoint.to_owned()),
+        ),
+        ("provider.model", PbKind::StringValue(model.to_owned())),
+        (
+            "provider.max_tokens",
+            PbKind::NumberValue(max_tokens.into()),
+        ),
+        (
+            "provider.timeout_secs",
+            PbKind::NumberValue(timeout_secs.into()),
+        ),
+    ]);
+    let result = client
+        .register_agent(RegisterAgentRequest {
+            specialty: specialty.to_owned(),
+            agent: Some(AgentSummary {
+                agent_id: agent_id.to_owned(),
+                specialty: specialty.to_owned(),
+                kind: "vllm".to_owned(),
+                attributes: None,
+            }),
+            agent_config: Some(attrs),
+        })
+        .await;
+    match result {
+        Ok(_) => {
+            info!(agent_id, specialty, "RegisterAgent ok (real vLLM)");
+            Ok(())
+        }
+        Err(status) if status.code() == Code::AlreadyExists => {
+            info!(
+                agent_id,
+                specialty, "RegisterAgent tolerated (agent already present)"
+            );
+            Ok(())
+        }
+        Err(status) => bail!("RegisterAgent failed unexpectedly for {agent_id}: {status}"),
+    }
+}
+
+async fn create_council(
+    client: &mut ChoreographerServiceClient<Channel>,
+    specialty: &str,
+    agent_count: u32,
+) -> Result<()> {
+    let result = client
+        .create_council(CreateCouncilRequest {
+            specialty: specialty.to_owned(),
+            num_agents: agent_count,
+            agent_config: None,
+        })
+        .await;
+    match result {
+        Ok(_) => {
+            info!(specialty, agent_count, "CreateCouncil ok (real vLLM)");
+            Ok(())
+        }
+        Err(status) if status.code() == Code::AlreadyExists => {
+            info!(
+                specialty,
+                "CreateCouncil tolerated (council already present)"
+            );
+            Ok(())
+        }
+        Err(status) => bail!("CreateCouncil failed unexpectedly: {status}"),
+    }
+}
+
+fn required_env(name: &str) -> Result<String> {
+    let raw = std::env::var(name).map_err(|_| anyhow!("required env var {name} is not set"))?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        bail!("required env var {name} is empty");
+    }
+    Ok(trimmed.to_owned())
+}
+
+fn env_u32(name: &str, default: u32) -> Result<u32> {
+    std::env::var(name)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .map(|raw| {
+            raw.parse::<u32>()
+                .with_context(|| format!("{name} must parse as u32"))
+        })
+        .transpose()
+        .map(|value| value.unwrap_or(default))
+}
+
+fn default_run_id() -> String {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or(0);
+    format!("{}-{millis}", std::process::id())
+}

--- a/crates/choreo-e2e-runner/src/scenarios/structured_output/real_vllm_multi_agent.rs
+++ b/crates/choreo-e2e-runner/src/scenarios/structured_output/real_vllm_multi_agent.rs
@@ -28,6 +28,7 @@ const RUN_ID_ENV: &str = "CHOREO_E2E_RUN_ID";
 /// council, then runs `RunCouncilDecision` in Strict mode and asserts
 /// that more than one candidate was considered and revised by the
 /// peer-review ceremony.
+#[allow(clippy::too_many_lines)] // single real-provider E2E scenario; splitting fragments the assertion
 pub(crate) async fn verify_multi_agent_council_against_real_vllm(
     client: &mut ChoreographerServiceClient<Channel>,
 ) -> Result<()> {
@@ -432,7 +433,6 @@ fn env_u32(name: &str, default: u32) -> Result<u32> {
 fn default_run_id() -> String {
     let millis = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_millis())
-        .unwrap_or(0);
+        .map_or(0, |duration| duration.as_millis());
     format!("{}-{millis}", std::process::id())
 }

--- a/crates/choreo-e2e-runner/src/scenarios/structured_output/report_openai.rs
+++ b/crates/choreo-e2e-runner/src/scenarios/structured_output/report_openai.rs
@@ -1,0 +1,277 @@
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Context, Result};
+use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
+use choreo_proto::v1::run_council_decision_request::Selector as RunCouncilSelector;
+use choreo_proto::v1::{
+    AgentSummary, CreateCouncilRequest, OutputContract, OutputFormat, RegisterAgentRequest,
+    RegisterContractRequest, RunCouncilDecisionRequest, ValidationMode,
+};
+use futures::StreamExt;
+use prost_types::value::Kind as PbKind;
+use tonic::transport::Channel;
+use tonic::Code;
+use tracing::{info, warn};
+
+use super::super::pb_struct_from_pairs;
+
+/// Drives `RunCouncilDecision` end-to-end against a stub OpenAI-shaped
+/// agent that always emits a JSON Report payload satisfying
+/// `api/examples/output-contracts/report.schema.json`. Closes the
+/// positive structured-output gap left by scenario 6 (which only
+/// proves the rejection path against `NoopAgent`).
+///
+/// Steps:
+///
+/// 1. Read the Report JSON Schema from
+///    `CHOREO_REPORT_SCHEMA_PATH` (compose pins it to
+///    `/etc/choreo/report.schema.json`).
+/// 2. Register the contract via `RegisterContract`. Tolerate the
+///    `AlreadyExists` and `FailedPrecondition` codes so a re-run
+///    against the same compose stack does not flake.
+/// 3. Register an `openai`-kind agent that points at `http://stub-llm:8000`.
+/// 4. Create a council with that single agent under specialty
+///    `"report"`.
+/// 5. Pre-subscribe to `choreo.deliberation.completed` so the bus
+///    envelope assertion cannot race.
+/// 6. Call `RunCouncilDecision` in `STRICT` mode bound to the
+///    contract.
+/// 7. Assert the response carries a winner whose proposal content
+///    parses as JSON and satisfies the Report schema; assert
+///    `validation.passed == true`.
+/// 8. Assert the outbound envelope carries the same task id and
+///    OMITS the `external_context_bundle_id` field (no bundle was
+///    passed — the field is `skip_serializing_if = Option::is_none`,
+///    so an absence is the contract, not an empty string).
+#[allow(clippy::too_many_lines)] // single end-to-end scenario; splitting fragments the assertion
+pub(crate) async fn verify_structured_output_against_stub_llm(
+    client: &mut ChoreographerServiceClient<Channel>,
+) -> Result<()> {
+    const CONTRACT_ID: &str = "scenario-8-report";
+    // Must match the id pattern the CreateCouncil handler mints
+    // (`agent-{specialty}-{i}`); without that pairing the council
+    // create step fails resolving the agent.
+    const AGENT_ID: &str = "agent-report-0";
+    const SPECIALTY: &str = "report";
+    const STUB_ENDPOINT: &str = "http://stub-llm:8000";
+
+    let schema_path = std::env::var("CHOREO_REPORT_SCHEMA_PATH")
+        .unwrap_or_else(|_| "/etc/choreo/report.schema.json".to_owned());
+    let schema_body = std::fs::read_to_string(&schema_path)
+        .with_context(|| format!("read Report schema at {schema_path}"))?;
+    let schema_value: serde_json::Value =
+        serde_json::from_str(&schema_body).context("Report schema must parse as JSON")?;
+    let compiled_schema = jsonschema::JSONSchema::compile(&schema_value)
+        .map_err(|err| anyhow!("Report schema must compile: {err}"))?;
+
+    // 2. Register the contract. Tolerate AlreadyExists /
+    // FailedPrecondition so a re-run against the same compose stack
+    // does not flake.
+    let register_contract = client
+        .register_contract(RegisterContractRequest {
+            contract: Some(OutputContract {
+                contract_id: CONTRACT_ID.to_owned(),
+                format: OutputFormat::JsonObject as i32,
+                fields: std::collections::HashMap::new(),
+                json_schema: schema_body.clone(),
+            }),
+        })
+        .await;
+    match register_contract {
+        Ok(_) => info!(contract_id = CONTRACT_ID, "RegisterContract ok"),
+        Err(status)
+            if matches!(
+                status.code(),
+                Code::AlreadyExists | Code::FailedPrecondition
+            ) =>
+        {
+            info!(
+                code = ?status.code(),
+                contract_id = CONTRACT_ID,
+                "RegisterContract tolerated (contract already present)"
+            );
+        }
+        Err(status) => bail!("RegisterContract failed unexpectedly: {status}"),
+    }
+
+    // 3. Register the openai-kind agent pointing at the stub-llm
+    // sidecar. The attribute keys mirror `DispatchingAgentFactory`'s
+    // recognised overrides (`provider.endpoint`, `provider.model`).
+    // The api_key attribute is NOT consumed by the factory (which
+    // demands a base config from env) — it's carried purely as a
+    // forward-compatible marker. compose sets a dummy
+    // `CHOREO_OPENAI_API_KEY` so the factory has a base config.
+    let agent_attrs = pb_struct_from_pairs([
+        (
+            "provider.endpoint",
+            PbKind::StringValue(STUB_ENDPOINT.to_owned()),
+        ),
+        (
+            "provider.model",
+            PbKind::StringValue("stub-report-v1".to_owned()),
+        ),
+        (
+            "provider.api_key",
+            PbKind::StringValue("stub-key-not-used".to_owned()),
+        ),
+    ]);
+    let register_agent = client
+        .register_agent(RegisterAgentRequest {
+            specialty: SPECIALTY.to_owned(),
+            agent: Some(AgentSummary {
+                agent_id: AGENT_ID.to_owned(),
+                specialty: SPECIALTY.to_owned(),
+                kind: "openai".to_owned(),
+                // The RegisterAgent mapper reads `agent_config`
+                // (NOT this nested attributes field) to feed the
+                // descriptor passed to the factory. Carrying the
+                // attributes here would silently drop them.
+                attributes: None,
+            }),
+            // `provider.endpoint` + `provider.model` must travel here
+            // for the factory to apply them as overrides.
+            agent_config: Some(agent_attrs),
+        })
+        .await;
+    match register_agent {
+        Ok(_) => info!(agent_id = AGENT_ID, "RegisterAgent ok"),
+        Err(status) if status.code() == Code::AlreadyExists => {
+            info!(
+                agent_id = AGENT_ID,
+                "RegisterAgent tolerated (agent already present)"
+            );
+        }
+        Err(status) => bail!("RegisterAgent failed unexpectedly: {status}"),
+    }
+
+    // 4. Create a council under specialty `report`. Tolerate
+    // AlreadyExists so a re-run against the same compose stack does
+    // not flake.
+    let create_council = client
+        .create_council(CreateCouncilRequest {
+            specialty: SPECIALTY.to_owned(),
+            num_agents: 1,
+            agent_config: None,
+        })
+        .await;
+    match create_council {
+        Ok(_) => info!(specialty = SPECIALTY, "CreateCouncil ok"),
+        Err(status) if status.code() == Code::AlreadyExists => {
+            info!(
+                specialty = SPECIALTY,
+                "CreateCouncil tolerated (council already present)"
+            );
+        }
+        Err(status) => bail!("CreateCouncil failed unexpectedly: {status}"),
+    }
+
+    // 5. Pre-subscribe so the published envelope cannot race the
+    // RPC.
+    let nats_url =
+        std::env::var("CHOREO_NATS_URL").unwrap_or_else(|_| "nats://nats:4222".to_owned());
+    let nats = async_nats::connect(&nats_url)
+        .await
+        .with_context(|| format!("connect NATS at {nats_url}"))?;
+    let mut subscription = nats
+        .subscribe("choreo.deliberation.completed".to_owned())
+        .await
+        .context("subscribe choreo.deliberation.completed for scenario 8")?;
+    nats.flush()
+        .await
+        .context("flush NATS subscribe (scenario 8)")?;
+
+    // 6. Call RunCouncilDecision.
+    let response = client
+        .run_council_decision(RunCouncilDecisionRequest {
+            contract_id: CONTRACT_ID.to_owned(),
+            external_context: None,
+            validation_mode: ValidationMode::Strict as i32,
+            metadata: None,
+            description: "scenario 8 structured-output positive path".to_owned(),
+            selector: Some(RunCouncilSelector::Specialty(SPECIALTY.to_owned())),
+        })
+        .await
+        .context("RunCouncilDecision failed (scenario 8)")?
+        .into_inner();
+
+    // 7. Assertions on the response.
+    let winner = response
+        .winner
+        .ok_or_else(|| anyhow!("RunCouncilDecision returned no winner"))?;
+    let proposal = winner
+        .proposal
+        .ok_or_else(|| anyhow!("winner has no proposal"))?;
+    let proposal_id = proposal.proposal_id.clone();
+    let parsed: serde_json::Value =
+        serde_json::from_str(proposal.content.trim()).with_context(|| {
+            format!(
+                "winner proposal content must parse as JSON; got: {}",
+                proposal.content
+            )
+        })?;
+    if let Err(errors) = compiled_schema.validate(&parsed) {
+        let messages: Vec<String> = errors.map(|e| e.to_string()).collect();
+        bail!(
+            "winner proposal content failed Report schema: {}",
+            messages.join("; ")
+        );
+    }
+    let validation = response
+        .validation
+        .as_ref()
+        .ok_or_else(|| anyhow!("response has no validation summary"))?;
+    if !validation.passed {
+        bail!("validation.passed should be true on the positive path");
+    }
+    info!(
+        proposal_id = proposal_id.as_str(),
+        task_id = response.task_id.as_str(),
+        candidates_passed = validation.candidates_passed,
+        candidates_total = validation.candidates_total,
+        "RunCouncilDecision succeeded with Report-shaped winner"
+    );
+
+    // 8. Bus envelope assertion. The task did NOT carry an
+    // ExternalContextBundle, so the JSON envelope MUST omit the
+    // `external_context_bundle_id` field (the field is annotated
+    // `skip_serializing_if = Option::is_none`). Asserting absence —
+    // not "empty string" — is the contract.
+    let task_id = response.task_id.clone();
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    while std::time::Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        let chunk = remaining.min(Duration::from_secs(2));
+        match tokio::time::timeout(chunk, subscription.next()).await {
+            Ok(Some(msg)) => {
+                let payload: serde_json::Value = serde_json::from_slice(&msg.payload)
+                    .context("DeliberationCompleted (scenario 8) payload not JSON")?;
+                let got_task = payload.get("task_id").and_then(|v| v.as_str());
+                if got_task == Some(task_id.as_str()) {
+                    if payload.get("external_context_bundle_id").is_some() {
+                        bail!(
+                            "scenario 8 envelope must omit external_context_bundle_id (no bundle was sent), got {payload}"
+                        );
+                    }
+                    info!(
+                        out_event_id = payload
+                            .get("event_id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or(""),
+                        task_id = task_id.as_str(),
+                        "DeliberationCompleted carried the expected task id and no bundle id"
+                    );
+                    return Ok(());
+                }
+                warn!(
+                    ?got_task,
+                    "DeliberationCompleted seen for a different task_id; continuing"
+                );
+            }
+            Ok(None) => {
+                bail!("NATS subscription closed before scenario 8 envelope arrived");
+            }
+            Err(_) => {}
+        }
+    }
+    bail!("no DeliberationCompleted for {task_id} arrived within 15s (scenario 8)")
+}

--- a/crates/choreo-e2e-runner/src/scenarios/structured_output/report_vllm.rs
+++ b/crates/choreo-e2e-runner/src/scenarios/structured_output/report_vllm.rs
@@ -1,0 +1,229 @@
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Context, Result};
+use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
+use choreo_proto::v1::run_council_decision_request::Selector as RunCouncilSelector;
+use choreo_proto::v1::{
+    AgentSummary, CreateCouncilRequest, OutputContract, OutputFormat, RegisterAgentRequest,
+    RegisterContractRequest, RunCouncilDecisionRequest, ValidationMode,
+};
+use futures::StreamExt;
+use prost_types::value::Kind as PbKind;
+use tonic::transport::Channel;
+use tonic::Code;
+use tracing::{info, warn};
+
+use super::super::pb_struct_from_pairs;
+
+/// Same end-to-end Report-contract success path as scenario 8, but
+/// the council's agent is registered with `kind=vllm`. The vLLM
+/// adapter sends the same `POST /v1/chat/completions` body shape the
+/// OpenAI adapter does, so we point it at the existing `stub-llm`
+/// sidecar — no second sidecar needed. Proves the vllm-shaped path
+/// works in the same compose run that scenario 8 covers for the
+/// openai-shaped path, closing Epic 11's provider-runner-merge
+/// follow-up.
+#[allow(clippy::too_many_lines)] // single end-to-end scenario; splitting fragments the assertion
+pub(crate) async fn verify_structured_output_against_vllm_kind(
+    client: &mut ChoreographerServiceClient<Channel>,
+) -> Result<()> {
+    const CONTRACT_ID: &str = "scenario-9-report-vllm";
+    // Must match the id pattern the CreateCouncil handler mints
+    // (`agent-{specialty}-{i}`).
+    const AGENT_ID: &str = "agent-report-vllm-0";
+    const SPECIALTY: &str = "report-vllm";
+    const STUB_ENDPOINT: &str = "http://stub-llm:8000";
+
+    let schema_path = std::env::var("CHOREO_REPORT_SCHEMA_PATH")
+        .unwrap_or_else(|_| "/etc/choreo/report.schema.json".to_owned());
+    let schema_body = std::fs::read_to_string(&schema_path)
+        .with_context(|| format!("read Report schema at {schema_path}"))?;
+    let schema_value: serde_json::Value =
+        serde_json::from_str(&schema_body).context("Report schema must parse as JSON")?;
+    let compiled_schema = jsonschema::JSONSchema::compile(&schema_value)
+        .map_err(|err| anyhow!("Report schema must compile: {err}"))?;
+
+    let register_contract = client
+        .register_contract(RegisterContractRequest {
+            contract: Some(OutputContract {
+                contract_id: CONTRACT_ID.to_owned(),
+                format: OutputFormat::JsonObject as i32,
+                fields: std::collections::HashMap::new(),
+                json_schema: schema_body.clone(),
+            }),
+        })
+        .await;
+    match register_contract {
+        Ok(_) => info!(
+            contract_id = CONTRACT_ID,
+            "RegisterContract ok (scenario 9)"
+        ),
+        Err(status)
+            if matches!(
+                status.code(),
+                Code::AlreadyExists | Code::FailedPrecondition
+            ) =>
+        {
+            info!(
+                code = ?status.code(),
+                contract_id = CONTRACT_ID,
+                "RegisterContract tolerated (contract already present)"
+            );
+        }
+        Err(status) => bail!("RegisterContract failed unexpectedly (scenario 9): {status}"),
+    }
+
+    // The vllm adapter does NOT read `provider.api_key`; only the
+    // endpoint + model overrides are meaningful.
+    let agent_attrs = pb_struct_from_pairs([
+        (
+            "provider.endpoint",
+            PbKind::StringValue(STUB_ENDPOINT.to_owned()),
+        ),
+        (
+            "provider.model",
+            PbKind::StringValue("stub-report-vllm-v1".to_owned()),
+        ),
+    ]);
+    let register_agent = client
+        .register_agent(RegisterAgentRequest {
+            specialty: SPECIALTY.to_owned(),
+            agent: Some(AgentSummary {
+                agent_id: AGENT_ID.to_owned(),
+                specialty: SPECIALTY.to_owned(),
+                kind: "vllm".to_owned(),
+                attributes: None,
+            }),
+            agent_config: Some(agent_attrs),
+        })
+        .await;
+    match register_agent {
+        Ok(_) => info!(agent_id = AGENT_ID, "RegisterAgent ok (scenario 9)"),
+        Err(status) if status.code() == Code::AlreadyExists => {
+            info!(
+                agent_id = AGENT_ID,
+                "RegisterAgent tolerated (agent already present)"
+            );
+        }
+        Err(status) => bail!("RegisterAgent failed unexpectedly (scenario 9): {status}"),
+    }
+
+    let create_council = client
+        .create_council(CreateCouncilRequest {
+            specialty: SPECIALTY.to_owned(),
+            num_agents: 1,
+            agent_config: None,
+        })
+        .await;
+    match create_council {
+        Ok(_) => info!(specialty = SPECIALTY, "CreateCouncil ok (scenario 9)"),
+        Err(status) if status.code() == Code::AlreadyExists => {
+            info!(
+                specialty = SPECIALTY,
+                "CreateCouncil tolerated (council already present)"
+            );
+        }
+        Err(status) => bail!("CreateCouncil failed unexpectedly (scenario 9): {status}"),
+    }
+
+    let nats_url =
+        std::env::var("CHOREO_NATS_URL").unwrap_or_else(|_| "nats://nats:4222".to_owned());
+    let nats = async_nats::connect(&nats_url)
+        .await
+        .with_context(|| format!("connect NATS at {nats_url}"))?;
+    let mut subscription = nats
+        .subscribe("choreo.deliberation.completed".to_owned())
+        .await
+        .context("subscribe choreo.deliberation.completed for scenario 9")?;
+    nats.flush()
+        .await
+        .context("flush NATS subscribe (scenario 9)")?;
+
+    let response = client
+        .run_council_decision(RunCouncilDecisionRequest {
+            contract_id: CONTRACT_ID.to_owned(),
+            external_context: None,
+            validation_mode: ValidationMode::Strict as i32,
+            metadata: None,
+            description: "scenario 9 structured-output positive path (vllm)".to_owned(),
+            selector: Some(RunCouncilSelector::Specialty(SPECIALTY.to_owned())),
+        })
+        .await
+        .context("RunCouncilDecision failed (scenario 9)")?
+        .into_inner();
+
+    let winner = response
+        .winner
+        .ok_or_else(|| anyhow!("RunCouncilDecision returned no winner (scenario 9)"))?;
+    let proposal = winner
+        .proposal
+        .ok_or_else(|| anyhow!("winner has no proposal (scenario 9)"))?;
+    let proposal_id = proposal.proposal_id.clone();
+    let parsed: serde_json::Value =
+        serde_json::from_str(proposal.content.trim()).with_context(|| {
+            format!(
+                "winner proposal content must parse as JSON (scenario 9); got: {}",
+                proposal.content
+            )
+        })?;
+    if let Err(errors) = compiled_schema.validate(&parsed) {
+        let messages: Vec<String> = errors.map(|e| e.to_string()).collect();
+        bail!(
+            "winner proposal content failed Report schema (scenario 9): {}",
+            messages.join("; ")
+        );
+    }
+    let validation = response
+        .validation
+        .as_ref()
+        .ok_or_else(|| anyhow!("response has no validation summary (scenario 9)"))?;
+    if !validation.passed {
+        bail!("validation.passed should be true on the positive path (scenario 9)");
+    }
+    info!(
+        proposal_id = proposal_id.as_str(),
+        task_id = response.task_id.as_str(),
+        candidates_passed = validation.candidates_passed,
+        candidates_total = validation.candidates_total,
+        "RunCouncilDecision succeeded with Report-shaped winner via vllm kind"
+    );
+
+    let task_id = response.task_id.clone();
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    while std::time::Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        let chunk = remaining.min(Duration::from_secs(2));
+        match tokio::time::timeout(chunk, subscription.next()).await {
+            Ok(Some(msg)) => {
+                let payload: serde_json::Value = serde_json::from_slice(&msg.payload)
+                    .context("DeliberationCompleted (scenario 9) payload not JSON")?;
+                let got_task = payload.get("task_id").and_then(|v| v.as_str());
+                if got_task == Some(task_id.as_str()) {
+                    if payload.get("external_context_bundle_id").is_some() {
+                        bail!(
+                            "scenario 9 envelope must omit external_context_bundle_id (no bundle was sent), got {payload}"
+                        );
+                    }
+                    info!(
+                        out_event_id = payload
+                            .get("event_id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or(""),
+                        task_id = task_id.as_str(),
+                        "DeliberationCompleted carried the expected task id (scenario 9)"
+                    );
+                    return Ok(());
+                }
+                warn!(
+                    ?got_task,
+                    "DeliberationCompleted seen for a different task_id; continuing"
+                );
+            }
+            Ok(None) => {
+                bail!("NATS subscription closed before scenario 9 envelope arrived");
+            }
+            Err(_) => {}
+        }
+    }
+    bail!("no DeliberationCompleted for {task_id} arrived within 15s (scenario 9)")
+}

--- a/crates/choreo-e2e-runner/src/scenarios/structured_output/strict_schema.rs
+++ b/crates/choreo-e2e-runner/src/scenarios/structured_output/strict_schema.rs
@@ -1,0 +1,140 @@
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
+use choreo_proto::v1::{Constraints, OrchestrateRequest, OutputContract, OutputFormat, Task};
+use futures::StreamExt;
+use prost_types::value::Kind as PbKind;
+use tonic::transport::Channel;
+use tracing::{info, warn};
+
+use super::super::pb_struct_from_pairs;
+
+/// Drives `Orchestrate` on the seeded council with a strict
+/// JSON-Schema output contract. `NoopAgent` emits free-form text, so
+/// the proposal cannot satisfy `{"type": "object", "required": [...]}`
+/// — the deliberation must fail with `NoValidProposal` and the
+/// orchestrator must publish a `TaskFailed` event whose envelope
+/// carries `error_kind = "deliberation.no_valid_proposal"`.
+///
+/// This is the negative half of Epic 11's structured-output stack
+/// proof. A positive scenario requires an agent that emits structured
+/// JSON; that lands once a stub-LLM provider sidecar ships, or once a
+/// real provider council is wired into this compose stack.
+#[allow(clippy::too_many_lines)] // single end-to-end scenario; splitting fragments the assertion
+pub(crate) async fn verify_orchestrate_rejects_proposal_violating_json_schema(
+    client: &mut ChoreographerServiceClient<Channel>,
+    specialty: &str,
+) -> Result<()> {
+    // Pre-subscribe so the published TaskFailed envelope cannot land
+    // before we are watching for it.
+    let nats_url =
+        std::env::var("CHOREO_NATS_URL").unwrap_or_else(|_| "nats://nats:4222".to_owned());
+    let nats = async_nats::connect(&nats_url)
+        .await
+        .with_context(|| format!("connect NATS at {nats_url}"))?;
+    let mut subscription = nats
+        .subscribe("choreo.task.failed".to_owned())
+        .await
+        .context("subscribe choreo.task.failed")?;
+    nats.flush().await.context("flush NATS subscribe")?;
+
+    let attributes = pb_struct_from_pairs([(
+        "runtime.tool_name",
+        PbKind::StringValue("stub.echo".to_owned()),
+    )]);
+    let constraints = Constraints {
+        rubric: None,
+        rounds: 0,
+        num_agents: 0,
+        deadline_ms: 0,
+        output_contract: Some(OutputContract {
+            contract_id: "scenario-6-strict".to_owned(),
+            format: OutputFormat::JsonObject as i32,
+            fields: std::collections::HashMap::new(),
+            json_schema: r#"{
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["decision", "reason"],
+                "properties": {
+                    "decision": { "type": "string", "enum": ["emit_event", "escalate"] },
+                    "reason":   { "type": "string", "minLength": 1 }
+                }
+            }"#
+            .to_owned(),
+        }),
+    };
+
+    let result = client
+        .orchestrate(OrchestrateRequest {
+            task: Some(Task {
+                task_id: "e2e-task-6".to_owned(),
+                specialty: specialty.to_owned(),
+                description:
+                    "End-to-end test: strict structured-output contract must reject free-form text."
+                        .to_owned(),
+                constraints: Some(constraints),
+                attributes: Some(attributes),
+                external_context: None,
+                metadata: None,
+            }),
+            execution_options: None,
+        })
+        .await;
+
+    let Err(status) = result else {
+        bail!(
+            "Orchestrate unexpectedly succeeded — NoopAgent should have failed the JSON Schema contract"
+        );
+    };
+    info!(
+        code = ?status.code(),
+        message = status.message(),
+        "Orchestrate returned the expected error"
+    );
+
+    // The use case publishes `TaskFailed` BEFORE returning the error,
+    // so the envelope should already be on the bus.
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while std::time::Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        let chunk = remaining.min(Duration::from_secs(2));
+        match tokio::time::timeout(chunk, subscription.next()).await {
+            Ok(Some(msg)) => {
+                let payload: serde_json::Value =
+                    serde_json::from_slice(&msg.payload).context("task.failed payload not JSON")?;
+                let task_id = payload
+                    .get("task_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let error_kind = payload
+                    .get("error_kind")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                if task_id == "e2e-task-6" && error_kind == "deliberation.no_valid_proposal" {
+                    info!(
+                        out_event_id = payload
+                            .get("event_id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or(""),
+                        error_kind, "TaskFailed carried the expected NoValidProposal kind"
+                    );
+                    return Ok(());
+                }
+                warn!(
+                    task_id,
+                    error_kind,
+                    "TaskFailed seen but task_id / error_kind did not match; continuing"
+                );
+            }
+            Ok(None) => {
+                bail!("NATS subscription closed before a matching TaskFailed envelope arrived");
+            }
+            Err(_) => {}
+        }
+    }
+
+    bail!(
+        "no TaskFailed envelope with task_id=e2e-task-6 and error_kind=deliberation.no_valid_proposal arrived within 10s"
+    )
+}

--- a/crates/choreo-mcp-proto/Cargo.toml
+++ b/crates/choreo-mcp-proto/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "choreo-mcp-proto"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.90"
+license = "Apache-2.0"
+authors = ["Tirso Garcia Ibañez"]
+repository = "https://github.com/underpass-ai/underpass-choreographer"
+description = "Standalone vendored proto types for underpass.choreo.v1, distributed alongside the choreo-mcp binary so `cargo install choreo-mcp` can pull from crates.io without depending on the choreographer's internal workspace crates."
+keywords = ["mcp", "choreographer", "grpc", "tonic", "underpass"]
+categories = ["api-bindings"]
+publish = true
+include = [
+    "src/**/*.rs",
+    "proto/**/*.proto",
+    "build.rs",
+    "Cargo.toml",
+    "README.md",
+    "LICENSE*",
+]
+
+[lib]
+
+[dependencies]
+# Explicit pins (NOT workspace = true). Published crates can't inherit
+# workspace deps once consumed by an out-of-workspace `cargo install`.
+prost = "0.13"
+prost-types = "0.13"
+tonic = { version = "0.12", features = ["tls", "tls-roots"] }
+
+[build-dependencies]
+tonic-build = "0.12"

--- a/crates/choreo-mcp-proto/build.rs
+++ b/crates/choreo-mcp-proto/build.rs
@@ -1,0 +1,7 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::configure()
+        .build_server(false)
+        .build_client(true)
+        .compile_protos(&["proto/underpass/choreo/v1/choreo.proto"], &["proto"])?;
+    Ok(())
+}

--- a/crates/choreo-mcp-proto/proto/underpass/choreo/v1/choreo.proto
+++ b/crates/choreo-mcp-proto/proto/underpass/choreo/v1/choreo.proto
@@ -1,0 +1,566 @@
+// Copyright Underpass AI. Licensed under Apache-2.0.
+//
+// Underpass Choreographer — event-driven coordinator of specialist agent
+// councils. Use-case agnostic: no vocabulary from any specific domain
+// (software engineering, clinical, supply chain, etc.) is baked in.
+//
+// Key concepts:
+//   - Specialty: a free-form label identifying a kind of expertise
+//                (e.g. "triage", "reviewer", "planner"). Defined by the
+//                operator, never enumerated by this contract.
+//   - Agent:     a participant capable of proposing, critiquing, and
+//                revising solutions for a task.
+//   - Council:   a group of Agents for a given Specialty that deliberates
+//                over a task.
+//   - Task:      a unit of work submitted for deliberation; carries a
+//                description and structured constraints.
+//   - Deliberation: proposal -> peer critique -> revision -> validation
+//                   -> scoring -> ranked results.
+//   - TriggerEvent: an inbound domain event that instructs the
+//                   choreographer to dispatch deliberations across one
+//                   or more specialties.
+//
+// All domain-specific content is carried as opaque, structured data
+// (google.protobuf.Struct / map<string, Value>) so any use case can
+// attach its own attributes without modifying this contract.
+
+syntax = "proto3";
+
+package underpass.choreo.v1;
+
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+
+// ============================================================================
+// Service
+// ============================================================================
+
+// Implementation status (server side) at v0.1:
+//
+// Every RPC is backed by a use case in `choreo-app/src/usecases/`
+// (or `services/auto_dispatch.rs` for ProcessTriggerEvent;
+// `StatisticsPort::snapshot` for GetStatus / GetMetrics;
+// `AgentFactoryPort` + `AgentRegistryPort` for RegisterAgent /
+// UnregisterAgent; `DeliberationObserverPort` bridged to an mpsc
+// channel for StreamDeliberation).
+//
+// Caveats the project's honesty principles require to surface:
+//
+//   RegisterAgent accepts `kind == "noop"` unconditionally. Provider-
+//   backed kinds (vLLM, Anthropic, OpenAI, …) are accepted when the
+//   binary was compiled with the matching feature and booted with the
+//   required provider configuration.
+//
+//   StreamDeliberation emits one `DeliberationUpdate` per phase
+//   transition (Proposing → Revising → Validating → Scoring →
+//   Completed) and a final frame carrying the winner
+//   `DeliberationResult`. It does not yet emit per-proposal /
+//   per-critique / per-revision frames.
+service ChoreographerService {
+  // ---- Deliberation ----------------------------------------------------
+
+  // Run a deliberation on the council registered for the requested
+  // specialty. Blocks until the ranked results are ready.
+  rpc Deliberate(DeliberateRequest) returns (DeliberateResponse);
+
+  // Like Deliberate but streams phase updates plus a final winner frame.
+  // Per-proposal, per-critique, and per-revision frames are reserved
+  // for a later additive slice.
+  rpc StreamDeliberation(StreamDeliberationRequest) returns (stream StreamDeliberationResponse);
+
+  // Retrieve a previously-executed deliberation by task id.
+  rpc GetDeliberationResult(GetDeliberationResultRequest) returns (GetDeliberationResultResponse);
+
+  // End-to-end orchestration: deliberate AND execute the winning
+  // proposal via the configured executor port. Opaque to the
+  // choreographer what "execute" means — determined by the adapter.
+  rpc Orchestrate(OrchestrateRequest) returns (OrchestrateResponse);
+
+  // ---- Council / Agent registry ---------------------------------------
+
+  rpc CreateCouncil(CreateCouncilRequest) returns (CreateCouncilResponse);
+  rpc ListCouncils(ListCouncilsRequest) returns (ListCouncilsResponse);
+  rpc DeleteCouncil(DeleteCouncilRequest) returns (DeleteCouncilResponse);
+
+  rpc RegisterAgent(RegisterAgentRequest) returns (RegisterAgentResponse);
+  rpc UnregisterAgent(UnregisterAgentRequest) returns (UnregisterAgentResponse);
+
+  // ---- Triggers (generic, replaces ProcessPlanningEvent) --------------
+
+  // Submit a domain event that should fan out to one or more
+  // deliberations. Mirrors the behavior of the NATS auto-dispatch path
+  // but exposed as a synchronous RPC for callers without a broker.
+  rpc ProcessTriggerEvent(ProcessTriggerEventRequest) returns (ProcessTriggerEventResponse);
+
+  // ---- Council decision (Epic 9) --------------------------------------
+  //
+  // Consumer-facing surface that hands the council a contract and
+  // an external-context bundle and returns the *validated* winner.
+  // Decoupled from any executor — consumers integrate the runtime
+  // separately if they need to act on the decision.
+
+  rpc RunCouncilDecision(RunCouncilDecisionRequest) returns (RunCouncilDecisionResponse);
+
+  // CRUD over the contract registry. Without these the
+  // RunCouncilDecision RPC would only accept contracts seeded via
+  // CHOREO_CONTRACT_DIR.
+
+  rpc RegisterContract(RegisterContractRequest) returns (RegisterContractResponse);
+  rpc ListContracts(ListContractsRequest) returns (ListContractsResponse);
+  rpc DeleteContract(DeleteContractRequest) returns (DeleteContractResponse);
+
+  // ---- Observability --------------------------------------------------
+
+  rpc GetStatus(GetStatusRequest) returns (GetStatusResponse);
+  rpc GetMetrics(GetMetricsRequest) returns (GetMetricsResponse);
+}
+
+// ============================================================================
+// Core value objects
+// ============================================================================
+
+// A Task is the unit of work a council deliberates over.
+// `description` is a free-form prompt; `attributes` is an opaque bag
+// for use-case-specific structured data. `external_context` is a
+// bounded, typed bundle of caller-materialized context that the
+// choreographer can pass through to councils without turning it into
+// one giant opaque blob.
+message Task {
+  string task_id = 1;
+  string description = 2;
+  string specialty = 3;
+  Constraints constraints = 4;
+  google.protobuf.Struct attributes = 5;
+  ExternalContextBundle external_context = 6;
+  TaskMetadata metadata = 7;
+}
+
+// Constraints shape how the council deliberates.
+// `rubric` is opaque to the choreographer — passed verbatim to agents
+// and validators as part of the deliberation context.
+message Constraints {
+  google.protobuf.Struct rubric = 1;
+  uint32 rounds = 2; // peer-review rounds; 0 means implementation default
+  uint32 num_agents = 3; // requested parallelism; 0 means use council size
+  uint64 deadline_ms = 4; // optional soft deadline; 0 means none
+  OutputContract output_contract = 5;
+}
+
+// Generic structured-output contract for one council invocation.
+// Presence of this block switches deliberation into structured-output
+// mode: callers require proposals to satisfy the declared format and
+// field rules instead of remaining free-form text only.
+//
+// `json_schema`, when non-empty, is a JSON Schema document (draft
+// 2020-12 or earlier, autodetected) that proposal outputs must
+// satisfy. Field-level rules (`fields`) keep working alongside — they
+// are the lightweight predecessor and remain useful for the simple
+// "required + enum" case without a full schema. Concrete behaviour:
+//
+//  - empty `json_schema` + non-empty `fields` -> legacy field-rule
+//    validators run (RequiredFieldsValidator, AllowedStringValuesValidator).
+//  - non-empty `json_schema` -> the schema is parsed at validator wiring
+//    time; every proposal output is validated against it as one extra
+//    `ValidatorReport` ("json_schema" kind).
+//  - both populated -> both run. Failure of either fails the proposal.
+//
+// Application-owned domain shapes (incident report, decision record,
+// inspection finding, ...) are expressed as JSON Schemas in
+// `api/examples/output-contracts/` and bound here by the caller.
+message OutputContract {
+  string contract_id = 1;
+  OutputFormat format = 2;
+  map<string, OutputFieldRule> fields = 3;
+  string json_schema = 4;
+}
+
+enum OutputFormat {
+  OUTPUT_FORMAT_UNSPECIFIED = 0;
+  OUTPUT_FORMAT_JSON_OBJECT = 1;
+}
+
+message OutputFieldRule {
+  bool required = 1;
+  repeated string allowed_string_values = 2;
+}
+
+// Bounded, caller-materialized context bundle passed into a council.
+// The contract is intentionally generic: callers define `item.kind`
+// labels and attach machine-readable detail through `attributes`.
+message ExternalContextBundle {
+  string bundle_id = 1;
+  string schema_version = 2;
+  ContextSummary summary = 3;
+  repeated ContextItem items = 4;
+  repeated ContextReference references = 5;
+  google.protobuf.Struct metadata = 6;
+}
+
+message ContextSummary {
+  string text = 1;
+  google.protobuf.Struct attributes = 2;
+}
+
+message ContextItem {
+  string item_id = 1;
+  string kind = 2;
+  string title = 3;
+  string narrative = 4;
+  google.protobuf.Struct attributes = 5;
+  repeated string reference_ids = 6;
+}
+
+message ContextReference {
+  string reference_id = 1;
+  string uri = 2;
+  string title = 3;
+  string media_type = 4;
+  google.protobuf.Struct attributes = 5;
+}
+
+// Integration-neutral task metadata. Product/domain identifiers
+// belong in Task.attributes or ExternalContextBundle.metadata; the
+// choreographer only interprets causal ids and its own contract /
+// execution hints.
+message TaskMetadata {
+  string source_event_id = 1;
+  string causation_id = 2;
+  string correlation_id = 3;
+  string council_contract_id = 4;
+  string output_contract_id = 5;
+  google.protobuf.Struct execution_profile = 6;
+}
+
+// A single agent's output from one step of deliberation.
+message Proposal {
+  string proposal_id = 1;
+  string author_agent_id = 2;
+  string content = 3; // free-form solution artifact
+  google.protobuf.Struct metadata = 4; // opaque per-agent annotations
+  uint32 revision_count = 5; // peer-review revisions applied to this proposal
+}
+
+// Outcome of validating and scoring a proposal.
+//
+// `passed` is NOT stored: it is a pure projection of `reports` and
+// MUST be computed by serializers as `reports.all(|r| r.passed)` if
+// their wire format needs it. Having two sources of truth for pass /
+// fail is a denormalization bug waiting to happen and is refused here.
+message ValidationOutcome {
+  double score = 1;
+  repeated ValidatorReport reports = 2;
+}
+
+message ValidatorReport {
+  // Free-form, adapter-defined kind (e.g. `"lint"`, `"policy"`,
+  // `"dry-run"`, `"clinical-safety"`, `"fact-check"`).
+  string kind = 1;
+  bool passed = 2;
+  string summary = 3;
+  google.protobuf.Struct details = 4;
+}
+
+// A ranked deliberation result.
+message DeliberationResult {
+  Proposal proposal = 1;
+  ValidationOutcome validation = 2;
+  uint32 rank = 3; // 0 = winner
+}
+
+// Incremental update emitted during streaming deliberation.
+message DeliberationUpdate {
+  string task_id = 1;
+  DeliberationPhase phase = 2;
+  oneof payload {
+    Proposal proposal = 10;
+    Critique critique = 11;
+    Revision revision = 12;
+    ValidationOutcome validation = 13;
+    DeliberationResult result = 14;
+  }
+  google.protobuf.Timestamp emitted_at = 20;
+}
+
+// Lifecycle phases of a deliberation. Matches the domain aggregate's
+// 5-state FSM: Proposing → Revising → Validating → Scoring → Completed.
+// There is no separate `CRITIQUING` phase — critique/revise rounds
+// happen internally within `REVISING`.
+enum DeliberationPhase {
+  DELIBERATION_PHASE_UNSPECIFIED = 0;
+  DELIBERATION_PHASE_PROPOSING = 1;
+  DELIBERATION_PHASE_REVISING = 2;
+  DELIBERATION_PHASE_VALIDATING = 3;
+  DELIBERATION_PHASE_SCORING = 4;
+  DELIBERATION_PHASE_COMPLETED = 5;
+}
+
+message Critique {
+  string reviewer_agent_id = 1;
+  string target_proposal_id = 2;
+  string feedback = 3;
+}
+
+message Revision {
+  string author_agent_id = 1;
+  string proposal_id = 2;
+  string updated_content = 3;
+}
+
+// ============================================================================
+// Council / Agent
+// ============================================================================
+
+message CouncilSummary {
+  string specialty = 1;
+  uint32 num_agents = 2;
+  repeated AgentSummary agents = 3; // optional; populated on request
+  google.protobuf.Timestamp created_at = 4;
+}
+
+message AgentSummary {
+  string agent_id = 1;
+  string specialty = 2;
+  string kind = 3; // adapter-defined, e.g. "vllm", "frontier", "rule", "human"
+  google.protobuf.Struct attributes = 4;
+}
+
+// ============================================================================
+// Triggers
+// ============================================================================
+
+// Opaque event instructing the choreographer to run deliberations.
+// The event carries its own domain payload and the list of specialties
+// whose councils should be dispatched.
+message TriggerEvent {
+  string event_id = 1;
+  string kind = 2; // free-form, e.g. "alert.fired", "case.opened"
+  string source = 3; // producer identifier
+  google.protobuf.Timestamp emitted_at = 4;
+
+  repeated string requested_specialties = 5;
+  string task_description_template = 6; // optional literal task description supplied by the producer
+  Constraints constraints = 7;
+
+  google.protobuf.Struct payload = 8; // opaque domain data
+  ExternalContextBundle external_context = 9;
+  string correlation_id = 10;
+  string causation_id = 11;
+}
+
+message ProcessTriggerEventRequest {
+  TriggerEvent event = 1;
+}
+
+message ProcessTriggerEventResponse {
+  TriggerAck ack = 1;
+}
+
+message TriggerAck {
+  string event_id = 1;
+  bool accepted = 2;
+  repeated string dispatched_task_ids = 3;
+  string reason = 4; // populated when accepted=false
+}
+
+// ============================================================================
+// RPC request / response messages
+// ============================================================================
+
+message DeliberateRequest {
+  Task task = 1;
+}
+
+message StreamDeliberationRequest {
+  Task task = 1;
+}
+
+message StreamDeliberationResponse {
+  DeliberationUpdate update = 1;
+}
+
+message DeliberateResponse {
+  string task_id = 1;
+  repeated DeliberationResult results = 2;
+  string winner_proposal_id = 3;
+  uint64 duration_ms = 4;
+  google.protobuf.Struct metadata = 5;
+}
+
+message GetDeliberationResultRequest {
+  string task_id = 1;
+}
+
+message GetDeliberationResultResponse {
+  bool found = 1;
+  DeliberateResponse result = 2;
+}
+
+message OrchestrateRequest {
+  Task task = 1;
+  google.protobuf.Struct execution_options = 2; // opaque for executor adapter
+}
+
+message OrchestrateResponse {
+  string task_id = 1;
+  string execution_id = 2;
+  DeliberationResult winner = 3;
+  repeated DeliberationResult candidates = 4;
+  uint64 duration_ms = 5;
+  google.protobuf.Struct metadata = 6;
+}
+
+message CreateCouncilRequest {
+  string specialty = 1;
+  uint32 num_agents = 2;
+  google.protobuf.Struct agent_config = 3; // passed to agent factory
+}
+
+message CreateCouncilResponse {
+  CouncilSummary council = 1;
+}
+
+message ListCouncilsRequest {
+  bool include_agents = 1;
+}
+
+message ListCouncilsResponse {
+  repeated CouncilSummary councils = 1;
+}
+
+message DeleteCouncilRequest {
+  string specialty = 1;
+}
+
+message DeleteCouncilResponse {
+  bool deleted = 1;
+}
+
+message RegisterAgentRequest {
+  string specialty = 1;
+  AgentSummary agent = 2;
+  google.protobuf.Struct agent_config = 3;
+}
+
+message RegisterAgentResponse {
+  string agent_id = 1;
+}
+
+message UnregisterAgentRequest {
+  string agent_id = 1;
+}
+
+message UnregisterAgentResponse {
+  bool unregistered = 1;
+}
+
+message GetStatusRequest {
+  bool include_stats = 1;
+}
+
+message GetStatusResponse {
+  string version = 1;
+  uint64 uptime_seconds = 2;
+  string health = 3; // "healthy" | "degraded" | "unhealthy"
+  Statistics stats = 4;
+}
+
+message GetMetricsRequest {}
+
+message GetMetricsResponse {
+  Statistics stats = 1;
+}
+
+message Statistics {
+  uint64 total_deliberations = 1;
+  uint64 total_orchestrations = 2;
+  uint64 total_duration_ms = 3;
+  double average_duration_ms = 4;
+  map<string, uint64> per_specialty_counts = 5;
+}
+
+// ============================================================================
+// Council decision (Epic 9) — consumer-facing, contract-aware,
+// no executor coupling.
+// ============================================================================
+
+message RunCouncilDecisionRequest {
+  // Caller picks one of two ways to identify the council.
+  oneof selector {
+    string council_id = 1;
+    string specialty = 2;
+  }
+  // Slug previously registered through RegisterContract or seeded
+  // from CHOREO_CONTRACT_DIR. Must match an existing contract.
+  string contract_id = 3;
+  // Optional bundle the council can read during deliberation
+  // (kernel rehydration output, retrieval results, etc.).
+  ExternalContextBundle external_context = 4;
+  // How strictly the response honours the contract. Defaults to
+  // STRICT when UNSPECIFIED.
+  ValidationMode validation_mode = 5;
+  // Causal metadata the choreographer copies into the outbound
+  // bus event when the deliberation completes.
+  TaskMetadata metadata = 6;
+  // Free-form task description the council reads as context. The
+  // choreographer itself does not parse it.
+  string description = 7;
+}
+
+enum ValidationMode {
+  VALIDATION_MODE_UNSPECIFIED = 0;
+  VALIDATION_MODE_STRICT = 1;
+  VALIDATION_MODE_WARN = 2;
+}
+
+message CandidateSummary {
+  string proposal_id = 1;
+  string author_agent_id = 2;
+  double score = 3;
+  repeated ValidatorReport reports = 4;
+  uint32 rank = 5;
+  bool passed = 6;
+  uint32 revision_count = 7;
+}
+
+message ValidationOutcomeSummary {
+  // True iff the winning proposal passed every validator.
+  bool passed = 1;
+  // Number of candidates that passed every validator.
+  uint32 candidates_passed = 2;
+  // Total candidates considered for ranking.
+  uint32 candidates_total = 3;
+}
+
+message RunCouncilDecisionResponse {
+  string task_id = 1;
+  // Winning proposal already validated when this message is built.
+  DeliberationResult winner = 2;
+  ValidationOutcomeSummary validation = 3;
+  // Per-candidate breakdown, ordered by rank ascending.
+  repeated CandidateSummary candidates = 4;
+  uint64 duration_ms = 5;
+  // Effective validation mode (echoed back so warned-but-returned
+  // responses are unambiguous).
+  ValidationMode validation_mode = 6;
+}
+
+// CRUD over the contract registry.
+
+message RegisterContractRequest {
+  OutputContract contract = 1;
+}
+message RegisterContractResponse {
+  string contract_id = 1;
+}
+
+message ListContractsRequest {}
+message ListContractsResponse {
+  repeated OutputContract contracts = 1;
+}
+
+message DeleteContractRequest {
+  string contract_id = 1;
+}
+message DeleteContractResponse {
+  bool deleted = 1;
+}

--- a/crates/choreo-mcp-proto/src/lib.rs
+++ b/crates/choreo-mcp-proto/src/lib.rs
@@ -1,0 +1,16 @@
+//! Vendored Choreographer gRPC types for the standalone
+//! `choreo-mcp` distribution. The internal workspace continues
+//! to use `choreo-proto`; this crate exists so `choreo-mcp` can
+//! be published to crates.io with all its proto deps already on
+//! the registry.
+//!
+//! Wire contract: `underpass.choreo.v1`.
+
+#![allow(clippy::pedantic)]
+#![allow(clippy::all)]
+
+pub mod v1 {
+    tonic::include_proto!("underpass.choreo.v1");
+}
+
+pub use v1::*;

--- a/crates/choreo-mcp/Cargo.toml
+++ b/crates/choreo-mcp/Cargo.toml
@@ -1,12 +1,22 @@
 [package]
 name = "choreo-mcp"
-version.workspace = true
-edition.workspace = true
-rust-version.workspace = true
-license.workspace = true
-authors.workspace = true
-repository.workspace = true
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.90"
+license = "Apache-2.0"
+authors = ["Tirso Garcia Ibañez"]
+repository = "https://github.com/underpass-ai/underpass-choreographer"
 description = "Stdio MCP (Model Context Protocol) adapter that exposes the Underpass Choreographer gRPC API to coding agents (Codex, Claude Desktop, …)."
+keywords = ["mcp", "anthropic", "choreographer", "stdio"]
+categories = ["command-line-utilities"]
+publish = true
+readme = "README.md"
+include = [
+    "src/**/*.rs",
+    "Cargo.toml",
+    "README.md",
+    "LICENSE*",
+]
 
 [lints]
 workspace = true
@@ -16,7 +26,7 @@ name = "choreo-mcp"
 path = "src/main.rs"
 
 [dependencies]
-choreo-proto = { workspace = true }
+choreo-mcp-proto = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }
 prost-types = { workspace = true }
@@ -28,6 +38,10 @@ tonic = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 opentelemetry = { workspace = true }
+testcontainers = { version = "0.23", optional = true }
+
+[features]
+container-tests = ["dep:testcontainers"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/choreo-mcp/README.md
+++ b/crates/choreo-mcp/README.md
@@ -10,6 +10,16 @@ This README is the developer-oriented twin: it covers running the
 adapter from a checkout, the test surface, and the design choices
 worth knowing when you touch the code.
 
+## Install (registry)
+
+```bash
+cargo install choreo-mcp --locked
+```
+
+This pulls `choreo-mcp` + the vendored `choreo-mcp-proto` from
+crates.io. The dev fallback against this repo's source tree is
+`CHOREO_MCP_INSTALL_MODE=git bash scripts/mcp/install-choreo-mcp.sh`.
+
 ## Run from a checkout
 
 ```bash
@@ -61,10 +71,6 @@ without an extra round trip.
 | `choreo_register_agent`           | `RegisterAgent`                   | control plane |
 | `choreo_unregister_agent`         | `UnregisterAgent`                 | control plane |
 | `choreo_process_trigger_event`    | `ProcessTriggerEvent`             | event ingest |
-| `choreo_run_council_decision`     | `RunCouncilDecision`              | validated council decision |
-| `choreo_register_contract`        | `RegisterContract`                | contract registry |
-| `choreo_list_contracts`           | `ListContracts`                   | contract registry |
-| `choreo_delete_contract`          | `DeleteContract`                  | contract registry |
 | `choreo_get_status`               | `GetStatus`                       | observability |
 | `choreo_get_metrics`              | `GetMetrics`                      | observability |
 
@@ -122,10 +128,22 @@ cargo test -p choreo-mcp --locked
 - `src/observability.rs::tests` — error-kind labels and the recursive
   size approximator used in trace events.
 
-Live gRPC backend integration tests against a real choreographer
-ship under
-[`crates/choreo-tests-integration`](../choreo-tests-integration/)
-(forthcoming in the smoke/integration slice).
+### Real-kernel container integration test
+
+A separate `tests/real_kernel.rs` boots the published
+`ghcr.io/underpass-ai/underpass-choreographer:latest` image via
+testcontainers, spawns this crate's binary against its mapped gRPC
+port, and exercises `initialize`, `tools/list` (asserts the full 16-
+tool catalog), and `tools/call` on the four simplest read-only RPCs.
+The test is gated by the `container-tests` Cargo feature so the
+default workspace `cargo test --workspace` stays fast + network-free.
+
+```bash
+cargo test -p choreo-mcp --features container-tests
+```
+
+The default `cargo test --workspace` does NOT compile testcontainers
+or pull the image.
 
 ## Common pitfalls
 

--- a/crates/choreo-mcp/src/fixture.rs
+++ b/crates/choreo-mcp/src/fixture.rs
@@ -38,12 +38,12 @@ impl ChoreoMcpToolBackend for FixtureChoreoMcpBackend {
                 "choreo_register_agent" => register_agent_fixture(),
                 "choreo_unregister_agent" => unregister_agent_fixture(),
                 "choreo_process_trigger_event" => process_trigger_fixture(),
-                "choreo_get_status" => get_status_fixture(),
-                "choreo_get_metrics" => get_metrics_fixture(),
                 "choreo_run_council_decision" => run_council_decision_fixture(),
                 "choreo_register_contract" => register_contract_fixture(),
                 "choreo_list_contracts" => list_contracts_fixture(),
                 "choreo_delete_contract" => delete_contract_fixture(),
+                "choreo_get_status" => get_status_fixture(),
+                "choreo_get_metrics" => get_metrics_fixture(),
                 other => {
                     return Err(format!(
                         "fixture backend: unknown tool `{other}` (this is a client-side typo, not a backend error)"
@@ -73,7 +73,8 @@ fn deliberate_fixture() -> Value {
                     "proposal_id": "proposal-fixture-a",
                     "author_agent_id": "agent-fixture-1",
                     "content": "fixture answer",
-                    "metadata": {}
+                    "metadata": {},
+                    "revision_count": 0
                 },
                 "validation": {
                     "score": 1.0,
@@ -204,7 +205,8 @@ fn run_council_decision_fixture() -> Value {
                     { "kind": "content-non-empty", "passed": true, "summary": "ok", "details": {} }
                 ],
                 "rank": 0,
-                "passed": true
+                "passed": true,
+                "revision_count": 0
             }
         ],
         "duration_ms": 42,
@@ -262,24 +264,13 @@ mod tests {
     #[tokio::test]
     async fn every_tool_has_a_fixture() {
         let backend = FixtureChoreoMcpBackend;
-        for tool in [
-            "choreo_deliberate",
-            "choreo_stream_deliberation",
-            "choreo_get_deliberation_result",
-            "choreo_orchestrate",
-            "choreo_create_council",
-            "choreo_list_councils",
-            "choreo_delete_council",
-            "choreo_register_agent",
-            "choreo_unregister_agent",
-            "choreo_process_trigger_event",
-            "choreo_get_status",
-            "choreo_get_metrics",
-            "choreo_run_council_decision",
-            "choreo_register_contract",
-            "choreo_list_contracts",
-            "choreo_delete_contract",
-        ] {
+        let catalog = crate::protocol::tools_list_result();
+        for tool in catalog["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|tool| tool["name"].as_str().unwrap())
+        {
             let v = backend.call_tool(tool, &json!({})).await.unwrap();
             assert_eq!(v["isError"], false, "{tool} fixture must be a success");
         }

--- a/crates/choreo-mcp/src/grpc/json_to_proto.rs
+++ b/crates/choreo-mcp/src/grpc/json_to_proto.rs
@@ -7,7 +7,7 @@
 
 use std::collections::BTreeMap;
 
-use choreo_proto::v1 as pb;
+use choreo_mcp_proto::v1 as pb;
 use prost_types::{
     value::Kind as PbKind, ListValue, Struct as PbStruct, Timestamp, Value as PbValue,
 };

--- a/crates/choreo-mcp/src/grpc/proto_to_json.rs
+++ b/crates/choreo-mcp/src/grpc/proto_to_json.rs
@@ -4,7 +4,7 @@
 //! key explicitly so the wire schema is documented in the code and
 //! reviewers can spot accidental drops at PR time.
 
-use choreo_proto::v1 as pb;
+use choreo_mcp_proto::v1 as pb;
 use prost_types::{
     value::Kind as PbKind, ListValue, Struct as PbStruct, Timestamp, Value as PbValue,
 };
@@ -76,6 +76,7 @@ pub(crate) fn proposal_to_json(p: pb::Proposal) -> Value {
         "author_agent_id": p.author_agent_id,
         "content": p.content,
         "metadata": optional_pb_struct_to_json(p.metadata),
+        "revision_count": p.revision_count,
     })
 }
 
@@ -265,6 +266,7 @@ fn candidate_summary_to_json(c: pb::CandidateSummary) -> Value {
             .collect::<Vec<_>>(),
         "rank": c.rank,
         "passed": c.passed,
+        "revision_count": c.revision_count,
     })
 }
 

--- a/crates/choreo-mcp/src/grpc/streaming.rs
+++ b/crates/choreo-mcp/src/grpc/streaming.rs
@@ -7,7 +7,7 @@
 //! winner pulled out of the last `result`-typed frame for caller
 //! convenience.
 
-use choreo_proto::v1 as pb;
+use choreo_mcp_proto::v1 as pb;
 use futures::StreamExt;
 use serde_json::{json, Value};
 use tonic::Streaming;

--- a/crates/choreo-mcp/src/grpc/tools.rs
+++ b/crates/choreo-mcp/src/grpc/tools.rs
@@ -5,8 +5,8 @@
 //! generated tonic client, and converts the response back via
 //! `proto_to_json`. tonic `Status` errors collapse to plain strings.
 
-use choreo_proto::v1 as pb;
-use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
+use choreo_mcp_proto::v1 as pb;
+use choreo_mcp_proto::v1::choreographer_service_client::ChoreographerServiceClient;
 use serde_json::{json, Value};
 use tonic::transport::Channel;
 
@@ -135,37 +135,6 @@ pub(crate) async fn dispatch(
             }))
         }
 
-        "choreo_get_status" => {
-            let request = build_get_status_request(arguments);
-            let response = client
-                .get_status(request)
-                .await
-                .map_err(|s| status_error(&s))?;
-            let pb::GetStatusResponse {
-                version,
-                uptime_seconds,
-                health,
-                stats,
-            } = response.into_inner();
-            Ok(json!({
-                "version": version,
-                "uptime_seconds": uptime_seconds,
-                "health": health,
-                "stats": stats.map_or(Value::Null, p2j::statistics_to_json),
-            }))
-        }
-
-        "choreo_get_metrics" => {
-            let response = client
-                .get_metrics(pb::GetMetricsRequest {})
-                .await
-                .map_err(|s| status_error(&s))?;
-            let pb::GetMetricsResponse { stats } = response.into_inner();
-            Ok(json!({
-                "stats": stats.map_or(Value::Null, p2j::statistics_to_json),
-            }))
-        }
-
         "choreo_run_council_decision" => {
             let request = build_run_council_decision_request(arguments)?;
             let response = client
@@ -209,6 +178,37 @@ pub(crate) async fn dispatch(
                 .map_err(|s| status_error(&s))?;
             let pb::DeleteContractResponse { deleted } = response.into_inner();
             Ok(json!({ "deleted": deleted }))
+        }
+
+        "choreo_get_status" => {
+            let request = build_get_status_request(arguments);
+            let response = client
+                .get_status(request)
+                .await
+                .map_err(|s| status_error(&s))?;
+            let pb::GetStatusResponse {
+                version,
+                uptime_seconds,
+                health,
+                stats,
+            } = response.into_inner();
+            Ok(json!({
+                "version": version,
+                "uptime_seconds": uptime_seconds,
+                "health": health,
+                "stats": stats.map_or(Value::Null, p2j::statistics_to_json),
+            }))
+        }
+
+        "choreo_get_metrics" => {
+            let response = client
+                .get_metrics(pb::GetMetricsRequest {})
+                .await
+                .map_err(|s| status_error(&s))?;
+            let pb::GetMetricsResponse { stats } = response.into_inner();
+            Ok(json!({
+                "stats": stats.map_or(Value::Null, p2j::statistics_to_json),
+            }))
         }
 
         other => Err(format!("unknown choreo MCP tool `{other}`")),

--- a/crates/choreo-mcp/src/protocol.rs
+++ b/crates/choreo-mcp/src/protocol.rs
@@ -179,29 +179,6 @@ fn tool_catalog() -> Vec<Value> {
             }),
         ),
         tool_def(
-            "choreo_get_status",
-            "Return service health, version, uptime, and optionally statistics.",
-            json!({
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                    "include_stats": {
-                        "type": "boolean",
-                        "description": "When true, include the full Statistics snapshot in the response."
-                    }
-                }
-            }),
-        ),
-        tool_def(
-            "choreo_get_metrics",
-            "Return the current statistics snapshot.",
-            json!({
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {}
-            }),
-        ),
-        tool_def(
             "choreo_run_council_decision",
             "Run a council deliberation against a registered output contract and return the validated winner plus candidate breakdown.",
             run_council_decision_schema(),
@@ -233,6 +210,29 @@ fn tool_catalog() -> Vec<Value> {
                 "additionalProperties": false,
                 "required": ["contract_id"],
                 "properties": { "contract_id": string_schema("Contract id previously returned by register_contract.") }
+            }),
+        ),
+        tool_def(
+            "choreo_get_status",
+            "Return service health, version, uptime, and optionally statistics.",
+            json!({
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "include_stats": {
+                        "type": "boolean",
+                        "description": "When true, include the full Statistics snapshot in the response."
+                    }
+                }
+            }),
+        ),
+        tool_def(
+            "choreo_get_metrics",
+            "Return the current statistics snapshot.",
+            json!({
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {}
             }),
         ),
     ]
@@ -568,32 +568,35 @@ mod tests {
     }
 
     #[test]
-    fn tools_catalog_is_one_for_one_with_grpc_service() {
-        let tools = tools_list_result();
-        let arr = tools["tools"].as_array().unwrap();
-        let names: Vec<&str> = arr.iter().map(|t| t["name"].as_str().unwrap()).collect();
+    fn tools_catalog_is_derived_one_for_one_from_grpc_service() {
+        let catalog_names = catalog_tool_names();
+        let proto_tool_names: Vec<String> = proto_rpc_names()
+            .into_iter()
+            .map(rpc_name_to_tool_name)
+            .collect();
+
         assert_eq!(
-            names,
-            vec![
-                "choreo_deliberate",
-                "choreo_stream_deliberation",
-                "choreo_get_deliberation_result",
-                "choreo_orchestrate",
-                "choreo_create_council",
-                "choreo_list_councils",
-                "choreo_delete_council",
-                "choreo_register_agent",
-                "choreo_unregister_agent",
-                "choreo_process_trigger_event",
-                "choreo_get_status",
-                "choreo_get_metrics",
-                "choreo_run_council_decision",
-                "choreo_register_contract",
-                "choreo_list_contracts",
-                "choreo_delete_contract",
-            ]
+            catalog_names, proto_tool_names,
+            "every underpass.choreo.v1 gRPC RPC must have exactly one MCP tool"
         );
-        assert_eq!(arr.len(), 16);
+    }
+
+    #[test]
+    fn grpc_dispatch_and_fixture_cover_every_catalog_tool() {
+        let grpc_dispatch_source = include_str!("grpc/tools.rs");
+        let fixture_source = include_str!("fixture.rs");
+
+        for tool in catalog_tool_names() {
+            let dispatch_arm = format!("\"{tool}\" =>");
+            assert!(
+                grpc_dispatch_source.contains(&dispatch_arm),
+                "live gRPC backend is missing a dispatch arm for {tool}"
+            );
+            assert!(
+                fixture_source.contains(&dispatch_arm),
+                "fixture backend is missing a canned response for {tool}"
+            );
+        }
     }
 
     #[test]
@@ -642,5 +645,44 @@ mod tests {
         let e = serde_json::from_str::<Value>(&jsonrpc_error(json!(2), -32601, "no")).unwrap();
         assert_eq!(e["error"]["code"], -32601);
         assert_eq!(e["error"]["message"], "no");
+    }
+
+    fn catalog_tool_names() -> Vec<String> {
+        let tools = tools_list_result();
+        tools["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|t| t["name"].as_str().unwrap().to_owned())
+            .collect()
+    }
+
+    fn proto_rpc_names() -> Vec<&'static str> {
+        const CHOREO_PROTO: &str =
+            include_str!("../../choreo-mcp-proto/proto/underpass/choreo/v1/choreo.proto");
+
+        CHOREO_PROTO
+            .lines()
+            .filter_map(|line| {
+                let trimmed = line.trim();
+                let rest = trimmed.strip_prefix("rpc ")?;
+                rest.split_once('(').map(|(rpc, _)| rpc.trim())
+            })
+            .collect()
+    }
+
+    fn rpc_name_to_tool_name(rpc: &str) -> String {
+        let mut snake = String::new();
+        for (idx, ch) in rpc.chars().enumerate() {
+            if ch.is_uppercase() {
+                if idx > 0 {
+                    snake.push('_');
+                }
+                snake.extend(ch.to_lowercase());
+            } else {
+                snake.push(ch);
+            }
+        }
+        format!("choreo_{snake}")
     }
 }

--- a/crates/choreo-mcp/tests/real_kernel.rs
+++ b/crates/choreo-mcp/tests/real_kernel.rs
@@ -1,0 +1,259 @@
+//! Real-kernel container integration test for the MCP adapter.
+//!
+//! Spins up a published choreographer image via `testcontainers`,
+//! spawns the locally-built `choreo-mcp` binary in gRPC mode pointing
+//! at the container's mapped port, and exercises the JSON-RPC surface:
+//!
+//!   1. `tools/list` — expect the full 16-tool catalog.
+//!   2. `tools/call` — invoke the 4 simplest read-only tools and
+//!      assert the response is a well-formed JSON-RPC envelope with
+//!      a `result` object.
+//!
+//! The per-tool 1:1 input/output shape is already covered by the
+//! fixture-backed unit tests in `crates/choreo-mcp/src/`. The
+//! invariant we want here is the end-to-end wiring:
+//!
+//!     MCP stdio (binary) ↔ gRPC client ↔ real choreographer
+//!
+//! Pulls the published `:latest` image instead of building from the
+//! repo's `Dockerfile` because `testcontainers` does not expose a
+//! "docker build" primitive in its 0.23 series — running the build
+//! out-of-band would dilute the contract this test claims.
+//!
+//! Gated on the `container-tests` feature. Workspace-default
+//! `cargo test --workspace` skips this file and stays fast +
+//! network-free; the gate runs with
+//! `cargo test -p choreo-mcp --features container-tests`.
+
+#![cfg(feature = "container-tests")]
+
+use std::env;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use testcontainers::{
+    core::{IntoContainerPort, WaitFor},
+    runners::AsyncRunner,
+    GenericImage, ImageExt,
+};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{ChildStdin, ChildStdout, Command};
+use tokio::time::timeout;
+
+const CHOREO_IMAGE: &str = "ghcr.io/underpass-ai/underpass-choreographer";
+const CHOREO_TAG: &str = "latest";
+const CHOREO_GRPC_PORT: u16 = 50055;
+const CHOREO_HTTP_PORT: u16 = 8080;
+
+/// Newline-delimited JSON-RPC request/response helper.
+struct McpStdio {
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    line_buf: String,
+    next_id: u64,
+}
+
+impl McpStdio {
+    async fn call(&mut self, method: &str, params: Value) -> Value {
+        self.next_id += 1;
+        let id = self.next_id;
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        });
+        let mut line = serde_json::to_string(&req).expect("serialize request");
+        line.push('\n');
+        self.stdin
+            .write_all(line.as_bytes())
+            .await
+            .expect("write stdin");
+        self.stdin.flush().await.expect("flush stdin");
+
+        self.line_buf.clear();
+        let read_fut = self.stdout.read_line(&mut self.line_buf);
+        let bytes = timeout(Duration::from_secs(20), read_fut)
+            .await
+            .expect("MCP response within 20s")
+            .expect("read stdout");
+        assert!(bytes > 0, "MCP closed stdout before responding");
+        serde_json::from_str(self.line_buf.trim_end())
+            .unwrap_or_else(|err| panic!("malformed JSON-RPC response: {err}: {}", self.line_buf))
+    }
+}
+
+fn workspace_target_dir() -> PathBuf {
+    // `cargo test` runs the test binary out of
+    // `target/<profile>/deps/...`. The MCP binary that this test
+    // shells out to lives in the same workspace target, under
+    // `target/<profile>/choreo-mcp`. Walking up from the current
+    // exe gives us a path that does NOT assume CARGO_MANIFEST_DIR.
+    let mut path = env::current_exe().expect("current exe path");
+    // pop test binary name + `deps/`
+    path.pop();
+    path.pop();
+    path
+}
+
+fn mcp_binary_path() -> PathBuf {
+    let mut path = workspace_target_dir();
+    path.push("choreo-mcp");
+    path
+}
+
+async fn spawn_choreographer() -> testcontainers::ContainerAsync<GenericImage> {
+    GenericImage::new(CHOREO_IMAGE, CHOREO_TAG)
+        .with_exposed_port(CHOREO_GRPC_PORT.tcp())
+        .with_exposed_port(CHOREO_HTTP_PORT.tcp())
+        // The binary writes the readiness line via tracing JSON. Wait
+        // for the gRPC bind log so we don't race the dial-in. Looser
+        // pattern keeps the test resilient to tracing format tweaks.
+        .with_wait_for(WaitFor::message_on_stderr("servers starting"))
+        .with_env_var("CHOREO_GRPC_PORT", CHOREO_GRPC_PORT.to_string())
+        .with_env_var("CHOREO_HTTP_PORT", CHOREO_HTTP_PORT.to_string())
+        // Disable NATS so the test does not need a broker side-car.
+        .with_env_var("CHOREO_NATS_ENABLED", "false")
+        // Seed one council so `choreo_list_councils` returns a
+        // non-empty list and the test exercises a real read path.
+        .with_env_var("CHOREO_SEED_SPECIALTIES", "triage")
+        .with_env_var("RUST_LOG", "info")
+        .start()
+        .await
+        .expect("choreographer container should start")
+}
+
+fn spawn_mcp(endpoint: &str) -> McpStdio {
+    let bin = mcp_binary_path();
+    assert!(
+        bin.exists(),
+        "choreo-mcp binary missing at {}; run `cargo build -p choreo-mcp` first",
+        bin.display(),
+    );
+
+    let mut child = Command::new(&bin)
+        .env("CHOREO_MCP_BACKEND", "grpc")
+        .env("CHOREO_MCP_GRPC_ENDPOINT", endpoint)
+        .env("RUST_LOG", "choreo_mcp=info")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn choreo-mcp");
+
+    let stdin_pipe = child.stdin.take().expect("child stdin");
+    let stdout_pipe = child.stdout.take().expect("child stdout");
+    let connection = McpStdio {
+        stdin: stdin_pipe,
+        stdout: BufReader::new(stdout_pipe),
+        line_buf: String::new(),
+        next_id: 0,
+    };
+
+    // Leak the child handle: the test process exits at the end of
+    // the test and the OS reaps the spawned MCP binary. Killing it
+    // explicitly would race the stdout drain.
+    std::mem::forget(child);
+
+    connection
+}
+
+#[tokio::test]
+async fn mcp_lists_full_tool_catalog_and_calls_read_endpoints() {
+    let container = spawn_choreographer().await;
+    let port = container
+        .get_host_port_ipv4(CHOREO_GRPC_PORT.tcp())
+        .await
+        .expect("host port");
+    let endpoint = format!("http://127.0.0.1:{port}");
+
+    let mut mcp = spawn_mcp(&endpoint);
+
+    // Initialize first — many clients require it, and the MCP
+    // server exposes adapter-side metadata in the reply that we
+    // log for debug if the next call fails.
+    let init = mcp.call("initialize", json!({})).await;
+    assert_eq!(
+        init.get("jsonrpc").and_then(Value::as_str),
+        Some("2.0"),
+        "initialize: malformed envelope: {init:?}",
+    );
+    let init_result = init
+        .get("result")
+        .unwrap_or_else(|| panic!("initialize had no result: {init:?}"));
+    assert!(
+        init_result.get("serverInfo").is_some(),
+        "initialize missing serverInfo: {init:?}",
+    );
+
+    // tools/list — assert the full 1:1 catalog.
+    let list = mcp.call("tools/list", json!({})).await;
+    let tools = list
+        .pointer("/result/tools")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("tools/list missing /result/tools array: {list:?}"));
+    assert_eq!(
+        tools.len(),
+        16,
+        "expected 16 tools, got {}: {:?}",
+        tools.len(),
+        tools.iter().map(|t| t.get("name")).collect::<Vec<_>>()
+    );
+
+    // Sanity-check that every tool name starts with `choreo_`.
+    for tool in tools {
+        let name = tool
+            .get("name")
+            .and_then(Value::as_str)
+            .unwrap_or_else(|| panic!("tool entry missing name: {tool:?}"));
+        assert!(
+            name.starts_with("choreo_"),
+            "tool name not prefixed: {name}"
+        );
+    }
+
+    // tools/call for the 4 simplest read-only RPCs. Each should
+    // come back as a well-formed JSON-RPC envelope with a `result`
+    // object.
+    let simple_tools = [
+        "choreo_list_councils",
+        "choreo_list_contracts",
+        "choreo_get_metrics",
+        "choreo_get_status",
+    ];
+
+    for tool in simple_tools {
+        let resp = mcp
+            .call(
+                "tools/call",
+                json!({
+                    "name": tool,
+                    "arguments": {},
+                }),
+            )
+            .await;
+        assert_eq!(
+            resp.get("jsonrpc").and_then(Value::as_str),
+            Some("2.0"),
+            "{tool}: malformed envelope: {resp:?}",
+        );
+        let result = resp
+            .get("result")
+            .unwrap_or_else(|| panic!("{tool}: missing result: {resp:?}"));
+        assert!(
+            result.is_object(),
+            "{tool}: result is not an object: {result:?}",
+        );
+        // Per MCP spec, tool errors come back as `isError: true`
+        // inside `result`, not as a JSON-RPC `error`. A real failure
+        // here means the gRPC wiring or the choreographer dropped
+        // the call — every read tool should land cleanly.
+        let is_error = result
+            .get("isError")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        assert!(!is_error, "{tool}: returned isError=true: {result:?}",);
+    }
+}

--- a/crates/choreo-proto/proto/underpass/choreo/v1/choreo.proto
+++ b/crates/choreo-proto/proto/underpass/choreo/v1/choreo.proto
@@ -237,6 +237,7 @@ message Proposal {
   string author_agent_id = 2;
   string content = 3; // free-form solution artifact
   google.protobuf.Struct metadata = 4; // opaque per-agent annotations
+  uint32 revision_count = 5; // peer-review revisions applied to this proposal
 }
 
 // Outcome of validating and scoring a proposal.
@@ -518,6 +519,7 @@ message CandidateSummary {
   repeated ValidatorReport reports = 4;
   uint32 rank = 5;
   bool passed = 6;
+  uint32 revision_count = 7;
 }
 
 message ValidationOutcomeSummary {

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -52,21 +52,19 @@ Two surfaces beyond the eight areas:
   expose a clean, fully-typed gRPC API plus the MCP wrapping so any
   agentic consumer can drive it.
 
-Genuinely open work after the 2026-05-14 bundles is narrower:
-document the compose E2E stub-LLM surface, optionally teach
-`choreo-consumer-smoke` to drive the positive structured-output
-sidecar path, and keep the operator-facing `make e2e-provider-vllm`
-flow for real external vLLM endpoints. Milestones A, B, C, D, and E
-are all complete as of 2026-05-14. The `choreo-mcp` crates.io
-distribution debt is also cleared: vendored proto crate + tag-gated
-publish jobs + per-PR publish-dry-run + real-kernel container
-integration test.
+Genuinely open work after the 2026-05-18 compose-E2E and consumer-smoke
+positive-path work is narrower: keep the operator-facing
+`make e2e-provider-vllm` flow for real external vLLM endpoints and
+finish the release-candidate publication gates.
+Milestones A, B, C, D, and E are all complete as of 2026-05-14. The
+`choreo-mcp` Git-install UX and fixture/live smoke path are present;
+crates.io publication remains release-candidate work tracked in
+`docs/product-publication-checklist.md`.
 
 The recommended remaining execution order is:
 
-- compose-level operations doc for the stub-runtime / stub-LLM E2E path
-- optional consumer-smoke positive-path mode against a structured JSON agent
 - real-provider validation as an operator-run E2E (`make e2e-provider-vllm`)
+- release-candidate publication gates
 
 ## Out of scope
 
@@ -151,7 +149,7 @@ notes still live in each epic block below.
   env vars, helm-lint gate 4 added.
 - **#50** `feat(mcp): hand-rolled stdio MCP adapter for the
   choreographer API` — Epic 13 foundation. Crate `choreo-mcp`
-  exposes the 12 RPCs of `underpass.choreo.v1` as MCP tools over
+  exposes every RPC of `underpass.choreo.v1` as MCP tools over
   JSON-RPC/stdio. Hand-rolled (no SDK), fixture + gRPC backends,
   field-for-field JSON↔proto mappers, TLS auto-detection, buffered
   streaming.
@@ -164,8 +162,8 @@ notes still live in each epic block below.
 State at session close: Milestones A (foundations) + B (mostly,
 report artifact pending) + C (Epic 6 + 7 done; Epic 8 server done,
 outbound client TLS open) substantially advanced. MCP adapter live
-end-to-end with `cargo install --git` UX (crates.io publication
-deferred — proto vendoring required).
+end-to-end with Git-install UX; crates.io publication required the
+later vendored-proto distribution slice.
 
 ## Phase 1 — Runtime And Context Foundations
 
@@ -770,8 +768,10 @@ remains an operator-run validation through `make e2e-provider-vllm`.
 
 Current state:
 
-- `crates/choreo-e2e-runner/src/main.rs` runs nine scenarios against
-  a real gRPC + NATS stack with stub-runtime + stub-llm sidecars:
+- `crates/choreo-e2e-runner/src/main.rs` dispatches the selected
+  scenarios; `crates/choreo-e2e-runner/src/scenarios/` contains the
+  assertions against a real gRPC + NATS stack with stub-runtime +
+  stub-llm sidecars:
   1. seeded council is visible
   2. `Deliberate` on the seeded specialty returns a winner
   3. `DeleteCouncil` on an unknown specialty returns `deleted=false`
@@ -828,6 +828,8 @@ Current state:
 Relevant code:
 
 - [`crates/choreo-e2e-runner/src/main.rs`](../crates/choreo-e2e-runner/src/main.rs)
+- [`crates/choreo-e2e-runner/src/scenario_selection.rs`](../crates/choreo-e2e-runner/src/scenario_selection.rs)
+- [`crates/choreo-e2e-runner/src/scenarios/`](../crates/choreo-e2e-runner/src/scenarios/)
 - [`crates/choreo-e2e-runner/src/bin/stub_runtime.rs`](../crates/choreo-e2e-runner/src/bin/stub_runtime.rs)
 - [`crates/choreo-e2e-runner/src/bin/stub_llm.rs`](../crates/choreo-e2e-runner/src/bin/stub_llm.rs)
 - [`tests/e2e/stub-runtime.Dockerfile`](../tests/e2e/stub-runtime.Dockerfile)
@@ -866,14 +868,13 @@ Status of the chain:
 #### Remaining follow-ups
 
 - compose-level operations doc (`docs/operations/compose-e2e.md`):
-  the stub-llm sidecar, its OpenAI-compat surface, the hard-coded
-  Report payload, and the `STUB_LLM_LISTEN` override all need a
-  prose home. The doc itself does not exist yet — leaving as a
-  follow-up so this slice stays additive.
-- optional consumer-smoke positive-path mode: the underlying stub-LLM
-  capability exists, but `choreo-consumer-smoke` still defaults to
-  the NoopAgent rejection path unless a consumer wires a structured
-  JSON agent.
+  done 2026-05-18. It documents the nine scenarios, `stub-runtime`,
+  `stub-llm`, Report schema, provider-shaped OpenAI/vLLM paths, and
+  when to use `make e2e-compose` versus `make e2e-provider-vllm`.
+- optional consumer-smoke positive-path mode: done 2026-05-18.
+  `--chain positive-path` registers an `openai` or `vllm` agent
+  against an OpenAI-compatible endpoint and validates a strict Report
+  winner. The default smoke still targets the NoopAgent rejection path.
 
 ### Epic 12. Consumer integration smoke prerequisites
 
@@ -919,12 +920,11 @@ Deliverables:
 - **Bundle round-trip** (`bundle_seam_documented`) remains `Skipped`
   in the consumer-smoke harness by design; Epic 11 scenario 7 already
   proves the stack-level round-trip in `make e2e-compose`.
-- **Chain 2 positive path** (`report_payload_validates`) remains
-  `Skipped` against the default NoopAgent stack. The stub-LLM sidecar
-  shipped under Epic 11 scenario 8, so consumers can now register an
-  `openai`-kind agent against `http://stub-llm:8000` to exercise the
-  positive path; teaching the smoke harness to run that variant is a
-  follow-up.
+- **Positive structured-output path** is opt-in. Chain 2 still proves
+  rejection against the default NoopAgent stack, and
+  `--chain positive-path` registers an `openai` or `vllm` agent
+  against a consumer-supplied OpenAI-compatible endpoint so
+  `report_payload_validates` can pass.
 - **Provider-runner E2E merged into `make e2e-compose`** is done via
   scenario 9. `make e2e-provider-vllm` remains for validating a real
   external vLLM endpoint.
@@ -957,11 +957,13 @@ Current state:
   the sibling rehydration-mcp.
 - 21 unit tests + workspace clippy clean.
 
-Distribution slice (done 2026-05-14):
+Distribution UX slice (done 2026-05-14; registry-readiness extended
+2026-05-18):
 
-- `scripts/mcp/install-choreo-mcp.sh` — registry mode by default
-  (`cargo install choreo-mcp`); `CHOREO_MCP_INSTALL_MODE=git` falls
-  back to the `--git`/`--branch`/`--tag`/`--rev` source path.
+- `scripts/mcp/install-choreo-mcp.sh` — registry install wrapper by
+  default (`cargo install choreo-mcp`), with
+  `CHOREO_MCP_INSTALL_MODE=git` fallback for unreleased branches,
+  tags, and revisions.
 - `scripts/mcp/choreo-stdio-smoke.sh` — one `tools/call` + grep marker
   for both fixture and live modes.
 - `docs/operations/mcp-stdio.md` — canonical user-facing UX.
@@ -969,19 +971,32 @@ Distribution slice (done 2026-05-14):
   — per-client config snippets.
 - `crates/choreo-mcp/README.md` — developer-oriented twin.
 - top-level `README.md` link to `docs/operations/mcp-stdio.md`.
+- `crates/choreo-mcp-proto` — vendored proto crate so `choreo-mcp`
+  can publish without depending on the internal `choreo-proto` crate.
+- `scripts/ci/publish-dry-run.sh` and tag-gated publish jobs in
+  `.github/workflows/publish-distribution.yml`.
 
 Relevant code:
 
 - [`crates/choreo-mcp/`](../crates/choreo-mcp/)
 - [`docs/operations/mcp-stdio.md`](./operations/mcp-stdio.md)
 
-#### Deliverables (met)
+#### Deliverables
 
-1. `crates.io` publication readiness: vendored proto crate,
-   tag-gated publish jobs, and per-PR publish dry-run.
-2. Real-kernel integration test that boots a choreographer in a
-   container and exercises every tool through MCP (separate from the
-   existing e2e-runner gRPC scenarios).
+Met:
+
+1. Git fallback install path for unreleased `choreo-mcp` builds.
+2. Fixture and live stdio smoke script.
+3. End-user docs plus Codex CLI and Claude Desktop snippets.
+4. crates.io publication readiness: vendored proto crate, tag-gated
+   publish jobs, and per-PR publish dry-run.
+
+Open release-candidate work:
+
+1. Publish `choreo-mcp-proto` and then `choreo-mcp` from the first
+   `v*` tag.
+2. Verify registry install path (`cargo install choreo-mcp`) after the
+   crates.io publish jobs complete.
 
 ## Proposed execution order
 
@@ -1136,8 +1151,9 @@ The following rule should be treated as hard policy:
 > output should depend on Choreographer until Milestones A, B, and C
 > are complete.
 
-Status 2026-05-14: Milestones A, B, C, D, and E are complete. The
-crates.io publication leg of Epic 13 also cleared in Bundle B.
+Status 2026-05-18: Milestones A, B, C, D, and E are complete.
+`choreo-mcp` has a Git-install UX and smoke coverage; crates.io
+publication remains release-candidate work.
 
 Why the rule still applies in spirit even with B and C now cleared:
 

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -170,9 +170,24 @@ lab-notebook contract).
 
 ## Running the binary
 
+The smallest local run does not need NATS, Postgres, Runtime, KMP,
+PIR, or provider credentials. It uses in-memory persistence, noop
+messaging, and the default noop executor:
+
 ```bash
 # With no external services.
 CHOREO_NATS_ENABLED=false just run
+
+# Same command without just.
+CHOREO_NATS_ENABLED=false cargo run --locked -p choreo
+
+# Optional: seed a demo council so ListCouncils/Deliberate are
+# immediately exercisable after boot.
+CHOREO_NATS_ENABLED=false CHOREO_SEED_SPECIALTIES=triage just run
+
+# Same seeded run without just.
+CHOREO_NATS_ENABLED=false CHOREO_SEED_SPECIALTIES=triage \
+  cargo run --locked -p choreo
 
 # With defaults, the binary expects NATS at nats://nats:4222 and uses
 # in-memory persistence unless CHOREO_POSTGRES_URL is set.
@@ -187,6 +202,43 @@ Full configuration surface — see the table in
 [`crates/choreo-adapters/src/config.rs`](../crates/choreo-adapters/src/config.rs)
 and
 [`charts/choreographer/values.yaml`](../charts/choreographer/values.yaml).
+
+## Running the MCP adapter
+
+Fixture mode is the quickest MCP client-wiring path because it needs no
+running Choreographer:
+
+```bash
+# Installed binary.
+CHOREO_MCP_BACKEND=fixture choreo-mcp
+
+# Same mode from a checkout.
+CHOREO_MCP_BACKEND=fixture cargo run -p choreo-mcp --locked
+
+# One-shot terminal smoke.
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
+  | CHOREO_MCP_BACKEND=fixture cargo run -q -p choreo-mcp --locked
+```
+
+Live mode points at a running Choreographer:
+
+```bash
+# Installed binary against the local server from `just run`.
+CHOREO_MCP_GRPC_ENDPOINT=http://127.0.0.1:50055 choreo-mcp
+
+# Same mode from a checkout.
+CHOREO_MCP_GRPC_ENDPOINT=http://127.0.0.1:50055 \
+  cargo run -p choreo-mcp --locked
+
+# One-shot smoke against the local server.
+CHOREO_MCP_GRPC_ENDPOINT=http://127.0.0.1:50055 \
+CHOREO_MCP_BIN=target/debug/choreo-mcp \
+  bash scripts/mcp/choreo-stdio-smoke.sh
+```
+
+The canonical end-user guide is
+[`docs/operations/mcp-stdio.md`](operations/mcp-stdio.md).
 
 ## Adding a new port
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,17 +22,23 @@ does not require KMP, PIR, or any downstream product to run:
 
 | Doc | Purpose |
 |---|---|
-| [`dev-loop.md`](./dev-loop.md) | Local iteration loop; every command mirrors a CI gate. |
+| [`dev-loop.md`](./dev-loop.md) | Local iteration loop, including `CHOREO_NATS_ENABLED=false just run` for no-external-service startup. |
 | [`release.md`](./release.md) | Versioning + cut-a-release checklist. |
-| [`operations/mcp-stdio.md`](./operations/mcp-stdio.md) | **MCP entry point.** Installable stdio adapter exposing every gRPC RPC as an MCP tool. |
+| [`operations/compose-e2e.md`](./operations/compose-e2e.md) | Repo-owned compose E2E: stack shape, nine scenarios, stubs, Report schema, and provider-shaped paths. |
+| [`operations/deploy-kubernetes.md`](./operations/deploy-kubernetes.md) | Helm install guide, including minimal standalone install, embedded NATS, TLS/mTLS, Postgres secret, provider env secrets, Runtime executor, and the Underpass Runtime profile. |
+| [`operations/mcp-stdio.md`](./operations/mcp-stdio.md) | **MCP entry point.** Installable stdio adapter exposing every gRPC RPC as an MCP tool, including fixture-mode quickstart. |
 | [`operations/mcp/codex.md`](./operations/mcp/codex.md) | Codex CLI specifics: `codex mcp add`, dev-from-checkout, mTLS, fixture. |
 | [`operations/mcp/claude-desktop.md`](./operations/mcp/claude-desktop.md) | `claude_desktop_config.json` snippets, per-OS paths, troubleshooting. |
+| [`operations/support-matrix.md`](./operations/support-matrix.md) | Supported Rust toolchain and release-support rules. |
 
 ## Discipline — how this project decides what to ship
 
 | Doc | Purpose |
 |---|---|
 | [`PRINCIPLES.md`](./PRINCIPLES.md) | Honest documentation, demonstrable claims, scientific iteration. |
+| [`../CHANGELOG.md`](../CHANGELOG.md) | Unreleased changes and release-note discipline before the first public tag. |
+| [`../CONTRIBUTING.md`](../CONTRIBUTING.md) | Contribution workflow, required gates, contract rules, and PR expectations. |
+| [`../SECURITY.md`](../SECURITY.md) | Supported security scope, private vulnerability reporting, and deployment hardening baseline. |
 
 ## Status, gaps, and roadmap
 

--- a/docs/operations/compose-e2e.md
+++ b/docs/operations/compose-e2e.md
@@ -1,0 +1,259 @@
+# Compose E2E
+
+`make e2e-compose` is the repository-owned end-to-end proof for the
+Choreographer stack. It runs the public gRPC API, core NATS events, the
+Runtime executor adapter, JSON-Schema output contracts, and
+provider-shaped agents without external credentials.
+
+Use it when changing user-visible coordination behavior, gRPC mapping,
+NATS envelopes, executor wiring, output validation, or provider adapter
+composition.
+
+## Quickstart
+
+Prerequisites:
+
+- Docker with the Compose plugin, Podman with compose support, or
+  `podman-compose`.
+- Enough local resources to build the Choreographer image plus the two
+  test sidecars.
+
+Run:
+
+```sh
+make e2e-compose
+```
+
+The wrapper auto-detects `docker compose`, `podman compose`, then
+`podman-compose`. To force a runtime:
+
+```sh
+CONTAINER_RUNTIME=docker make e2e-compose
+CONTAINER_RUNTIME=podman make e2e-compose
+CONTAINER_RUNTIME=podman-compose make e2e-compose
+```
+
+If `podman compose` delegates to Docker Compose and cannot find the
+rootless Podman socket, either start `podman.socket` for the user
+session or force `CONTAINER_RUNTIME=podman-compose`.
+
+## Scenario Selection
+
+The runner reads `CHOREO_E2E_SCENARIOS`. The default is `compose`, which
+keeps `make e2e-compose` on the full 1-9 suite. To run a subset:
+
+```sh
+CHOREO_E2E_SCENARIOS=cluster-connectivity make e2e-compose
+CHOREO_E2E_SCENARIOS=structured-output make e2e-compose
+CHOREO_E2E_SCENARIOS=1-4,8 make e2e-compose
+```
+
+Supported selectors:
+
+| Selector | Scenarios | Intended Use |
+|---|---:|---|
+| `compose` / `all` | 1-9 | Full repo-owned compose proof. |
+| `cluster-connectivity` | 1-4 | gRPC, seeded council, delete-idempotence, NATS trigger/envelope smoke. |
+| `runtime-stub` | 5 | Runtime executor adapter against `stub-runtime`. |
+| `structured-output` | 6-9 | Strict schema rejection plus positive Report contracts through `stub-llm`. |
+| `1`, `scenario-5`, `s8`, `1-4` | selected numbers | Targeted debugging. |
+
+The script writes compose logs to `tests/e2e/compose.log` during
+cleanup. A passing run exits `0` after the `e2e-runner` prints
+`E2E scenarios passed`.
+
+## New-User Validated Result
+
+A new user can obtain a validated result without reading Rust by
+running only:
+
+```sh
+make e2e-compose
+```
+
+The validated-result path is scenario 8. It registers the canonical
+Report JSON Schema, registers an `openai`-kind agent pointed at
+`stub-llm`, creates a `report` council, and calls
+`RunCouncilDecision` in `STRICT` mode. The expected success signals are:
+
+```text
+scenario 8: structured-output Report contract passes against a stub OpenAI-shaped agent
+RunCouncilDecision succeeded with Report-shaped winner ... candidates_passed=1 candidates_total=1
+E2E scenarios passed
+```
+
+Scenario 9 repeats the same positive Report-contract path through the
+`vllm` adapter shape. These scenarios require no external credentials;
+they prove the product-owned path with deterministic local fixtures, not
+a real provider deployment.
+
+Implementation entry points:
+
+- [`../../Makefile`](../../Makefile) — `e2e-compose` target.
+- [`../../scripts/ci/e2e-compose.sh`](../../scripts/ci/e2e-compose.sh)
+  — compose runtime detection, cleanup, and log capture.
+- [`../../tests/e2e/docker-compose.e2e.yaml`](../../tests/e2e/docker-compose.e2e.yaml)
+  — stack definition.
+- [`../../crates/choreo-e2e-runner/src/main.rs`](../../crates/choreo-e2e-runner/src/main.rs)
+  — runner entrypoint and scenario dispatch.
+- [`../../crates/choreo-e2e-runner/src/scenario_selection.rs`](../../crates/choreo-e2e-runner/src/scenario_selection.rs)
+  — selector parsing and scenario groups.
+- [`../../crates/choreo-e2e-runner/src/scenarios/`](../../crates/choreo-e2e-runner/src/scenarios/)
+  — the scenario assertions, split by surface.
+
+## Stack
+
+The compose file starts five meaningful services:
+
+| Service | Purpose |
+|---|---|
+| `nats` | Core NATS broker for inbound triggers and outbound events. The image starts with `-js`, but the adapter uses plain core NATS pub/sub semantics. |
+| `stub-runtime` | Minimal `underpass.runtime.v1` gRPC peer for `RuntimeExecutor`. |
+| `stub-llm` | OpenAI-compatible HTTP peer returning deterministic Report-shaped JSON. |
+| `choreographer` | Service under test, seeded with one `triage` council and configured for NATS + Runtime executor + OpenAI/vLLM provider kinds. |
+| `e2e-runner` | Drives assertions through public gRPC and NATS surfaces only. |
+
+The runner uses:
+
+- `CHOREOGRAPHER_ENDPOINT=http://choreographer:50055`
+- `CHOREO_SEED_SPECIALTY=triage`
+- `CHOREO_REPORT_SCHEMA_PATH=/etc/choreo/report.schema.json`
+
+## Scenarios
+
+| # | Surface | What It Proves |
+|---|---|---|
+| 1 | `ListCouncils` | The service booted and seeded the configured `triage` council. |
+| 2 | `Deliberate` | A task against the seeded council returns ranked results and a winner. |
+| 3 | `DeleteCouncil` | Deleting a missing specialty is non-destructive and returns `deleted=false`. |
+| 4 | NATS trigger -> `DeliberationCompleted` | `correlation_id` and `causation_id` propagate from inbound trigger to outbound event. |
+| 5 | `Orchestrate` -> `RuntimeExecutor` -> `stub-runtime` | A winning proposal is handed to the Runtime executor and returns the stub invocation id. |
+| 6 | `Orchestrate` with strict JSON Schema | Free-form `NoopAgent` output is rejected deterministically and publishes `TaskFailed` with `error_kind=deliberation.no_valid_proposal`. |
+| 7 | `Deliberate` with `ExternalContextBundle` | The caller-supplied context bundle id round-trips to the outbound `DeliberationCompleted` envelope. |
+| 8 | `RunCouncilDecision` + OpenAI-shaped agent | A strict Report contract passes against an `openai` agent pointed at `stub-llm`; the winner validates against the Report schema. |
+| 9 | `RunCouncilDecision` + vLLM-shaped agent | The same strict Report path passes through a `vllm` agent pointed at `stub-llm`, proving the OpenAI-compatible vLLM adapter shape. |
+
+The scenarios are intentionally additive. Scenario 6 proves the
+negative structured-output path; scenarios 8 and 9 prove the positive
+structured-output path with provider-shaped agents.
+
+## Stub Runtime
+
+`stub-runtime` is a small gRPC server built from
+[`../../crates/choreo-e2e-runner/src/bin/stub_runtime.rs`](../../crates/choreo-e2e-runner/src/bin/stub_runtime.rs).
+It implements the Runtime services needed by `RuntimeExecutor`:
+
+- `CreateSession` returns `stub-session-1`.
+- `InvokeTool` returns `stub-invocation-1` with status `SUCCEEDED`.
+- `CloseSession` returns `closed=true`.
+
+The compose service listens on `0.0.0.0:50053` through
+`STUB_RUNTIME_GRPC_ADDR`. Choreographer reaches it through:
+
+```text
+CHOREO_EXECUTOR_KIND=runtime
+CHOREO_RUNTIME_GRPC_ENDPOINT=http://stub-runtime:50053
+```
+
+Scenario 5 sets `runtime.tool_name=stub.echo`. That tool name is a
+test fixture. It is not a claim that a real `underpass-runtime`
+deployment contains `stub.echo`.
+
+## Stub LLM
+
+`stub-llm` is an OpenAI-compatible HTTP server built from
+[`../../crates/choreo-e2e-runner/src/bin/stub_llm.rs`](../../crates/choreo-e2e-runner/src/bin/stub_llm.rs).
+It exposes:
+
+- `POST /v1/chat/completions`
+- `GET /health`
+
+The chat-completions route always returns one deterministic assistant
+message. Its `choices[0].message.content` is a JSON string that
+satisfies the canonical Report schema.
+
+The listener is controlled by `STUB_LLM_LISTEN`; compose sets it to
+`0.0.0.0:8000`. The sidecar ignores bearer tokens and does not call a
+real model. It exists only to prove Choreographer's provider-shaped
+adapter path and structured-output validation without external
+credentials.
+
+## Report Contract
+
+Scenarios 8 and 9 use
+[`../../api/examples/output-contracts/report.schema.json`](../../api/examples/output-contracts/report.schema.json).
+The runner image copies it to `/etc/choreo/report.schema.json`, then
+registers it with `RegisterContract`.
+
+The schema requires:
+
+- `report_id`
+- `executive_summary`
+- at least one entry in `findings`
+- at least one entry in `recommended_actions`
+
+It is generic by design. Application identifiers and domain vocabulary
+belong in `Task.attributes`, `ExternalContextBundle.metadata`, or the
+calling product, not in the Choreographer core.
+
+## Provider Shapes
+
+Compose enables both provider kinds at boot:
+
+```text
+CHOREO_OPENAI_API_KEY=stub-key-not-used
+CHOREO_VLLM_MODEL=stub-report-vllm-v1
+CHOREO_VLLM_ENDPOINT=http://stub-llm:8000
+```
+
+Scenario 8 registers an `openai` agent with:
+
+```text
+provider.endpoint=http://stub-llm:8000
+provider.model=stub-report-v1
+provider.api_key=stub-key-not-used
+```
+
+Scenario 9 registers a `vllm` agent with:
+
+```text
+provider.endpoint=http://stub-llm:8000
+provider.model=stub-report-vllm-v1
+```
+
+Both adapters speak the OpenAI Chat Completions wire shape, so one
+sidecar can validate both paths. This proves Choreographer's adapter
+contract and registration flow. It does not prove latency,
+authentication, model behavior, or network policy for a real external
+provider.
+
+For a real vLLM endpoint, use the operator-run flow:
+
+```sh
+make e2e-provider-vllm
+```
+
+## When To Use Which E2E
+
+| Command | Use For | External Dependencies |
+|---|---|---|
+| `make e2e-compose` | Repo-owned stack proof with deterministic fixtures. | Local container runtime only. |
+| `make e2e-provider-vllm` | Adapter-level validation against a real vLLM endpoint. | Kubernetes access plus real vLLM endpoint configuration. |
+| Kubernetes smoke job | Connectivity smoke after Helm install. | Cluster, deployed Choreographer, and matching runtime/provider fixtures if running compose-shaped scenarios. |
+
+Do not present `make e2e-compose` as proof of real provider
+performance. It proves that Choreographer's public surfaces and
+provider-shaped wiring are coherent under deterministic test fixtures.
+
+## Troubleshooting
+
+- **No compose runtime found**: install Docker Compose, Podman compose,
+  or `podman-compose`, or set `CONTAINER_RUNTIME` explicitly.
+- **Scenario 5 fails against a real cluster**: the compose runner
+  expects `stub.echo`; use the compose stack or provide an equivalent
+  Runtime fixture.
+- **Scenarios 8 or 9 fail with provider kind unsupported**: confirm the
+  Choreographer binary was built with the OpenAI/vLLM feature flags and
+  booted with the provider env vars needed by `DispatchingAgentFactory`.
+- **Need detailed logs**: inspect `tests/e2e/compose.log` after the
+  wrapper exits.

--- a/docs/operations/consumer-smoke.md
+++ b/docs/operations/consumer-smoke.md
@@ -7,7 +7,9 @@ only talks gRPC over `tonic` and (optionally) core NATS over
 `async-nats`. That makes it a faithful smoke test of the integration
 contract a real consumer commits to.
 
-Two chains run, both shipped today:
+The default smoke runs two provider-free chains. An opt-in positive
+path is available when the target Choreographer has a provider-backed
+agent kind enabled and a compatible endpoint is reachable:
 
 - **Chain 1** — Warn-mode reevaluation. Mirrors what a consumer
   triggers after observing an incident or domain event: optionally
@@ -16,14 +18,18 @@ Two chains run, both shipped today:
   typed response + the outbound `choreo.deliberation.completed`
   envelope (correlation / causation propagation).
 
-- **Chain 2** — Strict-mode handoff report. Registers the canonical
+- **Chain 2** — Strict-mode handoff report / rejection path. Registers the canonical
   Report `OutputContract` (JSON Schema body bound in
   `OutputContract.json_schema`), invokes `RunCouncilDecision` in
-  Strict mode, and asserts that the choreographer either accepts a
-  schema-conformant response (positive path) or rejects free-form
-  text with `Code::FailedPrecondition` whose message mentions the
-  contract id (rejection path — the path today's NoopAgent stack
-  reaches).
+  Strict mode, and asserts that the choreographer rejects free-form
+  NoopAgent text with `Code::FailedPrecondition` whose message
+  mentions the contract id.
+
+- **Positive path** — Provider-backed strict Report. Registers the
+  canonical Report contract, registers an `openai` or `vllm` agent
+  against an OpenAI-compatible endpoint, creates a one-agent council,
+  runs `RunCouncilDecision` in Strict mode, and validates that
+  `report_payload_validates` is `Passed`.
 
 ## Prerequisites
 
@@ -37,6 +43,12 @@ Two chains run, both shipped today:
   `RegisterContract` and tolerates `AlreadyExists` /
   `FailedPrecondition` (already seeded) as a pass — but the registry
   must accept new contracts when starting from empty.
+- For `positive-path`: the Choreographer binary must be built with
+  the provider feature and booted with the provider's base config:
+  `agent-openai` plus `CHOREO_OPENAI_API_KEY` for `openai`, or
+  `agent-vllm` plus `CHOREO_VLLM_MODEL` and `CHOREO_VLLM_ENDPOINT`
+  for `vllm`. Per-run `provider.endpoint` and `provider.model`
+  overrides are sent through `RegisterAgent.agent_config`.
 
 For the canonical bus subjects (Chain 1's NATS-coupled assertions):
 
@@ -47,15 +59,23 @@ If `--nats-url` is omitted, those assertions are recorded as
 `Skipped` (never silently dropped) and the rest of the chain still
 runs.
 
+`--chain all` runs Chain 2 before Chain 1. That lets a fresh registry
+receive the Report contract before Chain 1 consumes the same contract
+in Warn mode.
+
 ## Invocation
 
 ```bash
 cargo run -p choreo-consumer-smoke -- \
     --endpoint http://localhost:50055 \
     [--nats-url nats://localhost:4222] \
-    [--chain {one,two,all}] \
+    [--chain {one,two,all,positive-path}] \
     [--specialty triage] \
-    [--contract-id consumer-smoke-report-v1]
+    [--contract-id consumer-smoke-report-v1] \
+    [--provider-kind {openai,vllm}] \
+    [--provider-endpoint http://localhost:8000] \
+    [--provider-model stub-report-v1] \
+    [--positive-specialty consumer-smoke-report-openai]
 ```
 
 Environment overrides:
@@ -67,6 +87,15 @@ Environment overrides:
 - `CHOREO_REPORT_SCHEMA_PATH` — Chain 2 reads the schema from this
   path. Default `api/examples/output-contracts/report.schema.json`
   (relative to the binary's cwd).
+- `CONSUMER_SMOKE_PROVIDER_KIND` — provider kind for
+  `positive-path`; `openai` or `vllm`. Default `openai`.
+- `CONSUMER_SMOKE_PROVIDER_ENDPOINT` — OpenAI-compatible endpoint
+  used by `positive-path`. Required for that chain.
+- `CONSUMER_SMOKE_PROVIDER_MODEL` — model override sent in
+  `RegisterAgent.agent_config`. Default `stub-report-v1`.
+- `CONSUMER_SMOKE_POSITIVE_SPECIALTY` — optional specialty for the
+  positive council. If omitted, the CLI uses
+  `consumer-smoke-report-<provider-kind>`.
 - `RUST_LOG` — standard tracing filter. Default `info`.
 
 A `make consumer-smoke` target wraps the same call:
@@ -76,6 +105,66 @@ make consumer-smoke
 CONSUMER_SMOKE_CHAIN=two CHOREOGRAPHER_ENDPOINT=https://staging:50055 \
     make consumer-smoke
 ```
+
+Positive path against a local OpenAI-compatible stub/provider:
+
+```bash
+cargo run -p choreo-consumer-smoke -- \
+    --endpoint http://localhost:50055 \
+    --chain positive-path \
+    --provider-kind openai \
+    --provider-endpoint http://localhost:8000 \
+    --provider-model stub-report-v1
+```
+
+## CI Example
+
+A downstream consumer can gate a staging deploy with two smoke steps:
+the default provider-free chain set, then the provider-backed positive
+path. The first step checks that the public API is alive, that strict
+schema rejection works, and, when `CHOREO_NATS_URL` is set, that
+correlation/causation propagate on the bus. The second step checks
+that a structured Report JSON winner is accepted.
+
+```yaml
+name: choreographer-consumer-smoke
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 * * * *"
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    env:
+      CHOREOGRAPHER_ENDPOINT: ${{ secrets.CHOREOGRAPHER_ENDPOINT }}
+      CHOREO_NATS_URL: ${{ secrets.CHOREO_NATS_URL }}
+      CONSUMER_SMOKE_PROVIDER_KIND: openai
+      CONSUMER_SMOKE_PROVIDER_ENDPOINT: ${{ secrets.CONSUMER_SMOKE_PROVIDER_ENDPOINT }}
+      CONSUMER_SMOKE_PROVIDER_MODEL: ${{ vars.CONSUMER_SMOKE_PROVIDER_MODEL }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: underpass-ai/underpass-choreographer
+          ref: <pinned-tag-or-sha>
+          path: choreographer-smoke
+
+      - name: Provider-free API and rejection smoke
+        working-directory: choreographer-smoke
+        run: |
+          cargo run -p choreo-consumer-smoke --locked -- \
+            --chain all
+
+      - name: Positive Report smoke
+        working-directory: choreographer-smoke
+        run: |
+          cargo run -p choreo-consumer-smoke --locked -- \
+            --chain positive-path
+```
+
+The job relies on exit codes only: `0` passes, `1` means a consumer
+assertion failed, and `2` means the smoke could not run.
 
 ## What each chain asserts
 
@@ -89,7 +178,15 @@ CONSUMER_SMOKE_CHAIN=two CHOREOGRAPHER_ENDPOINT=https://staging:50055 \
 | chain1 | `causal_metadata_propagated` | that envelope's `causation_id` matches the one the harness sent |
 | chain2 | `report_schema_registered` | `RegisterContract` succeeds or the contract already exists |
 | chain2 | `report_contract_rejects_freeform_text` | `RunCouncilDecision` returns `FailedPrecondition` mentioning the contract id |
-| chain2 | `report_payload_validates` | the winner's content satisfies the schema (positive path) |
+| chain2 | `report_payload_validates` | `Skipped` on rejection path; positive validation belongs to `positive-path` |
+| positive-path | `positive_provider_endpoint_configured` | `--provider-endpoint` / `CONSUMER_SMOKE_PROVIDER_ENDPOINT` is present |
+| positive-path | `report_schema_registered` | `RegisterContract` succeeds or the contract already exists |
+| positive-path | `positive_agent_registered` | `RegisterAgent` accepts the `openai`/`vllm` descriptor and endpoint/model overrides |
+| positive-path | `positive_council_created` | `CreateCouncil` succeeds or the council already exists |
+| positive-path | `run_council_decision_strict` | Strict `RunCouncilDecision` returns a winner proposal |
+| positive-path | `report_payload_validates` | the winner's content parses as JSON and satisfies the Report schema |
+| positive-path | `report_validation_summary_passed` | `response.validation.passed == true` |
+| positive-path | `positive_completion_envelope_observed` | optional: with NATS configured, the completion envelope for the task arrives |
 
 Each assertion is also typed (`Passed` / `Skipped { reason }` /
 `Failed { detail }`), so callers that embed the library can assert on
@@ -102,11 +199,11 @@ the typed shape without parsing the printed table.
   `make e2e-compose` scenario 7; this consumer harness keeps that
   assertion as a documented out-of-scope seam rather than duplicating
   the stack E2E.
-- **Chain 2's positive path needs a structured-JSON agent.** The
-  default smoke path targets a NoopAgent stack and proves strict
-  schema rejection. The compose stack also ships a `stub-llm` sidecar
-  that emits Report-shaped JSON; wiring the consumer smoke harness to
-  register that agent is a follow-up positive-path mode.
+- **Positive path is opt-in.** The default smoke path targets a
+  provider-free NoopAgent stack and proves strict schema rejection.
+  Run `--chain positive-path` only when the target deployment has
+  `openai` or `vllm` enabled and an OpenAI-compatible endpoint is
+  reachable.
 - The trigger publish in Chain 1 is informational only —
   `RunCouncilDecision` is invoked directly, so the trigger path does
   not gate the run. Pinning the trigger-driven path end-to-end is

--- a/docs/operations/deploy-kubernetes.md
+++ b/docs/operations/deploy-kubernetes.md
@@ -1,9 +1,746 @@
 # Deploying the Choreographer to Kubernetes
 
-The chart at `charts/choreographer/` ships with a deployment profile
-for the `underpass-runtime` namespace
-(`charts/choreographer/values.underpass-runtime.yaml`) and a wrapper
-script (`scripts/ci/deploy-kubernetes.sh`).
+The chart at `charts/choreographer/` supports four checked-in install
+profiles:
+
+- `charts/choreographer/values.minimal.yaml` - standalone install,
+  no external dependencies, noop executor, in-memory persistence, NATS
+  disabled, and plaintext in-cluster gRPC.
+- `charts/choreographer/values.embedded-nats.yaml` - standalone
+  install with a release-local NATS bus, noop executor, and in-memory
+  persistence.
+- `charts/choreographer/values.postgres-secret.yaml` - standalone
+  install with embedded NATS and Postgres persistence sourced from a
+  Kubernetes secret.
+- `charts/choreographer/values.underpass-runtime.yaml` - deployment
+  profile for the `underpass-runtime` namespace with a release-local
+  NATS and the Runtime executor.
+
+The wrapper script `scripts/ci/deploy-kubernetes.sh` runs
+`helm upgrade --install` with pinned image enforcement and the same
+defaults CI uses.
+
+## Minimal standalone install
+
+Use this path when you want the smallest Kubernetes install that
+proves the product surface starts and accepts gRPC calls. It does not
+need KMP, PIR, Runtime, Postgres, NATS, provider credentials, TLS
+secrets, or a NetworkPolicy-capable CNI.
+
+The profile seeds a `triage` NoopAgent council so the deployment is
+immediately smoke-testable.
+
+### Prerequisites
+
+1. A Kubernetes cluster with Helm 3.
+2. An image reference for the Choreographer. Prefer a digest:
+   `IMAGE_DIGEST=sha256:REPLACE_ME`. Use `IMAGE_TAG=sha-COMMIT` only
+   when that tag is immutable in your registry.
+3. If the image is private, an image pull secret in the namespace,
+   for example `ghcr-pull`.
+
+### Install from the checkout
+
+```bash
+NAMESPACE=choreographer-system \
+RELEASE_NAME=choreographer \
+IMAGE_DIGEST=sha256:REPLACE_ME \
+VALUES_FILE=charts/choreographer/values.minimal.yaml \
+./scripts/ci/deploy-kubernetes.sh
+```
+
+For a tag-based install:
+
+```bash
+NAMESPACE=choreographer-system \
+RELEASE_NAME=choreographer \
+IMAGE_TAG=sha-COMMIT \
+VALUES_FILE=charts/choreographer/values.minimal.yaml \
+./scripts/ci/deploy-kubernetes.sh
+```
+
+With a private registry pull secret:
+
+```bash
+helm -n choreographer-system upgrade --install choreographer \
+  charts/choreographer \
+  --create-namespace \
+  -f charts/choreographer/values.minimal.yaml \
+  --set image.digest=sha256:REPLACE_ME \
+  --set imagePullSecrets[0].name=ghcr-pull \
+  --wait --timeout 10m --atomic
+```
+
+For local `kind` or `k3d` development, build/load the image into the
+cluster and use a local tag only with the explicit development escape
+hatch:
+
+```bash
+helm -n choreographer-system upgrade --install choreographer \
+  charts/choreographer \
+  --create-namespace \
+  -f charts/choreographer/values.minimal.yaml \
+  --set image.repository=underpass-choreographer \
+  --set image.tag=dev \
+  --set development.allowMutableImageTags=true \
+  --wait --timeout 10m --atomic
+```
+
+### Minimal smoke
+
+```bash
+kubectl -n choreographer-system rollout status deploy/choreographer
+
+kubectl -n choreographer-system port-forward svc/choreographer 8080:8080 &
+curl -fsS localhost:8080/healthz
+curl -fsS localhost:8080/readyz
+```
+
+With `values.minimal.yaml`, readiness reports NATS as healthy but
+`not wired (noop messaging)`, because NATS is intentionally disabled.
+That is expected for the minimal profile.
+
+To smoke the gRPC surface from this repository:
+
+```bash
+kubectl -n choreographer-system port-forward svc/choreographer 50055:50055 &
+cargo run -p choreo-consumer-smoke --locked -- \
+  --endpoint http://127.0.0.1:50055 \
+  --chain all
+```
+
+The default `--chain all` run registers the Report contract, proves
+Strict-mode rejection against the seeded NoopAgent, then proves
+Warn-mode `RunCouncilDecision` returns a winner. NATS assertions are
+reported as `Skipped` because no bus is configured in this profile.
+
+### Render check
+
+Before applying changes, operators can render the minimal manifest
+without touching a cluster:
+
+```bash
+helm template choreographer charts/choreographer \
+  -f charts/choreographer/values.minimal.yaml \
+  --set image.tag=sha-COMMIT
+```
+
+The chart refuses to render if neither `image.tag` nor `image.digest`
+is set. It also refuses `image.tag=latest` unless
+`development.allowMutableImageTags=true` is set for a local
+development install.
+
+## Standalone install with embedded NATS
+
+Use `values.embedded-nats.yaml` when you want the Choreographer's
+event surface enabled but do not want to operate a separate NATS
+release. This keeps the install independent from KMP, PIR, Runtime,
+Postgres, provider credentials, and gRPC TLS while still exercising:
+
+- outbound `choreo.task.*`, `choreo.phase.changed`, and
+  `choreo.deliberation.completed` events;
+- inbound triggers on `choreo.trigger.>`;
+- readiness checking of the NATS connection;
+- consumer-smoke assertions for `correlation_id` and `causation_id`
+  propagation.
+
+### Install
+
+```bash
+NAMESPACE=choreographer-system \
+RELEASE_NAME=choreographer \
+IMAGE_DIGEST=sha256:REPLACE_ME \
+VALUES_FILE=charts/choreographer/values.embedded-nats.yaml \
+./scripts/ci/deploy-kubernetes.sh
+```
+
+For local `kind` or `k3d` development:
+
+```bash
+helm -n choreographer-system upgrade --install choreographer \
+  charts/choreographer \
+  --create-namespace \
+  -f charts/choreographer/values.embedded-nats.yaml \
+  --set image.repository=underpass-choreographer \
+  --set image.tag=dev \
+  --set development.allowMutableImageTags=true \
+  --wait --timeout 10m --atomic
+```
+
+With release name `choreographer`, the embedded bus is exposed as the
+ClusterIP Service `choreographer-nats` and the application receives:
+
+```text
+CHOREO_NATS_ENABLED=true
+CHOREO_NATS_URL=nats://choreographer-nats:4222
+CHOREO_TRIGGER_SUBJECT=choreo.trigger.>
+CHOREO_PUBLISH_PREFIX=choreo
+```
+
+For a different release name, inspect the generated Service:
+
+```bash
+kubectl -n choreographer-system get svc \
+  -l app.kubernetes.io/component=nats
+```
+
+### Smoke
+
+```bash
+kubectl -n choreographer-system rollout status deploy/choreographer
+kubectl -n choreographer-system rollout status deploy/choreographer-nats
+
+kubectl -n choreographer-system port-forward svc/choreographer 8080:8080 &
+curl -fsS localhost:8080/readyz
+```
+
+`/readyz` should report the `nats` check as healthy and include the
+configured URL.
+
+To verify the gRPC surface plus event propagation from this checkout:
+
+```bash
+kubectl -n choreographer-system port-forward svc/choreographer 50055:50055 &
+kubectl -n choreographer-system port-forward svc/choreographer-nats 4222:4222 &
+
+cargo run -p choreo-consumer-smoke --locked -- \
+  --endpoint http://127.0.0.1:50055 \
+  --nats-url nats://127.0.0.1:4222 \
+  --chain all
+```
+
+Expected result:
+
+- `chain2 report_contract_rejects_freeform_text PASS`;
+- `chain1 rpc_returned_winner PASS`;
+- `chain1 trigger_envelope_observed PASS`;
+- `chain1 causal_metadata_propagated PASS`.
+
+### Render check
+
+```bash
+helm template choreographer charts/choreographer \
+  -f charts/choreographer/values.embedded-nats.yaml \
+  --set image.tag=sha-COMMIT
+```
+
+The rendered manifest should include both Deployments:
+`choreographer` and `choreographer-nats`. With JetStream disabled, the
+embedded NATS pod has no PVC; current Choreographer events are
+fire-and-forget and do not require stream storage.
+
+## gRPC server TLS and mTLS
+
+The chart has two independent TLS surfaces:
+
+- `tls.*` protects the Choreographer's own gRPC server on port `50055`.
+- `executor.runtime.tls.*` protects the outbound client connection
+  from Choreographer to Runtime.
+
+This section covers `tls.*`. HTTP health probes on port `8080` remain
+plain in-cluster endpoints for Kubernetes liveness/readiness.
+
+### Server TLS
+
+Use `tls.mode=server` when clients should verify the Choreographer
+server identity but do not need to present client certificates.
+
+Create a secret with `tls.crt` and `tls.key`:
+
+```bash
+kubectl -n choreographer-system create secret generic choreographer-grpc-tls \
+  --from-file=tls.crt=./server.crt \
+  --from-file=tls.key=./server.key
+```
+
+Install or upgrade with:
+
+```bash
+helm -n choreographer-system upgrade --install choreographer \
+  charts/choreographer \
+  --create-namespace \
+  -f charts/choreographer/values.embedded-nats.yaml \
+  --set image.digest=sha256:REPLACE_ME \
+  --set tls.mode=server \
+  --set tls.existingSecret=choreographer-grpc-tls \
+  --wait --timeout 10m --atomic
+```
+
+The pod receives:
+
+```text
+CHOREO_GRPC_TLS_MODE=server
+CHOREO_GRPC_TLS_CERT_PATH=/etc/choreographer/tls/tls.crt
+CHOREO_GRPC_TLS_KEY_PATH=/etc/choreographer/tls/tls.key
+```
+
+### Mutual TLS
+
+Use `tls.mode=mutual` when the Choreographer must also authenticate
+gRPC clients. The server secret needs the server identity plus the CA
+bundle used to validate client certificates:
+
+```bash
+kubectl -n choreographer-system create secret generic choreographer-grpc-mtls \
+  --from-file=tls.crt=./server.crt \
+  --from-file=tls.key=./server.key \
+  --from-file=ca.crt=./client-ca.crt
+```
+
+Install or upgrade with:
+
+```bash
+helm -n choreographer-system upgrade --install choreographer \
+  charts/choreographer \
+  --create-namespace \
+  -f charts/choreographer/values.embedded-nats.yaml \
+  --set image.digest=sha256:REPLACE_ME \
+  --set tls.mode=mutual \
+  --set tls.existingSecret=choreographer-grpc-mtls \
+  --wait --timeout 10m --atomic
+```
+
+The pod receives the same server cert/key env vars plus:
+
+```text
+CHOREO_GRPC_TLS_MODE=mutual
+CHOREO_GRPC_TLS_CLIENT_CA_PATH=/etc/choreographer/tls/ca.crt
+```
+
+The chart refuses to render `tls.mode=server` or `tls.mode=mutual`
+without `tls.existingSecret`.
+
+### Client configuration
+
+Clients must use a TLS-capable gRPC endpoint, typically
+`https://choreographer.choreographer-system.svc:50055`. If you use
+`kubectl port-forward`, set the client TLS domain override to the
+certificate SAN rather than `127.0.0.1`.
+
+For the MCP adapter in server-TLS mode:
+
+```bash
+CHOREO_MCP_GRPC_ENDPOINT=https://127.0.0.1:50055 \
+CHOREO_MCP_GRPC_TLS_MODE=server \
+CHOREO_MCP_GRPC_TLS_CA_PATH=./server-ca.crt \
+CHOREO_MCP_GRPC_TLS_DOMAIN_NAME=choreographer-grpc \
+choreo-mcp
+```
+
+For mTLS:
+
+```bash
+CHOREO_MCP_GRPC_ENDPOINT=https://127.0.0.1:50055 \
+CHOREO_MCP_GRPC_TLS_MODE=mutual \
+CHOREO_MCP_GRPC_TLS_CA_PATH=./server-ca.crt \
+CHOREO_MCP_GRPC_TLS_CERT_PATH=./client.crt \
+CHOREO_MCP_GRPC_TLS_KEY_PATH=./client.key \
+CHOREO_MCP_GRPC_TLS_DOMAIN_NAME=choreographer-grpc \
+choreo-mcp
+```
+
+See [`operations/mcp-stdio.md`](./mcp-stdio.md) for full MCP smoke
+commands. The `choreo-consumer-smoke` binary intentionally keeps a
+narrow plain-gRPC surface today; use MCP or another TLS-capable gRPC
+client for hardened transport checks.
+
+### Render checks
+
+```bash
+helm template choreographer charts/choreographer \
+  -f charts/choreographer/values.embedded-nats.yaml \
+  --set image.tag=sha-COMMIT \
+  --set tls.mode=server \
+  --set tls.existingSecret=choreographer-grpc-tls
+
+helm template choreographer charts/choreographer \
+  -f charts/choreographer/values.embedded-nats.yaml \
+  --set image.tag=sha-COMMIT \
+  --set tls.mode=mutual \
+  --set tls.existingSecret=choreographer-grpc-mtls
+```
+
+`scripts/ci/helm-lint.sh` pins both renders and the missing-secret
+failure path.
+
+## Postgres persistence from a secret
+
+By default, Choreographer uses in-memory persistence. Enable Postgres
+when councils, agents, deliberations, and statistics must survive pod
+restarts or replica replacement.
+
+Current scope is deliberately narrow: Postgres backs deliberations,
+councils, agents, and statistics. Output contracts are still managed
+by the in-memory contract registry and should be registered after
+startup or seeded by the deployment workflow.
+
+### Secret shape
+
+Create a Kubernetes secret containing a single key, `url`, whose value
+is the Postgres DSN. Prefer your normal secret manager, External
+Secrets operator, SealedSecret, or SOPS flow. For a direct Kubernetes
+example:
+
+```bash
+kubectl -n choreographer-system create secret generic choreographer-postgres-dsn \
+  --from-file=url=./postgres-url.txt
+```
+
+`postgres-url.txt` should contain a DSN in this shape:
+
+```text
+postgres://USER:PASSWORD@postgresql.choreographer-system.svc:5432/choreographer?sslmode=require
+```
+
+The database user needs enough privileges for startup migrations to
+create and alter the Choreographer schema. Migrations are embedded in
+the binary and run on startup; if the database is unreachable or the
+user lacks migration privileges, the pod fails before serving gRPC.
+
+### Install
+
+The checked-in profile uses embedded NATS and reads the DSN from
+`choreographer-postgres-dsn/url`:
+
+```bash
+NAMESPACE=choreographer-system \
+RELEASE_NAME=choreographer \
+IMAGE_DIGEST=sha256:REPLACE_ME \
+VALUES_FILE=charts/choreographer/values.postgres-secret.yaml \
+./scripts/ci/deploy-kubernetes.sh
+```
+
+Equivalent direct Helm command:
+
+```bash
+helm -n choreographer-system upgrade --install choreographer \
+  charts/choreographer \
+  --create-namespace \
+  -f charts/choreographer/values.embedded-nats.yaml \
+  --set image.digest=sha256:REPLACE_ME \
+  --set persistence.postgres.enabled=true \
+  --set persistence.postgres.urlFromSecret.name=choreographer-postgres-dsn \
+  --set persistence.postgres.urlFromSecret.key=url \
+  --wait --timeout 10m --atomic
+```
+
+The rendered pod receives only a secret reference, not the literal DSN:
+
+```yaml
+- name: CHOREO_POSTGRES_URL
+  valueFrom:
+    secretKeyRef:
+      name: "choreographer-postgres-dsn"
+      key: "url"
+```
+
+The chart refuses to render
+`persistence.postgres.enabled=true` unless either
+`persistence.postgres.urlFromSecret.{name,key}` or
+`persistence.postgres.url` is set. `urlFromSecret` is the recommended
+production path; `url` is retained for ephemeral local testing only.
+
+### NetworkPolicy
+
+If `networkPolicy.enabled=true`, make sure
+`networkPolicy.egress.postgres` matches the labels and port of your
+Postgres Service. The chart emits the Postgres egress block only when
+`persistence.postgres.enabled=true`.
+
+### Smoke
+
+```bash
+kubectl -n choreographer-system rollout status deploy/choreographer
+kubectl -n choreographer-system logs deploy/choreographer | grep 'postgres persistence wired'
+
+kubectl -n choreographer-system port-forward svc/choreographer 50055:50055 &
+grpcurl -plaintext \
+  -import-path crates/choreo-proto/proto \
+  -proto underpass/choreo/v1/choreo.proto \
+  -d '{"specialty":"persistence-smoke","numAgents":1,"agentConfig":{"kind":"noop"}}' \
+  127.0.0.1:50055 underpass.choreo.v1.ChoreographerService/CreateCouncil
+
+kubectl -n choreographer-system rollout restart deploy/choreographer
+kubectl -n choreographer-system rollout status deploy/choreographer
+
+grpcurl -plaintext \
+  -import-path crates/choreo-proto/proto \
+  -proto underpass/choreo/v1/choreo.proto \
+  -d '{"includeAgents":true}' \
+  127.0.0.1:50055 underpass.choreo.v1.ChoreographerService/ListCouncils
+```
+
+The final `ListCouncils` response should still include
+`persistence-smoke`. If the deployment is using gRPC TLS/mTLS, use
+the matching `grpcurl` TLS flags or run the same create/list flow via
+a configured MCP client.
+
+## Provider environment secrets
+
+Provider-backed agent kinds are optional. The chart can inject the
+required `CHOREO_*` provider env vars from a Secret, but the binary
+must also be built with the matching Cargo feature:
+
+- `agent-openai` for `kind=openai`;
+- `agent-vllm` for `kind=vllm`;
+- `agent-anthropic` for `kind=anthropic`.
+
+The startup log includes `agent_kinds=...`; only kinds listed there
+will be accepted by `RegisterAgent`.
+
+### Env vars
+
+| Provider | Required env | Optional env |
+|---|---|---|
+| `openai` | `CHOREO_OPENAI_API_KEY` | `CHOREO_OPENAI_MODEL`, `CHOREO_OPENAI_ENDPOINT`, `CHOREO_OPENAI_MAX_TOKENS` |
+| `vllm` | `CHOREO_VLLM_MODEL`, `CHOREO_VLLM_ENDPOINT` | `CHOREO_VLLM_BEARER_TOKEN`, `CHOREO_VLLM_MAX_TOKENS` |
+| `anthropic` | `CHOREO_ANTHROPIC_API_KEY` | `CHOREO_ANTHROPIC_MODEL`, `CHOREO_ANTHROPIC_ENDPOINT`, `CHOREO_ANTHROPIC_MAX_TOKENS` |
+
+`provider.model`, `provider.endpoint`, and `provider.max_tokens` can
+still be supplied as per-agent descriptor attributes on
+`RegisterAgent`. Credentials stay in environment only; agent
+descriptors may be persisted in Postgres and must not carry secrets.
+
+The service's vLLM factory currently loads endpoint/model/bearer from
+env. The `CHOREO_VLLM_CLIENT_CERT_PATH` and
+`CHOREO_VLLM_CLIENT_KEY_PATH` variables documented for the
+provider-E2E runner are not part of the service factory's Helm path
+yet.
+
+### Secret shape
+
+One Secret can expose all provider variables. Keep the env file out
+of Git:
+
+```text
+CHOREO_OPENAI_API_KEY=REPLACE_ME
+CHOREO_OPENAI_MODEL=gpt-4o-mini
+CHOREO_OPENAI_ENDPOINT=https://api.openai.com
+CHOREO_VLLM_MODEL=stub-report-vllm-v1
+CHOREO_VLLM_ENDPOINT=http://vllm-server:8000
+CHOREO_VLLM_BEARER_TOKEN=REPLACE_ME
+CHOREO_ANTHROPIC_API_KEY=REPLACE_ME
+CHOREO_ANTHROPIC_MODEL=claude-haiku-4-5-20251001
+```
+
+Create the Secret from that file:
+
+```bash
+kubectl -n choreographer-system create secret generic choreographer-provider-env \
+  --from-env-file=./provider.env
+```
+
+Only include providers you intend to enable. Empty strings count as
+unset.
+
+### Install with envFrom
+
+The checked-in overlay
+`charts/choreographer/values.provider-env-secrets.yaml` references
+`choreographer-provider-env` through `envFrom.secretRef`:
+
+```bash
+helm -n choreographer-system upgrade --install choreographer \
+  charts/choreographer \
+  --create-namespace \
+  -f charts/choreographer/values.embedded-nats.yaml \
+  -f charts/choreographer/values.provider-env-secrets.yaml \
+  --set image.digest=sha256:REPLACE_ME \
+  --wait --timeout 10m --atomic
+```
+
+Rendered shape:
+
+```yaml
+envFrom:
+  - secretRef:
+      name: choreographer-provider-env
+```
+
+### Install with per-key references
+
+For tighter ownership, reference individual keys instead of importing
+the full Secret:
+
+```yaml
+providerEnv:
+  - name: CHOREO_OPENAI_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: choreographer-openai
+        key: api-key
+  - name: CHOREO_OPENAI_MODEL
+    value: gpt-4o-mini
+  - name: CHOREO_OPENAI_ENDPOINT
+    value: https://api.openai.com
+```
+
+Apply that values file together with the install profile:
+
+```bash
+helm -n choreographer-system upgrade --install choreographer \
+  charts/choreographer \
+  --create-namespace \
+  -f charts/choreographer/values.embedded-nats.yaml \
+  -f ./provider-env.yaml \
+  --set image.digest=sha256:REPLACE_ME \
+  --wait --timeout 10m --atomic
+```
+
+### Smoke
+
+First check that the provider kind is enabled at boot:
+
+```bash
+kubectl -n choreographer-system logs deploy/choreographer | grep 'agent_kinds='
+```
+
+Then register a provider-backed agent. This validates that the binary
+was compiled with the feature and that required env vars were present;
+it does not call the provider yet.
+
+```bash
+kubectl -n choreographer-system port-forward svc/choreographer 50055:50055 &
+
+grpcurl -plaintext \
+  -import-path crates/choreo-proto/proto \
+  -proto underpass/choreo/v1/choreo.proto \
+  -d '{"specialty":"provider-smoke","agent":{"agentId":"agent-provider-smoke-0","specialty":"provider-smoke","kind":"openai","attributes":{}}}' \
+  127.0.0.1:50055 underpass.choreo.v1.ChoreographerService/RegisterAgent
+```
+
+For an end-to-end provider call, run `choreo-consumer-smoke --chain
+positive-path` against a provider or OpenAI-compatible stub that
+returns the Report JSON shape.
+
+## Enabling the Runtime executor
+
+The Runtime executor is optional. The Choreographer can run with
+`executor.kind: noop` for local installs, consumer smoke, and
+structured-output validation. Set `executor.kind: runtime` only when
+you want `Orchestrate` to hand the winning proposal to an
+`underpass.runtime.v1` service.
+
+`RunCouncilDecision` does not call Runtime; it returns the validated
+winner and candidate breakdown to the caller. Runtime integration is
+therefore proved through `Orchestrate`, not through the consumer-smoke
+`RunCouncilDecision` chains.
+
+### Plain in-cluster Runtime
+
+Use this for private clusters or local fixture environments where the
+Runtime endpoint is plain HTTP/2:
+
+```bash
+helm -n choreographer-system upgrade --install choreographer \
+  charts/choreographer \
+  --create-namespace \
+  -f charts/choreographer/values.embedded-nats.yaml \
+  --set image.digest=sha256:REPLACE_ME \
+  --set executor.kind=runtime \
+  --set executor.runtime.endpoint=http://underpass-runtime:50053 \
+  --set executor.runtime.principal.tenantId=underpass \
+  --set executor.runtime.principal.actorId=choreographer \
+  --set executor.runtime.principal.roles=orchestrator \
+  --wait --timeout 10m --atomic
+```
+
+The rendered pod receives:
+
+```text
+CHOREO_EXECUTOR_KIND=runtime
+CHOREO_RUNTIME_GRPC_ENDPOINT=http://underpass-runtime:50053
+CHOREO_RUNTIME_PRINCIPAL_TENANT_ID=underpass
+CHOREO_RUNTIME_PRINCIPAL_ACTOR_ID=choreographer
+CHOREO_RUNTIME_PRINCIPAL_ROLES=orchestrator
+```
+
+The chart fails render if `executor.kind=runtime` and
+`executor.runtime.endpoint` is empty.
+
+### Runtime with server TLS
+
+When Runtime serves HTTPS and Choreographer only needs to verify the
+server identity, create a secret containing `ca.crt` and enable
+server TLS:
+
+```bash
+kubectl -n choreographer-system create secret generic runtime-server-ca \
+  --from-file=ca.crt=./runtime-ca.crt
+
+helm -n choreographer-system upgrade --install choreographer \
+  charts/choreographer \
+  --create-namespace \
+  -f charts/choreographer/values.embedded-nats.yaml \
+  --set image.digest=sha256:REPLACE_ME \
+  --set executor.kind=runtime \
+  --set executor.runtime.endpoint=https://underpass-runtime:50053 \
+  --set executor.runtime.principal.tenantId=underpass \
+  --set executor.runtime.principal.actorId=choreographer \
+  --set executor.runtime.principal.roles=orchestrator \
+  --set executor.runtime.tls.mode=server \
+  --set executor.runtime.tls.domainName=underpass-runtime \
+  --set executor.runtime.tls.existingSecret=runtime-server-ca \
+  --wait --timeout 10m --atomic
+```
+
+The chart mounts that secret at `/etc/choreographer/runtime-tls` and
+sets `CHOREO_RUNTIME_TLS_CA_PATH=/etc/choreographer/runtime-tls/ca.crt`.
+
+### Runtime with mutual TLS
+
+When Runtime requires client authentication, the secret must contain
+`ca.crt`, `tls.crt`, and `tls.key`. Cert-manager users can apply
+[`tests/cluster/choreographer-runtime-client-cert.yaml`](../../tests/cluster/choreographer-runtime-client-cert.yaml)
+as an example of the expected secret shape.
+
+```bash
+helm -n choreographer-system upgrade --install choreographer \
+  charts/choreographer \
+  --create-namespace \
+  -f charts/choreographer/values.embedded-nats.yaml \
+  --set image.digest=sha256:REPLACE_ME \
+  --set executor.kind=runtime \
+  --set executor.runtime.endpoint=https://underpass-runtime:50053 \
+  --set executor.runtime.principal.tenantId=underpass \
+  --set executor.runtime.principal.actorId=choreographer \
+  --set executor.runtime.principal.roles=orchestrator \
+  --set executor.runtime.tls.mode=mutual \
+  --set executor.runtime.tls.domainName=underpass-runtime \
+  --set executor.runtime.tls.existingSecret=choreographer-runtime-client-tls \
+  --wait --timeout 10m --atomic
+```
+
+The chart refuses to render any non-disabled Runtime TLS mode without
+`executor.runtime.tls.existingSecret`.
+
+### Runtime smoke
+
+Basic readiness only proves that Choreographer booted. To prove the
+Runtime executor path, run an `Orchestrate` request whose task carries
+a Runtime tool name accepted by the target Runtime:
+
+```text
+task.attributes["runtime.tool_name"] = "YOUR_RUNTIME_TOOL"
+```
+
+In this repository, `make e2e-compose` proves that path against the
+`stub-runtime` service with `runtime.tool_name=stub.echo`. In
+Kubernetes, run the `runtime-stub` E2E scenario only when the namespace
+provides that fixture or an equivalent tool contract:
+
+```bash
+sed 's/value: cluster-connectivity/value: runtime-stub/' \
+  tests/e2e/kubernetes/runner-job.yaml \
+  | kubectl -n choreographer-system apply -f -
+kubectl -n choreographer-system logs -f job/choreographer-e2e-runner
+```
+
+For a real Runtime deployment, replace the fixture tool name with a
+tool that exists in the Runtime catalog and validate the returned
+`execution_id` against Runtime logs or audit records.
+
+## Underpass Runtime profile
 
 The profile reflects the agreed Underpass topology: every plane
 (KMP, Runtime, Choreographer) owns its **own NATS bus** — the planes
@@ -12,7 +749,7 @@ collocating buses would couple deploys without sharing data. The
 choreographer's chart therefore deploys a release-local NATS via
 `messaging.nats.embedded.enabled: true`.
 
-## Prerequisites
+### Prerequisites
 
 1. **Image pull secret.** A namespace secret `ghcr-pull`
    (`kubernetes.io/dockerconfigjson`) with credentials that can pull
@@ -27,12 +764,12 @@ choreographer's chart therefore deploys a release-local NATS via
    the namespace and the chart values (or the override) must point at
    it (`executor.runtime.endpoint: https://underpass-runtime:50053`).
 
-## Deploy
+### Deploy
 
 ```bash
 NAMESPACE=underpass-runtime \
 RELEASE_NAME=choreographer \
-IMAGE_TAG=sha-<commit> \
+IMAGE_TAG=sha-COMMIT \
 VALUES_FILE=charts/choreographer/values.underpass-runtime.yaml \
 ./scripts/ci/deploy-kubernetes.sh
 ```
@@ -44,7 +781,7 @@ The wrapper:
   back to `--dry-run=server`.
 - Always passes `--create-namespace`.
 
-## Smoke
+### Smoke
 
 ```bash
 # Liveness + readiness via the HTTP sidecar port (NATS readiness
@@ -56,37 +793,339 @@ curl -s localhost:8080/readyz   # {"checks":[{"name":"nats","healthy":true,...}]
 
 ## End-to-end against the deploy
 
-`tests/cluster/e2e-job.yaml` runs the `choreo-e2e-runner` binary as
-a Job. The current runner is the same nine-scenario binary used by
-compose. Scenarios 1–4 cover gRPC + NATS + causal metadata against a
-real deploy and pass when the choreographer is wired correctly.
+`tests/e2e/kubernetes/runner-job.yaml` runs the `choreo-e2e-runner`
+binary as a Job. The manifest sets
+`CHOREO_E2E_SCENARIOS=cluster-connectivity`, so the default cluster
+smoke runs only scenarios 1-4 against the real deploy:
 
-Scenarios 5-9 are compose-shaped: scenario 5 expects a Runtime tool
-named `stub.echo`, scenarios 8-9 expect the `stub-llm` OpenAI-
-compatible sidecar, and scenario 6 asserts strict rejection of the
-NoopAgent's free-form output. Against the real `underpass-runtime`,
-the `stub.echo` tool is not normally in the catalog, so the runner can
-exit with `NotFound: runtime resource` from scenario 5. That proves
-the Runtime gRPC path was reached, but it is not a green full-stack
-acceptance signal. Treat the cluster Job as a targeted connectivity
-smoke unless the namespace also provides the same stub services or
-equivalent test fixtures.
+- `ListCouncils` sees the seeded `triage` council.
+- `Deliberate` returns a winner.
+- `DeleteCouncil` on a missing specialty returns `deleted=false`.
+- NATS trigger -> outbound `DeliberationCompleted` preserves
+  `correlation_id` and `causation_id`.
+
+Scenarios 5-9 are fixture-shaped and stay opt-in for Kubernetes:
+scenario 5 expects a Runtime tool named `stub.echo`, scenarios 8-9
+expect the `stub-llm` OpenAI-compatible sidecar, and scenario 6
+asserts strict rejection of the NoopAgent's free-form output. Run
+`runtime-stub`, `structured-output`, or `compose` only when the
+namespace provides equivalent fixtures or real matching services.
 
 ```bash
-kubectl apply -f tests/cluster/e2e-job.yaml
-kubectl -n "$NAMESPACE" logs -f -l app.kubernetes.io/component=e2e
+kubectl -n "$NAMESPACE" apply -f tests/e2e/kubernetes/runner-job.yaml
+kubectl -n "$NAMESPACE" logs -f job/choreographer-e2e-runner
 ```
+
+## Operator deploy verification
+
+This is the release-candidate verification path for the product claim:
+an operator can deploy a pinned image, use the versioned chart, wire
+Secrets by reference, and run a post-deploy smoke.
+
+### Current checkout verification
+
+This checkout has no public `v*` tag yet, so a published OCI chart
+cannot honestly be verified from the repository state alone. The local
+chart/package and rendered Secret references are verifiable now.
+
+Commands run against this checkout on 2026-05-18:
+
+```bash
+mkdir -p /tmp/choreographer-operator-verify
+
+helm template choreographer charts/choreographer \
+  -f charts/choreographer/values.postgres-secret.yaml \
+  -f charts/choreographer/values.provider-env-secrets.yaml \
+  --set image.digest=sha256:1111111111111111111111111111111111111111111111111111111111111111 \
+  > /tmp/choreographer-operator-verify/pinned-secretrefs.yaml
+
+helm template choreographer charts/choreographer \
+  -f charts/choreographer/values.postgres-secret.yaml \
+  -f charts/choreographer/values.provider-env-secrets.yaml \
+  --set image.digest=sha256:1111111111111111111111111111111111111111111111111111111111111111 \
+  --set tls.mode=mutual \
+  --set tls.existingSecret=choreographer-grpc-mtls \
+  > /tmp/choreographer-operator-verify/pinned-secretrefs-mtls.yaml
+
+helm package charts/choreographer \
+  --destination /tmp/choreographer-operator-verify
+```
+
+Expected rendered markers:
+
+- image reference uses
+  `ghcr.io/underpass-ai/underpass-choreographer@sha256:...`;
+- `CHOREO_POSTGRES_URL` is sourced from
+  `secretKeyRef.name=choreographer-postgres-dsn`;
+- provider env is sourced from
+  `envFrom.secretRef.name=choreographer-provider-env`;
+- mTLS render mounts `secretName: "choreographer-grpc-mtls"` and sets
+  `CHOREO_GRPC_TLS_MODE=mutual`;
+- `helm package` produces `choreographer-0.1.0.tgz` from the current
+  chart metadata.
+
+### Post-release OCI verification
+
+After `docs/release.md` has cut a `vX.Y.Z` tag and
+`publish-distribution.yml` has pushed the chart, verify the exact OCI
+chart version before installing:
+
+```bash
+export NAMESPACE=choreographer-system
+export RELEASE_NAME=choreographer
+export CHART_VERSION=0.2.0
+export IMAGE_DIGEST=sha256:REPLACE_ME
+
+helm show chart \
+  oci://ghcr.io/underpass-ai/charts/choreographer \
+  --version "$CHART_VERSION"
+
+helm template "$RELEASE_NAME" \
+  oci://ghcr.io/underpass-ai/charts/choreographer \
+  --version "$CHART_VERSION" \
+  -f charts/choreographer/values.postgres-secret.yaml \
+  -f charts/choreographer/values.provider-env-secrets.yaml \
+  --set image.digest="$IMAGE_DIGEST" \
+  > /tmp/choreographer-oci-render.yaml
+```
+
+Confirm required Secrets exist before install:
+
+```bash
+kubectl -n "$NAMESPACE" get secret choreographer-postgres-dsn
+kubectl -n "$NAMESPACE" get secret choreographer-provider-env
+```
+
+Install or upgrade from the OCI chart:
+
+```bash
+helm -n "$NAMESPACE" upgrade --install "$RELEASE_NAME" \
+  oci://ghcr.io/underpass-ai/charts/choreographer \
+  --version "$CHART_VERSION" \
+  --create-namespace \
+  -f charts/choreographer/values.postgres-secret.yaml \
+  -f charts/choreographer/values.provider-env-secrets.yaml \
+  --set image.digest="$IMAGE_DIGEST" \
+  --wait --timeout 10m --atomic
+```
+
+Post-deploy smoke:
+
+```bash
+kubectl -n "$NAMESPACE" rollout status deploy/choreographer
+
+kubectl -n "$NAMESPACE" get deploy choreographer \
+  -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+
+kubectl -n "$NAMESPACE" port-forward svc/choreographer 8080:8080 &
+curl -fsS localhost:8080/healthz
+curl -fsS localhost:8080/readyz
+
+kubectl -n "$NAMESPACE" port-forward svc/choreographer 50055:50055 &
+kubectl -n "$NAMESPACE" port-forward svc/choreographer-nats 4222:4222 &
+
+cargo run -p choreo-consumer-smoke --locked -- \
+  --endpoint http://127.0.0.1:50055 \
+  --nats-url nats://127.0.0.1:4222 \
+  --chain all
+```
+
+## Upgrading
+
+Use upgrades for a new pinned image digest, chart version, values
+profile, or Secret wiring change. Keep `--atomic` on so a failed
+upgrade returns the release to the previous revision automatically.
+
+Concrete example: upgrade release `choreographer` in namespace
+`choreographer-system` to a new image digest with the embedded NATS
+profile.
+
+1. Set the target inputs:
+
+   ```bash
+   export NAMESPACE=choreographer-system
+   export RELEASE_NAME=choreographer
+   export VALUES_FILE=charts/choreographer/values.embedded-nats.yaml
+   export IMAGE_DIGEST=sha256:REPLACE_ME
+   ```
+
+2. Render before touching the cluster:
+
+   ```bash
+   helm template "$RELEASE_NAME" charts/choreographer \
+     -f "$VALUES_FILE" \
+     --set image.digest="$IMAGE_DIGEST" \
+     > /tmp/choreographer-upgrade.yaml
+   ```
+
+3. Upgrade from the checkout:
+
+   ```bash
+   ./scripts/ci/deploy-kubernetes.sh
+   ```
+
+   Equivalent direct Helm command:
+
+   ```bash
+   helm -n "$NAMESPACE" upgrade --install "$RELEASE_NAME" \
+     charts/choreographer \
+     --create-namespace \
+     -f "$VALUES_FILE" \
+     --set image.digest="$IMAGE_DIGEST" \
+     --wait --timeout 10m --atomic
+   ```
+
+4. Upgrade from a published OCI chart after a release:
+
+   ```bash
+   export CHART_VERSION=0.2.0
+
+   helm -n "$NAMESPACE" upgrade --install "$RELEASE_NAME" \
+     oci://ghcr.io/underpass-ai/charts/choreographer \
+     --version "$CHART_VERSION" \
+     --create-namespace \
+     -f "$VALUES_FILE" \
+     --set image.digest="$IMAGE_DIGEST" \
+     --wait --timeout 10m --atomic
+   ```
+
+   Use the exact chart version published by the release workflow. Do
+   not use an unversioned chart reference.
+
+5. Verify rollout and pinned image:
+
+   ```bash
+   helm -n "$NAMESPACE" status "$RELEASE_NAME"
+   kubectl -n "$NAMESPACE" rollout status deploy/choreographer
+
+   kubectl -n "$NAMESPACE" get deploy choreographer \
+     -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+   ```
+
+6. Run post-upgrade smoke:
+
+   ```bash
+   kubectl -n "$NAMESPACE" port-forward svc/choreographer 8080:8080 &
+   curl -fsS localhost:8080/healthz
+   curl -fsS localhost:8080/readyz
+
+   kubectl -n "$NAMESPACE" port-forward svc/choreographer 50055:50055 &
+   kubectl -n "$NAMESPACE" port-forward svc/choreographer-nats 4222:4222 &
+
+   cargo run -p choreo-consumer-smoke --locked -- \
+     --endpoint http://127.0.0.1:50055 \
+     --nats-url nats://127.0.0.1:4222 \
+     --chain all
+   ```
+
+7. Record the new revision:
+
+   ```bash
+   helm -n "$NAMESPACE" history "$RELEASE_NAME"
+   ```
+
+Upgrade notes:
+
+- If the upgrade changes Postgres, provider, pull, or TLS secrets,
+  create or rotate those Secrets before running Helm:
+
+  ```bash
+  kubectl -n "$NAMESPACE" get secret choreographer-postgres-dsn
+  kubectl -n "$NAMESPACE" get secret choreographer-provider-env
+  kubectl -n "$NAMESPACE" get secret choreographer-grpc-mtls
+  ```
+
+- If the upgrade changes database schema, take a Postgres backup first
+  and review rollback compatibility.
+- If the upgrade changes `tls.mode`, update MCP, consumer, and grpcurl
+  clients to the matching TLS posture before switching traffic.
+- If the upgrade changes `executor.kind=runtime`, confirm Runtime
+  endpoint, Runtime TLS Secret, and Runtime tool catalog first.
 
 ## Rolling back
 
-Helm-managed:
+Use Helm rollback when a previously successful release must be restored
+after a bad image, chart value, or config rollout. Failed upgrades run
+through this guide use `--atomic`, so Helm already rolls back before
+returning non-zero; this section is for manual rollback after a release
+was accepted.
 
-```bash
-helm -n "$NAMESPACE" rollback choreographer <revision>
-```
+Concrete example: release `choreographer` in namespace
+`choreographer-system`, current revision `7`, previous good revision
+`6`.
 
-The script's `--atomic` ensures a failed `helm upgrade` already
-rolls back the release before it returns non-zero.
+1. Inspect release history:
+
+   ```bash
+   helm -n choreographer-system history choreographer
+   ```
+
+   Example shape:
+
+   ```text
+   REVISION  UPDATED                  STATUS      CHART                APP VERSION  DESCRIPTION
+   5         2026-05-18 09:10:42      superseded  choreographer-0.1.0  0.1.0        Upgrade complete
+   6         2026-05-18 10:42:18      superseded  choreographer-0.1.0  0.1.0        Upgrade complete
+   7         2026-05-18 11:03:57      deployed    choreographer-0.1.0  0.1.0        Upgrade complete
+   ```
+
+2. Roll back to the known-good revision:
+
+   ```bash
+   helm -n choreographer-system rollback choreographer 6 \
+     --wait --timeout 10m
+   ```
+
+3. Confirm rollout and restored image reference:
+
+   ```bash
+   kubectl -n choreographer-system rollout status deploy/choreographer
+
+   kubectl -n choreographer-system get deploy choreographer \
+     -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+   ```
+
+4. Run health and gRPC smoke:
+
+   ```bash
+   kubectl -n choreographer-system port-forward svc/choreographer 8080:8080 &
+   curl -fsS localhost:8080/healthz
+   curl -fsS localhost:8080/readyz
+
+   kubectl -n choreographer-system port-forward svc/choreographer 50055:50055 &
+   cargo run -p choreo-consumer-smoke --locked -- \
+     --endpoint http://127.0.0.1:50055 \
+     --chain all
+   ```
+
+   If NATS is intentionally disabled, consumer smoke reports bus checks
+   as skipped. For embedded or external NATS, add:
+
+   ```bash
+   kubectl -n choreographer-system port-forward svc/choreographer-nats 4222:4222 &
+   cargo run -p choreo-consumer-smoke --locked -- \
+     --endpoint http://127.0.0.1:50055 \
+     --nats-url nats://127.0.0.1:4222 \
+     --chain all
+   ```
+
+5. Record the new deployed revision:
+
+   ```bash
+   helm -n choreographer-system status choreographer
+   helm -n choreographer-system history choreographer
+   ```
+
+Notes:
+
+- Helm rollback restores the rendered Kubernetes objects owned by the
+  release, including the previous image tag or digest.
+- Helm does not restore external Secrets, external Postgres state,
+  external NATS state, or provider-side configuration. Restore or rotate
+  those separately if the failed release changed them.
+- Startup migrations run on boot. Before rolling back across a version
+  that changed database schema, verify the migration is backward
+  compatible or restore from a database backup.
 
 ## Topology recap
 

--- a/docs/operations/mcp-stdio.md
+++ b/docs/operations/mcp-stdio.md
@@ -13,6 +13,336 @@ Companion docs:
 - [Codex CLI configuration](./mcp/codex.md)
 - [Claude Desktop configuration](./mcp/claude-desktop.md)
 
+## Quickstart — fixture mode
+
+After installing `choreo-mcp`, the fastest client-wiring check needs
+no running Choreographer and no gRPC endpoint:
+
+```bash
+CHOREO_MCP_BACKEND=fixture choreo-mcp
+```
+
+That starts the stdio MCP server and waits for JSON-RPC on stdin. For
+a terminal smoke that exits immediately:
+
+```bash
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
+  | CHOREO_MCP_BACKEND=fixture choreo-mcp
+```
+
+From a checkout, without installing the binary first:
+
+```bash
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
+  | CHOREO_MCP_BACKEND=fixture cargo run -q -p choreo-mcp --locked
+```
+
+Fixture mode returns deterministic canned responses for every tool. It
+is for MCP client setup, tool-choice validation, and demos; it is not a
+live Choreographer integration test.
+
+## Quickstart — live local gRPC
+
+To test the MCP adapter against a real local Choreographer, use two
+terminals.
+
+Terminal 1 starts Choreographer with no external services and seeds one
+demo council:
+
+```bash
+CHOREO_NATS_ENABLED=false CHOREO_SEED_SPECIALTIES=triage just run
+```
+
+If `just` is not installed, use the equivalent Cargo command:
+
+```bash
+CHOREO_NATS_ENABLED=false CHOREO_SEED_SPECIALTIES=triage \
+  cargo run --locked -p choreo
+```
+
+Terminal 2 starts the MCP stdio adapter against the local gRPC endpoint:
+
+```bash
+CHOREO_MCP_GRPC_ENDPOINT=http://127.0.0.1:50055 choreo-mcp
+```
+
+For a one-shot terminal smoke from a checkout:
+
+```bash
+CHOREO_MCP_GRPC_ENDPOINT=http://127.0.0.1:50055 \
+CHOREO_MCP_BIN=target/debug/choreo-mcp \
+  bash scripts/mcp/choreo-stdio-smoke.sh
+```
+
+The smoke calls `choreo_list_councils` and expects the seeded `triage`
+council. If `choreo-mcp` is already installed on PATH, omit
+`CHOREO_MCP_BIN`.
+
+## Tool Call Examples
+
+### CreateCouncil
+
+`choreo_create_council` creates a council for a specialty and asks the
+server to seat `num_agents` agents. In live mode those agents must
+already be resolvable. The gRPC handler mints ids in the form
+`agent-<specialty>-<index>`, so `{"specialty":"triage","num_agents":1}`
+expects `agent-triage-0` to exist.
+
+Fixture-mode terminal check:
+
+```bash
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"choreo_create_council","arguments":{"specialty":"triage","num_agents":1}}}' \
+  | CHOREO_MCP_BACKEND=fixture cargo run -q -p choreo-mcp --locked
+```
+
+Expected response shape:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "isError": false,
+    "structuredContent": {
+      "council": {
+        "specialty": "triage",
+        "num_agents": 1,
+        "agents": []
+      }
+    }
+  }
+}
+```
+
+The fixture response is deterministic and does not mutate state. For a
+live local call, first ensure the matching agent exists through seeding
+or `choreo_register_agent`, then set
+`CHOREO_MCP_GRPC_ENDPOINT=http://127.0.0.1:50055` instead of
+`CHOREO_MCP_BACKEND=fixture`.
+
+### RegisterAgent
+
+`choreo_register_agent` registers an agent descriptor so later calls can
+resolve that agent by id. It does not attach the agent to a council by
+itself; `CreateCouncil` still controls council membership.
+
+Fixture-mode terminal check:
+
+```bash
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"choreo_register_agent","arguments":{"specialty":"review","agent":{"agent_id":"agent-review-0","specialty":"review","kind":"noop"},"agent_config":{"label":"local noop reviewer"}}}}' \
+  | CHOREO_MCP_BACKEND=fixture cargo run -q -p choreo-mcp --locked
+```
+
+Expected response shape:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "isError": false,
+    "structuredContent": {
+      "agent_id": "agent-fixture-1"
+    }
+  }
+}
+```
+
+For a live local call, use `kind: "noop"` when you want a provider-free
+agent. Provider-backed kinds such as `openai` or `vllm` require the
+corresponding adapter and environment to be configured. Per-agent
+factory options belong in top-level `agent_config`; the nested `agent`
+object is only the public summary (`agent_id`, `specialty`, `kind`,
+optional `attributes`). If the next step is `CreateCouncil`, keep the id
+pattern `agent-<specialty>-<index>`; for the example above that means
+creating a `review` council with `num_agents: 1`.
+
+### RegisterContract
+
+`choreo_register_contract` stores an `OutputContract` in the contract
+registry. Later `RunCouncilDecision` calls reference it by
+`contract_id` and validate the council winner against its field rules
+and optional embedded JSON Schema.
+
+Fixture-mode terminal check:
+
+```bash
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"choreo_register_contract","arguments":{"contract":{"contract_id":"contract-review-v1","format":"json_object","fields":{"status":{"required":true,"allowed_string_values":["accepted","needs_changes"]},"summary":{"required":true},"rationale":{"required":false}}}}}}' \
+  | CHOREO_MCP_BACKEND=fixture cargo run -q -p choreo-mcp --locked
+```
+
+Expected response shape:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "isError": false,
+    "structuredContent": {
+      "contract_id": "contract-fixture-1"
+    }
+  }
+}
+```
+
+For a live local call, keep the returned or requested `contract_id` and
+pass it to `choreo_run_council_decision`. `format` is currently
+`json_object`. Field rules can require named fields and constrain string
+values; for stricter validation, include a `json_schema` string. The
+canonical Report-shape example lives at
+[`api/examples/output-contracts/report.schema.json`](../../api/examples/output-contracts/report.schema.json).
+
+### RunCouncilDecision
+
+`choreo_run_council_decision` runs a council and validates the winning
+proposal against a previously registered contract. The call must include
+`contract_id`, `description`, and exactly one selector:
+`specialty` or `council_id`.
+
+Fixture-mode terminal check:
+
+```bash
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"choreo_run_council_decision","arguments":{"specialty":"review","contract_id":"contract-review-v1","description":"Review the candidate change and return status, summary, and rationale.","validation_mode":"VALIDATION_MODE_STRICT"}}}' \
+  | CHOREO_MCP_BACKEND=fixture cargo run -q -p choreo-mcp --locked
+```
+
+Expected response shape:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "isError": false,
+    "structuredContent": {
+      "task_id": "task-fixture-1",
+      "winner": {
+        "rank": 0,
+        "proposal": {
+          "proposal_id": "proposal-fixture-a",
+          "author_agent_id": "agent-fixture-1",
+          "content": "fixture answer",
+          "metadata": {},
+          "revision_count": 0
+        },
+        "validation": {
+          "score": 1.0,
+          "reports": [
+            {
+              "kind": "content-non-empty",
+              "passed": true,
+              "summary": "ok",
+              "details": {}
+            }
+          ]
+        }
+      },
+      "validation": {
+        "passed": true,
+        "candidates_passed": 1,
+        "candidates_total": 1
+      },
+      "candidates": [
+        {
+          "proposal_id": "proposal-fixture-a",
+          "author_agent_id": "agent-fixture-1",
+          "score": 1.0,
+          "reports": [
+            {
+              "kind": "content-non-empty",
+              "passed": true,
+              "summary": "ok",
+              "details": {}
+            }
+          ],
+          "rank": 0,
+          "passed": true,
+          "revision_count": 0
+        }
+      ],
+      "duration_ms": 42,
+      "validation_mode": "VALIDATION_MODE_STRICT"
+    }
+  }
+}
+```
+
+For a live local call, the selected council must exist and the
+`contract_id` must already be registered. `VALIDATION_MODE_STRICT`
+fails the call when no candidate satisfies the contract; use
+`VALIDATION_MODE_WARN` when the caller wants the best-ranked candidate
+returned even if validation fails.
+
+### Orchestrate
+
+`choreo_orchestrate` runs the full path: deliberate on the task's
+specialty, pick the winning proposal, and pass that winner to the
+configured `ExecutorPort`. The call takes a `task` object and optional
+opaque `execution_options`.
+
+Fixture-mode terminal check:
+
+```bash
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"choreo_orchestrate","arguments":{"task":{"task_id":"task-review-orchestrate-1","description":"Review the candidate change and execute the accepted plan.","specialty":"review","constraints":{"rounds":1,"num_agents":1}},"execution_options":{"executor":"noop","trace_label":"mcp-orchestrate-demo"}}}}' \
+  | CHOREO_MCP_BACKEND=fixture cargo run -q -p choreo-mcp --locked
+```
+
+Expected response shape:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "isError": false,
+    "structuredContent": {
+      "task_id": "task-fixture-1",
+      "execution_id": "exec-fixture-1",
+      "duration_ms": 73,
+      "winner": {
+        "rank": 0,
+        "proposal": {
+          "proposal_id": "proposal-fixture-a",
+          "author_agent_id": "agent-fixture-1",
+          "content": "fixture answer",
+          "metadata": {},
+          "revision_count": 0
+        },
+        "validation": {
+          "score": 1.0,
+          "reports": [
+            {
+              "kind": "content-non-empty",
+              "passed": true,
+              "summary": "ok",
+              "details": {}
+            }
+          ]
+        }
+      },
+      "candidates": [],
+      "metadata": {
+        "fixture": true
+      }
+    }
+  }
+}
+```
+
+For a live local call, `task.specialty` must point to an existing
+council. The default local executor is `noop`; set the Runtime executor
+environment only when you want the winner sent to an external Runtime
+service. `execution_options` is forwarded to the configured executor and
+takes precedence over overlapping execution-profile metadata.
+
 ## Tools
 
 The 16 MCP tools are 1:1 with the choreographer's gRPC service:
@@ -26,15 +356,15 @@ The 16 MCP tools are 1:1 with the choreographer's gRPC service:
 | `choreo_create_council`           | `CreateCouncil`                       | Create / replace a council for a specialty. |
 | `choreo_list_councils`            | `ListCouncils`                        | Enumerate registered councils. |
 | `choreo_delete_council`           | `DeleteCouncil`                       | Idempotent delete. |
-| `choreo_register_agent`           | `RegisterAgent`                       | Add an agent to a council (`noop` / `anthropic` / `openai` / `vllm`). |
+| `choreo_register_agent`           | `RegisterAgent`                       | Register an agent descriptor (`noop` / `anthropic` / `openai` / `vllm`). |
 | `choreo_unregister_agent`         | `UnregisterAgent`                     | Remove an agent. |
 | `choreo_process_trigger_event`    | `ProcessTriggerEvent`                 | Submit a domain event; fans out to deliberations. |
-| `choreo_get_status`               | `GetStatus`                           | Service health, version, uptime, optional stats. |
-| `choreo_get_metrics`              | `GetMetrics`                          | Statistics snapshot. |
 | `choreo_run_council_decision`     | `RunCouncilDecision`                  | Run a council against a registered output contract; returns the validated winner plus per-candidate breakdown. |
 | `choreo_register_contract`        | `RegisterContract`                    | Register an `OutputContract` in the contract registry. |
 | `choreo_list_contracts`           | `ListContracts`                       | Enumerate registered contracts. |
 | `choreo_delete_contract`          | `DeleteContract`                      | Idempotent contract delete. |
+| `choreo_get_status`               | `GetStatus`                           | Service health, version, uptime, optional stats. |
+| `choreo_get_metrics`              | `GetMetrics`                          | Statistics snapshot. |
 
 The choreographer API is **respected at 100%** — every proto field has
 an explicit JSON key in both the tool input schema and the response.
@@ -57,19 +387,26 @@ CHOREO_MCP_BACKEND=fixture cargo run -p choreo-mcp --locked
 
 ## Installation
 
-For users outside the repo, install as a Cargo binary from Git:
+For users outside the repo, install as a Cargo binary from crates.io
+after the first release has published the package:
 
 ```bash
-cargo install --git https://github.com/underpass-ai/underpass-choreographer choreo-mcp --locked
+cargo install choreo-mcp --locked
 ```
 
-The repo helper wraps the same path and supports pinned refs:
+The repo helper uses the registry path by default:
 
 ```bash
 bash scripts/mcp/install-choreo-mcp.sh
+```
 
-CHOREO_MCP_TAG=v0.1.0 bash scripts/mcp/install-choreo-mcp.sh
-CHOREO_MCP_REV=<git-sha> bash scripts/mcp/install-choreo-mcp.sh
+For unreleased changes, switch the helper to Git mode and pin a ref:
+
+```bash
+CHOREO_MCP_INSTALL_MODE=git bash scripts/mcp/install-choreo-mcp.sh
+
+CHOREO_MCP_INSTALL_MODE=git CHOREO_MCP_TAG=v0.1.0 bash scripts/mcp/install-choreo-mcp.sh
+CHOREO_MCP_INSTALL_MODE=git CHOREO_MCP_REV=<git-sha> bash scripts/mcp/install-choreo-mcp.sh
 ```
 
 After install, the adapter is just `choreo-mcp` on PATH:
@@ -78,13 +415,12 @@ After install, the adapter is just `choreo-mcp` on PATH:
 CHOREO_MCP_GRPC_ENDPOINT=https://choreographer.example.com choreo-mcp
 ```
 
-### Distribution debt — crates.io
+### Distribution model
 
-The crate is **not** on crates.io. The generated gRPC client builds
-from the repository's checked-in proto tree, which `cargo install`
-needs at build time. Vendoring the proto tree into a dedicated crate
-is tracked as a follow-up in [`docs/backlog.md`](../backlog.md). The
-supported external path for this phase is `cargo install --git`.
+`choreo-mcp` depends on `choreo-mcp-proto`, a small vendored proto
+crate that carries only the public `underpass.choreo.v1` API needed by
+the MCP adapter. Release tags publish `choreo-mcp-proto` first, wait
+for crates.io index propagation, and then publish `choreo-mcp`.
 
 ## Live gRPC mode
 

--- a/docs/operations/mcp/claude-desktop.md
+++ b/docs/operations/mcp/claude-desktop.md
@@ -15,6 +15,16 @@ env-var reference, and TLS posture options.
 
 ## Installed binary
 
+Install from crates.io:
+
+```bash
+cargo install choreo-mcp --locked
+```
+
+The dev fallback (in-tree source) lives at
+`CHOREO_MCP_INSTALL_MODE=git bash scripts/mcp/install-choreo-mcp.sh`
+in the repo.
+
 ```json
 {
   "mcpServers": {

--- a/docs/operations/mcp/codex.md
+++ b/docs/operations/mcp/codex.md
@@ -3,13 +3,23 @@
 Codex CLI reads MCP servers from its TOML config (usually
 `~/.codex/config.toml` or `~/.config/codex/config.toml`). The
 `choreo-mcp` adapter is added once; every Codex session can then call
-the 12 `choreo_*` tools.
+the 16 `choreo_*` tools.
 
 See the canonical UX reference at
 [`docs/operations/mcp-stdio.md`](../mcp-stdio.md) for the tool list,
 env-var reference, and TLS posture options.
 
 ## Quick add (installed binary)
+
+Install from crates.io:
+
+```bash
+cargo install choreo-mcp --locked
+```
+
+The dev fallback (in-tree source) lives at
+`CHOREO_MCP_INSTALL_MODE=git bash scripts/mcp/install-choreo-mcp.sh`
+in the repo.
 
 ```bash
 codex mcp add underpass-choreographer \
@@ -62,7 +72,7 @@ command = "choreo-mcp"
 CHOREO_MCP_BACKEND = "fixture"
 ```
 
-The 12 `choreo_*` tools become callable; every call returns the
+The 16 `choreo_*` tools become callable; every call returns the
 deterministic canned response (no network).
 
 ## mTLS to a hardened deployment

--- a/docs/operations/support-matrix.md
+++ b/docs/operations/support-matrix.md
@@ -1,0 +1,271 @@
+# Support Matrix
+
+This page records what the repository actually supports today. A
+support claim belongs here only when the source of truth and the
+enforcement gate are both named.
+
+Choreographer remains independently usable. KMP, PIR, Runtime, provider
+endpoints, and downstream products may be useful integration cases, but
+they do not define this repository's support matrix unless this chart,
+binary, or API requires them.
+
+## Rust Toolchain
+
+Current support is exact-version support, not a broad Rust range.
+
+| Surface | Supported | Source of truth | Enforcement |
+|---|---:|---|---|
+| Workspace MSRV | `1.90` | `Cargo.toml` `[workspace.package].rust-version` | Cargo package metadata |
+| Local toolchain | `1.90.0` | `rust-toolchain.toml` | `cargo`, `clippy`, `rustfmt` use the pinned toolchain |
+| PR CI toolchain | `1.90.0` | `.github/workflows/quality-gate.yml` | `rustfmt`, `clippy`, tests, benches compile |
+| Container-backed CI toolchain | `1.90.0` | `.github/workflows/integration.yml` | NATS and Postgres integration workflows |
+| Developer setup | `1.90.0` | `docs/dev-loop.md` | Manual local setup and `just` recipes |
+| Dependency resolution | `Cargo.lock` committed | `Cargo.lock` | CI and local gates use `--locked` |
+
+### Supported
+
+- Rust `1.90.0` with the components in `rust-toolchain.toml`:
+  `clippy` and `rustfmt`.
+- The locked dependency graph in `Cargo.lock`.
+- The provider-feature matrix used by CI:
+  `choreo-adapters/agent-anthropic`,
+  `choreo-adapters/agent-openai`, and
+  `choreo-adapters/agent-vllm`.
+
+### Not Supported
+
+- Older Rust versions.
+- Nightly-only compiler features.
+- "Latest stable" as a moving target.
+- Builds that require dependency resolution different from the
+  committed `Cargo.lock`.
+
+### Change Rule
+
+Changing the supported Rust version requires one PR that updates all of
+these together:
+
+- `Cargo.toml`;
+- `rust-toolchain.toml`;
+- `.github/workflows/quality-gate.yml`;
+- `.github/workflows/integration.yml`;
+- `docs/dev-loop.md`;
+- this support matrix;
+- `CHANGELOG.md`.
+
+That PR must run:
+
+```bash
+just check
+just helm-lint
+just integration
+```
+
+Release-candidate work should also run:
+
+```bash
+make e2e-compose
+make e2e-kubernetes
+```
+
+Do not merge a Rust version bump based only on local `cargo check`.
+
+## Container Image Tags
+
+Published image repositories:
+
+| Image | Purpose | Build source | Publish path |
+|---|---|---|---|
+| `ghcr.io/underpass-ai/underpass-choreographer` | Product runtime image | `Dockerfile` | `.github/workflows/publish-distribution.yml` |
+| `ghcr.io/underpass-ai/underpass-choreographer-e2e-runner` | Release/E2E runner image | `tests/e2e/runner.Dockerfile` | `.github/workflows/publish-distribution.yml` |
+
+The provider-E2E image built by `scripts/ci/build-provider-image.sh`
+is operator-pushed test tooling. It is not a supported production
+runtime image.
+
+| Reference form | Produced by | Support status | Production use |
+|---|---|---|---|
+| `image@sha256:<digest>` | Registry content digest | Supported and preferred | Yes. Use for normal Helm installs. |
+| `image:vX.Y.Z` | `v*` tag publish workflow | Supported release label after the tag exists | Acceptable when release immutability is controlled; digest is still preferred. |
+| `image:sha-<short>` | publish workflow commit tag | Supported for CI, release-candidate smoke, and cluster verification | Use only when the rollout records the source commit; digest is preferred. |
+| `image:main` | default-branch publish workflow | Moving branch pointer | No. Development or smoke only. |
+| `image:latest` | default-branch publish workflow | Moving branch pointer | No. The chart rejects it unless `development.allowMutableImageTags=true`. |
+| `image:e2e-latest` | E2E runner publish workflow | Moving E2E runner pointer | No. Test runner only. |
+| `image:dev`, `image:ci`, `image:e2e` | local scripts and test manifests | Local-only | No. Local compose/kind/k3d only. |
+
+### Helm Image Rules
+
+- `image.digest` wins over `image.tag`.
+- Either `image.digest` or `image.tag` must be set; the chart has no
+  production default image reference.
+- `image.tag=latest` fails chart rendering unless
+  `development.allowMutableImageTags=true`.
+- `docs/operations/deploy-kubernetes.md` uses digests for normal
+  installs and local tags only with an explicit development escape
+  hatch.
+- `scripts/ci/helm-lint.sh` asserts the missing-image and mutable-tag
+  failure paths.
+
+### Change Rule
+
+Changing image tag support requires updating:
+
+- `.github/workflows/publish-distribution.yml`;
+- `scripts/ci/container-image.sh`, if local build semantics change;
+- `charts/choreographer/templates/_helpers.tpl`, if chart acceptance
+  changes;
+- `scripts/ci/helm-lint.sh`;
+- `docs/operations/deploy-kubernetes.md`;
+- this support matrix;
+- `CHANGELOG.md`.
+
+## Helm Chart Versions
+
+Chart source and release registry:
+
+| Surface | Current value | Source of truth | Enforcement |
+|---|---:|---|---|
+| Chart path | `charts/choreographer` | repository layout | `scripts/ci/helm-lint.sh` |
+| Chart name | `choreographer` | `charts/choreographer/Chart.yaml` | `helm lint` |
+| Chart version | `0.1.0` | `charts/choreographer/Chart.yaml` `version` | `scripts/release.sh release` |
+| App version | `0.1.0` | `charts/choreographer/Chart.yaml` `appVersion` | `scripts/release.sh release` |
+| Kubernetes version floor | `>=1.28.0-0` | `charts/choreographer/Chart.yaml` `kubeVersion` | Helm client compatibility check |
+| OCI registry | `oci://ghcr.io/underpass-ai/charts/choreographer` | `.github/workflows/publish-distribution.yml` | `helm package` + `helm push` |
+
+| Chart reference | Support status | Notes |
+|---|---|---|
+| Checkout chart at `charts/choreographer` | Supported for development, PR review, and release-candidate validation | Must pass `bash scripts/ci/helm-lint.sh`. |
+| `oci://ghcr.io/underpass-ai/charts/choreographer:0.1.0` | Pending | `0.1.0` is present in metadata but no public `v0.1.0` tag exists in this checkout yet. |
+| `oci://ghcr.io/underpass-ai/charts/choreographer:X.Y.Z` | Supported after the matching `vX.Y.Z` release tag publishes successfully | Chart `version`, `appVersion`, and workspace version must match. |
+| Older chart versions | Not currently supported | No stable-release support window has been declared yet. |
+| Unversioned or moving chart references | Not supported | Use an explicit chart version. |
+
+### Version Lockstep
+
+The release helper keeps these values in lockstep:
+
+- `Cargo.toml` `[workspace.package].version`;
+- `charts/choreographer/Chart.yaml` `version`;
+- `charts/choreographer/Chart.yaml` `appVersion`;
+- Git tag `vX.Y.Z`;
+- published product image tag `vX.Y.Z`;
+- published E2E runner image tag `vX.Y.Z`;
+- OCI chart version `X.Y.Z`.
+
+Do not publish or document a chart version whose `appVersion` does not
+match the binary/image version it is meant to deploy.
+
+### Change Rule
+
+Changing chart version support requires updating:
+
+- `charts/choreographer/Chart.yaml`;
+- `scripts/release.sh`;
+- `.github/workflows/publish-distribution.yml`;
+- `docs/release.md`;
+- `docs/operations/deploy-kubernetes.md`, if install commands change;
+- this support matrix;
+- `CHANGELOG.md`.
+
+## Provider Adapters
+
+Provider support has three separate gates:
+
+1. The binary must be compiled with the provider feature.
+2. Required `CHOREO_*` environment variables must be present at boot.
+3. The registered agent must use a kind listed in the startup
+   `agent_kinds=...` log field.
+
+Credentials must stay in environment or secret-managed files. Agent
+descriptors may be persisted and must not carry credentials.
+
+| Kind | Cargo feature | Default product image | Required env | Optional env | Repo validation | Support status |
+|---|---|---:|---|---|---|---|
+| `noop` | none | yes | none | none | unit tests, local smoke, minimal Helm smoke | Always supported. |
+| `openai` | `choreo-adapters/agent-openai` | yes | `CHOREO_OPENAI_API_KEY` | `CHOREO_OPENAI_MODEL`, `CHOREO_OPENAI_ENDPOINT`, `CHOREO_OPENAI_MAX_TOKENS` | CI compile/test, compose scenario with OpenAI-compatible stub, consumer positive-path | Supported adapter shape. Real provider credentials, quotas, endpoint policy, and model behavior are operator-owned. |
+| `vllm` | `choreo-adapters/agent-vllm` | yes | `CHOREO_VLLM_MODEL`, `CHOREO_VLLM_ENDPOINT` | `CHOREO_VLLM_BEARER_TOKEN`, `CHOREO_VLLM_MAX_TOKENS` | CI compile/test, compose scenario with OpenAI-compatible stub, provider-E2E runner for real vLLM | Supported adapter shape. Service factory Helm path supports endpoint/model/bearer; vLLM client cert envs are provider-E2E runner only today. |
+| `anthropic` | `choreo-adapters/agent-anthropic` | no | `CHOREO_ANTHROPIC_API_KEY` | `CHOREO_ANTHROPIC_MODEL`, `CHOREO_ANTHROPIC_ENDPOINT`, `CHOREO_ANTHROPIC_MAX_TOKENS` | CI compile/test | Implemented feature, not included in the default Dockerfile, and not covered by repo-owned E2E yet. Operators need a downstream image that enables the feature. |
+
+Per-agent descriptor attributes supported by provider adapters:
+
+| Attribute | Type | Meaning |
+|---|---|---|
+| `provider.model` | string | Override the env/default model for this agent. |
+| `provider.endpoint` | string | Override the env/default endpoint for this agent. |
+| `provider.max_tokens` | number, non-negative `u32` | Override token budget for this agent. |
+
+### Image Feature Matrix
+
+| Artifact | Provider features enabled |
+|---|---|
+| Default product `Dockerfile` | `agent-openai`, `agent-vllm` |
+| `just check` / `scripts/ci/quality-gate.sh` | `agent-anthropic`, `agent-openai`, `agent-vllm` |
+| Compose E2E stack | OpenAI-compatible and vLLM-compatible stub paths |
+| Provider-E2E runner image | real `agent-vllm` runner path |
+
+### Change Rule
+
+Changing provider support requires updating:
+
+- `crates/choreo-adapters/Cargo.toml`;
+- `crates/choreo-adapters/src/agents/factory.rs`;
+- `Dockerfile`, if the default product image feature set changes;
+- `justfile` and `scripts/ci/quality-gate.sh`, if CI feature coverage
+  changes;
+- `docs/operations/deploy-kubernetes.md`;
+- this support matrix;
+- `CHANGELOG.md`.
+
+If a provider is described as end-to-end supported, add or point to a
+repo-owned smoke path that proves the provider shape without leaking
+credentials.
+
+## Kubernetes Posture
+
+The Helm chart supports multiple deployment postures. "Supported" here
+means the chart renders the posture, the binary has the corresponding
+code path, and `scripts/ci/helm-lint.sh` or an operator smoke covers
+the shape.
+
+| Posture | Values / knobs | Status | Notes |
+|---|---|---|---|
+| Minimal standalone | `values.minimal.yaml` | Supported first-install smoke | No NATS, no Postgres, no Runtime, no provider credentials, no gRPC TLS. Not a hardened internet-facing posture. |
+| Standalone with embedded NATS | `values.embedded-nats.yaml` | Supported standalone event bus | Release-local core NATS, no JetStream storage by default, no external NATS operation required. |
+| Postgres persistence from Secret | `values.postgres-secret.yaml` | Supported for current persistent repositories | Persists deliberations, councils, agents, and statistics. Output contracts are still registered/seeded separately. |
+| Provider env secrets | `values.provider-env-secrets.yaml`, `providerEnv`, `providerEnvFrom` | Supported env wiring | Secret injection only. Provider features and required env still gate runtime availability. |
+| gRPC server TLS | `tls.mode=server` + `tls.existingSecret` | Supported | Secret must contain `tls.crt` and `tls.key`; health endpoints remain plaintext HTTP in-cluster. |
+| gRPC mutual TLS | `tls.mode=mutual` + `tls.existingSecret` | Supported | Secret must contain `tls.crt`, `tls.key`, and client CA `ca.crt`. |
+| Runtime executor | `executor.kind=runtime` + endpoint | Supported optional executor | Chart fails render without endpoint. Use only when Runtime is actually deployed. |
+| Runtime client TLS/mTLS | `executor.runtime.tls.*` | Supported | Chart fails render for non-disabled Runtime TLS without an existing Secret. |
+| NetworkPolicy | `networkPolicy.enabled=true` | Supported opt-in | Requires a NetworkPolicy-capable CNI and operator-owned ingress selectors / egress rules. |
+| PodDisruptionBudget | `pdb.enabled=true` | Supported opt-in | Meaningful for multi-replica deployments only. Default is single replica and PDB off. |
+| Non-root pod hardening | default `podSecurityContext`, `securityContext`, `automountServiceAccountToken=false` | Supported default | Chart lint asserts non-root, read-only root filesystem, dropped capabilities, seccomp, and no service-account token mount. |
+
+### Not Supported As Chart-Owned Posture Today
+
+- Public internet exposure directly from the Service without TLS/mTLS,
+  mesh, gateway, or equivalent controls.
+- Chart-managed Ingress. `values.yaml` has reserved ingress fields, but
+  no Ingress template is shipped yet.
+- Embedded NATS as a highly available durable event store. Current
+  Choreographer events are fire-and-forget and the embedded profile
+  disables JetStream by default.
+- Multi-replica production state without an explicit state plan.
+  Postgres covers current persistent repositories, but output-contract
+  registration is still process-local and should be registered/seeded
+  consistently after rollout.
+- Provider egress allow-lists generated automatically by the chart.
+  Add provider endpoint rules through `networkPolicy.egress.extra` or
+  route providers through an operator-managed egress proxy.
+
+### Change Rule
+
+Changing Kubernetes posture support requires updating:
+
+- `charts/choreographer/values.yaml`;
+- any checked-in profile under `charts/choreographer/values.*.yaml`;
+- relevant templates under `charts/choreographer/templates/`;
+- `scripts/ci/helm-lint.sh`;
+- `docs/operations/deploy-kubernetes.md`;
+- this support matrix;
+- `CHANGELOG.md`.

--- a/docs/product-publication-checklist.md
+++ b/docs/product-publication-checklist.md
@@ -33,106 +33,318 @@ Convención:
 
 ## Fase 1 - Camino Local Usable
 
-- [ ] Crear `docs/operations/compose-e2e.md`.
-- [ ] Documentar los 9 escenarios de `make e2e-compose`.
-- [ ] Documentar `stub-runtime`.
-- [ ] Documentar `stub-llm`.
-- [ ] Documentar el Report schema usado por los escenarios positivos.
-- [ ] Documentar los provider shapes OpenAI y vLLM usados en E2E.
-- [ ] Añadir quickstart sin servicios externos:
-  `CHOREO_NATS_ENABLED=false just run`.
-- [ ] Añadir quickstart de demo completa: `make e2e-compose`.
-- [ ] Añadir quickstart MCP fixture:
-  `CHOREO_MCP_BACKEND=fixture choreo-mcp`.
-- [ ] Añadir quickstart MCP live contra gRPC local.
-- [ ] Añadir ejemplo de `CreateCouncil`.
-- [ ] Añadir ejemplo de `RegisterAgent`.
-- [ ] Añadir ejemplo de `RegisterContract`.
-- [ ] Añadir ejemplo de `RunCouncilDecision`.
-- [ ] Añadir ejemplo de `Orchestrate`.
-- [ ] Verificar que un usuario nuevo puede obtener un resultado
-  validado sin leer código Rust.
+- [x] Crear `docs/operations/compose-e2e.md`. Referencia:
+  `docs/operations/compose-e2e.md`.
+- [x] Documentar los 9 escenarios de `make e2e-compose`. Referencia:
+  `docs/operations/compose-e2e.md`.
+- [x] Documentar `stub-runtime`. Referencia:
+  `docs/operations/compose-e2e.md`.
+- [x] Documentar `stub-llm`. Referencia:
+  `docs/operations/compose-e2e.md`.
+- [x] Documentar el Report schema usado por los escenarios positivos.
+  Referencia: `docs/operations/compose-e2e.md`.
+- [x] Documentar los provider shapes OpenAI y vLLM usados en E2E.
+  Referencia: `docs/operations/compose-e2e.md`.
+- [x] Añadir quickstart sin servicios externos:
+  `CHOREO_NATS_ENABLED=false just run`. Referencia: `README.md` y
+  `docs/dev-loop.md`.
+- [x] Añadir quickstart de demo completa: `make e2e-compose`.
+  Referencia: `docs/operations/compose-e2e.md`.
+- [x] Añadir quickstart MCP fixture:
+  `CHOREO_MCP_BACKEND=fixture choreo-mcp`. Referencia:
+  `docs/operations/mcp-stdio.md`, `README.md` y `docs/dev-loop.md`.
+- [x] Añadir quickstart MCP live contra gRPC local. Referencia:
+  `docs/operations/mcp-stdio.md`, `README.md` y `docs/dev-loop.md`.
+- [x] Añadir ejemplo de `CreateCouncil`. Referencia:
+  `docs/operations/mcp-stdio.md`.
+- [x] Añadir ejemplo de `RegisterAgent`. Referencia:
+  `docs/operations/mcp-stdio.md`.
+- [x] Añadir ejemplo de `RegisterContract`. Referencia:
+  `docs/operations/mcp-stdio.md`.
+- [x] Añadir ejemplo de `RunCouncilDecision`. Referencia:
+  `docs/operations/mcp-stdio.md`.
+- [x] Añadir ejemplo de `Orchestrate`. Referencia:
+  `docs/operations/mcp-stdio.md`.
+- [x] Verificar que un usuario nuevo puede obtener un resultado
+  validado sin leer código Rust. Evidencia:
+  `bash scripts/ci/e2e-compose.sh` pasó el 2026-05-18; escenario 8
+  ejecutó `RunCouncilDecision` en Strict contra el contrato Report con
+  `candidates_passed=1` y `candidates_total=1`.
 
 ## Fase 2 - Separar Demos De Producción
 
-- [ ] Añadir selector de escenarios al e2e-runner.
-- [ ] Definir grupo `compose` para escenarios 1-9.
-- [ ] Definir grupo `cluster-connectivity` para escenarios 1-4.
-- [ ] Definir grupo `runtime-stub` para escenario 5.
-- [ ] Definir grupo `structured-output` para escenarios 6-9.
-- [ ] Actualizar `make e2e-compose` para usar el grupo completo.
-- [ ] Actualizar Kubernetes Job para no ejecutar por defecto escenarios
-  que requieren `stub.echo` o `stub-llm`.
-- [ ] Actualizar `docs/operations/deploy-kubernetes.md` con el nuevo
-  modo de smoke real.
-- [ ] Verificar que Kubernetes smoke pasa contra un deploy real.
-- [ ] Verificar que `make e2e-compose` sigue probando todo el stack con
-  fixtures.
-- [ ] Eliminar cualquier mención operativa a "fallos esperados" como
+- [x] Añadir selector de escenarios al e2e-runner. Referencia:
+  `crates/choreo-e2e-runner/src/scenario_selection.rs`.
+- [x] Definir grupo `compose` para escenarios 1-9. Referencia:
+  `crates/choreo-e2e-runner/src/scenario_selection.rs`.
+- [x] Definir grupo `cluster-connectivity` para escenarios 1-4.
+  Referencia: `crates/choreo-e2e-runner/src/scenario_selection.rs`.
+- [x] Definir grupo `runtime-stub` para escenario 5. Referencia:
+  `crates/choreo-e2e-runner/src/scenario_selection.rs`.
+- [x] Definir grupo `structured-output` para escenarios 6-9.
+  Referencia: `crates/choreo-e2e-runner/src/scenario_selection.rs`.
+- [x] Actualizar `make e2e-compose` para usar el grupo completo.
+  Referencia: `tests/e2e/docker-compose.e2e.yaml`.
+- [x] Actualizar Kubernetes Job para no ejecutar por defecto escenarios
+  que requieren `stub.echo` o `stub-llm`. Referencia:
+  `tests/e2e/kubernetes/runner-job.yaml`.
+- [x] Actualizar `docs/operations/deploy-kubernetes.md` con el nuevo
+  modo de smoke real. Referencia:
+  `docs/operations/deploy-kubernetes.md`.
+- [x] Verificar que Kubernetes smoke pasa contra un deploy real.
+  Validado contra `underpass-runtime` con
+  `CHOREO_E2E_SCENARIOS=cluster-connectivity`; el runner selecciona
+  escenarios 1-4 y termina con `E2E scenarios passed`.
+- [x] Verificar que `make e2e-compose` sigue probando todo el stack con
+  fixtures. Validado con `CONTAINER_RUNTIME=podman-compose make
+  e2e-compose`; el runner selecciona escenarios 1-9 y termina con
+  `E2E scenarios passed`.
+- [x] Eliminar cualquier mención operativa a "fallos esperados" como
   estado aceptable.
+
+## Fase 2.1 - Ceremonia E2E vLLM Real Multiagente
+
+Objetivo: demostrar una ceremonia peer-review 360 real con varios
+agentes `vllm` contra un endpoint vLLM externo. Esto no convierte vLLM
+en dependencia del producto; es una validación de provider externo y
+Choreographer sigue siendo agnóstico.
+
+- [x] Inventariar cobertura existente: `make e2e-provider-vllm` prueba
+  el adapter `agent-vllm` contra vLLM real, pero no arranca
+  Choreographer ni crea council. Referencia:
+  `crates/choreo-e2e-runner/src/bin/provider.rs`.
+- [x] Inventariar cobertura existente: escenario 9 de
+  `make e2e-compose` prueba `kind=vllm` a través de Choreographer, pero
+  usa `stub-llm` y un solo agente. Referencia:
+  `crates/choreo-e2e-runner/src/scenarios/structured_output/report_vllm.rs`.
+- [x] Validar endpoint vLLM real accesible con mTLS. Validado el
+  2026-05-18 contra `https://vllm.underpassai.com` con modelo
+  `google/gemma-4-31B-it`: `/health`, `/v1/models` y
+  `/v1/chat/completions` respondieron correctamente.
+- [x] Validar `make e2e-provider-vllm` contra vLLM real. Validado el
+  2026-05-18 con imagen
+  `ghcr.io/underpass-ai/underpass-choreographer-e2e-provider:sha-c74aac2`,
+  `E2E_CLIENT_TLS_SECRET=underpass-demo-client-tls`,
+  `E2E_IMAGE_PULL_SECRET=ghcr-pull`,
+  `CHOREO_VLLM_ENDPOINT=https://vllm.underpassai.com` y
+  `CHOREO_VLLM_MODEL=google/gemma-4-31B-it`; el Job terminó con
+  `Job completed successfully`.
+- [x] Añadir escenario E2E que arranque contra un Choreographer real y
+  registre varios agentes `kind=vllm` apuntando al endpoint vLLM
+  externo. Referencia:
+  `crates/choreo-e2e-runner/src/scenarios/structured_output/real_vllm_multi_agent.rs`.
+- [x] Crear council con `num_agents > 1` y ejecutar
+  `RunCouncilDecision` en `Strict` contra el contrato Report.
+  Referencia:
+  `crates/choreo-e2e-runner/src/scenarios/structured_output/real_vllm_multi_agent.rs`.
+- [x] Exponer evidencia de interacción entre agentes en la respuesta
+  pública: `Proposal.revision_count` y
+  `CandidateSummary.revision_count`. Referencia:
+  `crates/choreo-proto/proto/underpass/choreo/v1/choreo.proto`.
+- [x] Asertar que el resultado viene de una ceremonia multiagente:
+  `candidates_total > 1`, autores distintos, `revision_count > 0` en
+  winner y candidatos, `candidates_passed >= 1`, winner presente y
+  payload válido contra JSON Schema. Referencia:
+  `crates/choreo-e2e-runner/src/scenarios/structured_output/real_vllm_multi_agent.rs`.
+- [x] Añadir Job/Make target separado para este flujo:
+  `make e2e-council-vllm`. Referencia:
+  `scripts/ci/e2e-council-vllm.sh`,
+  `tests/e2e/kubernetes/council-vllm-job.yaml` y `Makefile`.
+- [x] Validar compilación y tests locales del cambio. Validado con
+  `cargo check -p choreo-e2e-runner -p choreo-adapters -p choreo-mcp
+  --locked --features choreo-adapters/agent-vllm` y
+  `cargo test -p choreo-e2e-runner -p choreo-adapters -p choreo-mcp
+  --locked --features choreo-adapters/agent-vllm`.
+- [ ] Build/push de imagen E2E runner con este escenario, habilitar
+  `kind=vllm` en el Choreographer objetivo mediante
+  `CHOREO_VLLM_MODEL` + `CHOREO_VLLM_ENDPOINT`, y ejecutar
+  `make e2e-council-vllm` contra `vllm.underpassai.com`.
+- [ ] Documentar operación, requisitos y límites del E2E multiagente
+  vLLM en `docs/operations/compose-e2e.md`, `docs/dev-loop.md` y
+  `docs/operations/support-matrix.md`.
+
+## Fase 2.2 - Ceremonia E2E MCP
+
+Objetivo: probar la misma ceremonia desde la superficie MCP, no solo
+desde gRPC. MCP debe demostrar paridad de ejecución: registrar contrato,
+registrar agentes, crear council, ejecutar decisión y recibir evidencia
+de interacción (`revision_count`) en la respuesta.
+
+- [ ] Añadir test/runner MCP live contra Choreographer real usando
+  `choreo-mcp` como backend stdio.
+- [ ] Ejecutar por MCP `choreo_register_contract`,
+  `choreo_register_agent`, `choreo_create_council` y
+  `choreo_run_council_decision`.
+- [ ] Asertar desde la respuesta MCP: `candidates_total > 1`,
+  `candidates_passed >= 1`, winner JSON válido y
+  `revision_count > 0`.
+- [ ] Añadir Make/script separado, por ejemplo
+  `make e2e-mcp-council-vllm`, para no mezclarlo con el runner gRPC.
+- [ ] Documentar el flujo MCP live y su relación con el E2E gRPC.
 
 ## Fase 3 - Consumer Smoke Integrable
 
-- [ ] Añadir modo positive-path a `choreo-consumer-smoke`.
-- [ ] Permitir registrar un agent `openai` contra endpoint
-  OpenAI-compatible.
-- [ ] Permitir registrar un agent `vllm` contra endpoint
-  OpenAI-compatible.
-- [ ] Registrar el Report schema desde el smoke positivo.
-- [ ] Ejecutar `RunCouncilDecision` en Strict mode desde el smoke
-  positivo.
-- [ ] Validar `report_payload_validates = Passed`.
-- [ ] Mantener modo NoopAgent rejection-path.
-- [ ] Documentar modo rejection-path.
-- [ ] Documentar modo positive-path.
-- [ ] Documentar NATS opcional.
-- [ ] Documentar exit codes.
-- [ ] Añadir ejemplo de CI para consumidores.
-- [ ] Verificar que un consumidor puede comprobar API viva, rechazo de
+- [x] Añadir modo positive-path a `choreo-consumer-smoke`.
+  Referencia: `crates/choreo-consumer-smoke/src/positive.rs`.
+- [x] Permitir registrar un agent `openai` contra endpoint
+  OpenAI-compatible. Referencia:
+  `crates/choreo-consumer-smoke/src/positive.rs`.
+- [x] Permitir registrar un agent `vllm` contra endpoint
+  OpenAI-compatible. Referencia:
+  `crates/choreo-consumer-smoke/src/positive.rs`.
+- [x] Registrar el Report schema desde el smoke positivo. Referencia:
+  `crates/choreo-consumer-smoke/src/positive.rs`.
+- [x] Ejecutar `RunCouncilDecision` en Strict mode desde el smoke
+  positivo. Validado con `--chain positive-path` contra
+  `choreo-stub-llm` local.
+- [x] Validar `report_payload_validates = Passed`. Validado con
+  `--chain positive-path` contra `choreo-stub-llm` local.
+- [x] Mantener modo NoopAgent rejection-path. Referencia:
+  `crates/choreo-consumer-smoke/src/chain2.rs`.
+- [x] Documentar modo rejection-path. Referencia:
+  `docs/operations/consumer-smoke.md`.
+- [x] Documentar modo positive-path. Referencia:
+  `docs/operations/consumer-smoke.md`.
+- [x] Documentar NATS opcional. Referencia:
+  `docs/operations/consumer-smoke.md`.
+- [x] Documentar exit codes. Referencia:
+  `docs/operations/consumer-smoke.md`.
+- [x] Añadir ejemplo de CI para consumidores. Referencia:
+  `docs/operations/consumer-smoke.md`.
+- [x] Verificar que un consumidor puede comprobar API viva, rechazo de
   output inválido, aceptación de JSON válido y propagación de
-  correlation/causation por NATS.
+  correlation/causation por NATS. Validado con
+  `cargo run -p choreo-consumer-smoke --locked -- --endpoint
+  http://127.0.0.1:58055 --nats-url nats://127.0.0.1:58222 --chain
+  all` y `cargo run -p choreo-consumer-smoke --locked -- --endpoint
+  http://127.0.0.1:58055 --nats-url nats://127.0.0.1:58222 --chain
+  positive-path --provider-kind openai --provider-endpoint
+  http://127.0.0.1:58000 --provider-model stub-report-v1` contra
+  Choreographer local, NATS y `choreo-stub-llm`.
 
 ## Fase 4 - Publicación Operativa
 
-- [ ] Completar guía Helm de instalación mínima.
-- [ ] Completar guía Helm con embedded NATS.
-- [ ] Completar guía Helm con Runtime executor opcional.
-- [ ] Completar guía Helm con TLS/mTLS.
-- [ ] Completar guía Helm con Postgres secret.
-- [ ] Completar guía Helm con provider env secrets.
-- [ ] Añadir `SECURITY.md`.
-- [ ] Añadir `CHANGELOG.md`.
-- [ ] Añadir `CONTRIBUTING.md`.
-- [ ] Añadir matriz de soporte de Rust version.
-- [ ] Añadir matriz de soporte de image tags.
-- [ ] Añadir matriz de soporte de chart versions.
-- [ ] Añadir matriz de soporte de providers.
-- [ ] Añadir matriz de soporte de postura Kubernetes.
-- [ ] Documentar rollback con ejemplo real.
-- [ ] Documentar upgrade con ejemplo real.
+- [x] Completar guía Helm de instalación mínima. Referencia:
+  `docs/operations/deploy-kubernetes.md` y
+  `charts/choreographer/values.minimal.yaml`.
+- [x] Completar guía Helm con embedded NATS. Referencia:
+  `docs/operations/deploy-kubernetes.md` y
+  `charts/choreographer/values.embedded-nats.yaml`.
+- [x] Completar guía Helm con Runtime executor opcional. Referencia:
+  `docs/operations/deploy-kubernetes.md`,
+  `charts/choreographer/values.underpass-runtime.yaml` y
+  `scripts/ci/helm-lint.sh`.
+- [x] Completar guía Helm con TLS/mTLS. Referencia:
+  `docs/operations/deploy-kubernetes.md` y
+  `scripts/ci/helm-lint.sh`.
+- [x] Completar guía Helm con Postgres secret. Referencia:
+  `docs/operations/deploy-kubernetes.md`,
+  `charts/choreographer/values.postgres-secret.yaml` y
+  `scripts/ci/helm-lint.sh`.
+- [x] Completar guía Helm con provider env secrets. Referencia:
+  `docs/operations/deploy-kubernetes.md`,
+  `charts/choreographer/values.provider-env-secrets.yaml` y
+  `scripts/ci/helm-lint.sh`.
+- [x] Añadir `SECURITY.md`. Referencia: `SECURITY.md`, `README.md` y
+  `docs/index.md`.
+- [x] Añadir `CHANGELOG.md`. Referencia: `CHANGELOG.md`, `README.md`
+  y `docs/index.md`.
+- [x] Añadir `CONTRIBUTING.md`. Referencia: `CONTRIBUTING.md`,
+  `README.md` y `docs/index.md`.
+- [x] Añadir matriz de soporte de Rust version. Referencia:
+  `docs/operations/support-matrix.md`, `Cargo.toml`,
+  `rust-toolchain.toml` y `.github/workflows/quality-gate.yml`.
+- [x] Añadir matriz de soporte de image tags. Referencia:
+  `docs/operations/support-matrix.md`,
+  `.github/workflows/publish-distribution.yml` y
+  `charts/choreographer/templates/_helpers.tpl`.
+- [x] Añadir matriz de soporte de chart versions. Referencia:
+  `docs/operations/support-matrix.md`,
+  `charts/choreographer/Chart.yaml` y `scripts/release.sh`.
+- [x] Añadir matriz de soporte de providers. Referencia:
+  `docs/operations/support-matrix.md`,
+  `crates/choreo-adapters/src/agents/factory.rs`, `Dockerfile` y
+  `scripts/ci/quality-gate.sh`.
+- [x] Añadir matriz de soporte de postura Kubernetes. Referencia:
+  `docs/operations/support-matrix.md`,
+  `docs/operations/deploy-kubernetes.md` y
+  `scripts/ci/helm-lint.sh`.
+- [x] Documentar rollback con ejemplo real. Referencia:
+  `docs/operations/deploy-kubernetes.md`.
+- [x] Documentar upgrade con ejemplo real. Referencia:
+  `docs/operations/deploy-kubernetes.md`.
 - [ ] Verificar que un operador puede desplegar imagen pinneada, chart
-  OCI, secret refs y smoke post-deploy.
+  OCI, secret refs y smoke post-deploy. Pendiente de tag `v*` y chart
+  OCI publicado. Preparado y validado parcialmente el 2026-05-18:
+  `helm template` con digest + Postgres/provider Secret refs,
+  `helm template` con mTLS Secret ref y `helm package` local generando
+  `choreographer-0.1.0.tgz`; runbook OCI post-release en
+  `docs/operations/deploy-kubernetes.md`.
 
 ## Fase 5 - Release Candidate
 
-- [ ] `just check` pasa.
-- [ ] `just helm-lint` pasa.
-- [ ] `just integration` pasa.
-- [ ] `make e2e-compose` pasa.
-- [ ] Kubernetes smoke con escenarios seleccionados pasa.
-- [ ] `make consumer-smoke` rejection-path pasa.
-- [ ] consumer-smoke positive-path contra `stub-llm` o provider
-  compatible pasa.
-- [ ] `make e2e-provider-vllm` pasa si se anuncia vLLM real.
-- [ ] `cargo publish --dry-run -p choreo-mcp-proto` pasa.
-- [ ] `cargo publish --dry-run -p choreo-mcp` pasa.
-- [ ] Dry run de build/push de imagen pasa.
-- [ ] Dry run de build/push de chart pasa.
+- [x] `just check` pasa. Validado el 2026-05-18 con el equivalente
+  directo `bash scripts/ci/quality-gate.sh`: contract gate, fmt-check,
+  clippy con matriz de providers, tests workspace y bench-compile.
+- [x] `just helm-lint` pasa. Validado el 2026-05-18 con
+  `bash scripts/ci/helm-lint.sh`.
+- [x] `just integration` pasa. Validado el 2026-05-18 con
+  `bash scripts/ci/integration-nats.sh` y
+  `bash scripts/ci/integration-postgres.sh` contra contenedores reales.
+- [x] `make e2e-compose` pasa. Validado el 2026-05-18: build de
+  servicios con Docker Compose, escenarios 1-9 y cierre con
+  `E2E scenarios passed`.
+- [x] Kubernetes smoke con escenarios seleccionados pasa. Validado el
+  2026-05-18 con `make e2e-kubernetes`,
+  `E2E_IMAGE_REPOSITORY_PREFIX=ghcr.io/underpass-ai`,
+  `E2E_IMAGE_TAG=sha-c74aac2` y `E2E_IMAGE_PULL_SECRET=ghcr-pull`:
+  escenarios 1-4 y cierre con `E2E kubernetes scenarios passed`.
+- [x] `make consumer-smoke` rejection-path pasa. Validado el
+  2026-05-18 contra RC temporal `sha-c74aac2` vía port-forward:
+  `CONSUMER_SMOKE_CHAIN=two`, `report_schema_registered` PASS,
+  `report_contract_rejects_freeform_text` PASS.
+- [x] consumer-smoke positive-path contra `stub-llm` o provider
+  compatible pasa. Validado el 2026-05-18 contra RC temporal
+  `sha-c74aac2` con `stub-llm` en Kubernetes:
+  `CONSUMER_SMOKE_CHAIN=positive-path`,
+  `CONSUMER_SMOKE_PROVIDER_KIND=openai`,
+  `report_payload_validates` PASS y
+  `report_validation_summary_passed` PASS.
+- [x] `make e2e-provider-vllm` pasa contra vLLM real. Validado el
+  2026-05-18 con runner
+  `ghcr.io/underpass-ai/underpass-choreographer-e2e-provider:sha-c74aac2`,
+  `E2E_CLIENT_TLS_SECRET=underpass-demo-client-tls`,
+  `E2E_IMAGE_PULL_SECRET=ghcr-pull`,
+  `CHOREO_VLLM_ENDPOINT=https://vllm.underpassai.com` y
+  `CHOREO_VLLM_MODEL=google/gemma-4-31B-it`; el Job completó
+  correctamente. El council multiagente con vLLM real queda como check
+  separado en la Fase 2.1.
+- [x] `cargo publish --dry-run -p choreo-mcp-proto` pasa. Validado el
+  2026-05-18 en la rama `feat/bundle-b-mcp-distribution`; el crate
+  vendorizado evita publicar el crate interno `choreo-proto`.
+- [ ] `cargo publish --dry-run -p choreo-mcp` pasa. Bloqueado hasta
+  publicar primero `choreo-mcp-proto v0.1.0` en crates.io: el
+  manifest ya apunta al crate vendorizado y `cargo check -p
+  choreo-mcp` pasa, pero el dry-run completo resuelve
+  `choreo-mcp-proto` contra crates.io y falla porque aún no existe
+  allí.
+- [x] Dry run de build/push de imagen pasa. Validado el 2026-05-18
+  con Podman login contra GHCR usando token local, build y push de
+  `ghcr.io/underpass-ai/underpass-choreographer:sha-c74aac2` y
+  `ghcr.io/underpass-ai/underpass-choreographer-e2e-runner:sha-c74aac2`;
+  para positive-path se publicó también
+  `ghcr.io/underpass-ai/underpass-choreographer-stub-llm:sha-c74aac2`.
+- [x] Dry run de build/push de chart pasa. Validado el 2026-05-18:
+  `helm package charts/choreographer --destination /tmp/choreographer-chart-dry-run`,
+  `helm lint charts/choreographer` y `helm registry login ghcr.io`
+  pasaron. `helm push` no tiene modo dry-run; el push OCI real queda
+  reservado para el check de chart publicado tras tag.
 - [ ] Tag RC creado.
 - [ ] Imagen GHCR publicada.
 - [ ] Helm chart OCI publicado.
 - [ ] `choreo-mcp` instalable desde registry.
-- [ ] Release notes incluyen límites explícitos.
+- [x] Release notes incluyen límites explícitos. Validado el
+  2026-05-18 en `CHANGELOG.md` con sección `Known Limits`.
 
 ## Fase 6 - Public Beta
 
@@ -181,3 +393,153 @@ Añadir entradas breves aquí cuando se completen bloques grandes.
 
 - 2026-05-18: checklist inicial creado a partir del plan de usabilidad
   y publicación.
+- 2026-05-18: `docs/operations/compose-e2e.md` añadido como guía
+  operativa para `make e2e-compose`; cubre los 9 escenarios,
+  `stub-runtime`, `stub-llm`, Report schema y provider shapes
+  OpenAI/vLLM.
+- 2026-05-18: quickstart sin servicios externos elevado a `README.md`
+  y `docs/dev-loop.md`: `CHOREO_NATS_ENABLED=false just run`.
+- 2026-05-18: quickstart MCP fixture añadido a
+  `docs/operations/mcp-stdio.md`, `README.md` y `docs/dev-loop.md`.
+- 2026-05-18: quickstart MCP live local añadido: Choreographer con
+  `CHOREO_NATS_ENABLED=false CHOREO_SEED_SPECIALTIES=triage just run`
+  y MCP con `CHOREO_MCP_GRPC_ENDPOINT=http://127.0.0.1:50055`.
+  Validado con fallback `cargo run --locked -p choreo` porque `just`
+  no está instalado en este entorno; smoke live pasó con
+  `CHOREO_MCP_GRPC_ENDPOINT=http://127.0.0.1:50055
+  CHOREO_MCP_BIN=target/debug/choreo-mcp
+  bash scripts/mcp/choreo-stdio-smoke.sh`.
+- 2026-05-18: ejemplo MCP `CreateCouncil` añadido y validado en
+  fixture mode con `choreo_create_council`.
+- 2026-05-18: paridad MCP == gRPC reforzada con test en
+  `crates/choreo-mcp/src/protocol.rs`: lee `choreo.proto`, deriva
+  los nombres `choreo_*` esperados y comprueba catálogo, dispatch
+  gRPC y fixture.
+- 2026-05-18: ejemplo MCP `RegisterAgent` añadido y validado en
+  fixture mode con `choreo_register_agent`.
+- 2026-05-18: ejemplo MCP `RegisterContract` añadido y validado en
+  fixture mode con `choreo_register_contract`.
+- 2026-05-18: ejemplo MCP `RunCouncilDecision` añadido y validado en
+  fixture mode con `choreo_run_council_decision`.
+- 2026-05-18: ejemplo MCP `Orchestrate` añadido y validado en fixture
+  mode con `choreo_orchestrate`.
+- 2026-05-18: `bash scripts/ci/e2e-compose.sh` ejecutado completo.
+  Escenario 8 produjo `RunCouncilDecision succeeded with Report-shaped
+  winner` con `candidates_passed=1` y `candidates_total=1`; escenario
+  9 repitió el camino positivo por el adapter `vllm`; el runner cerró
+  con `E2E scenarios passed`.
+- 2026-05-18: selector de escenarios añadido al `choreo-e2e-runner`
+  mediante `CHOREO_E2E_SCENARIOS`; grupos definidos: `compose` / `all`
+  (1-9), `cluster-connectivity` (1-4), `runtime-stub` (5) y
+  `structured-output` (6-9). `make e2e-compose` usa `compose` por
+  defecto y permite override desde el entorno.
+- 2026-05-18: `choreo-e2e-runner` separado en módulos: `main.rs`
+  conserva el dispatch, `scenario_selection.rs` conserva el parser y
+  `scenarios/` divide las assertions por superficie.
+- 2026-05-18: `SECURITY.md` añadido con alcance soportado, canal
+  privado de reporte, disclosure coordinado, baseline operativa y
+  contención de secretos; enlazado desde `README.md` y `docs/index.md`.
+- 2026-05-18: `CHANGELOG.md` añadido en modo pre-release: mantiene
+  `Unreleased`, declara `0.1.0` como pendiente de tag y enlaza la
+  disciplina de release notes desde `README.md` y `docs/index.md`.
+- 2026-05-18: `CONTRIBUTING.md` añadido con alcance del repo, setup,
+  workflow de PR, gates obligatorios, cambios de contrato, expectativas
+  de tests/docs, reglas de seguridad y flujo de release.
+- 2026-05-18: matriz de soporte Rust añadida en
+  `docs/operations/support-matrix.md`: soporte exacto `1.90.0`,
+  `Cargo.lock` obligatorio y regla de cambio coordinada para toolchain,
+  CI, docs y changelog.
+- 2026-05-18: matriz de soporte de image tags añadida: digest como
+  referencia preferida, `vX.Y.Z` tras tag, `sha-<short>` para smoke/RC,
+  y `main`/`latest`/tags locales como referencias no productivas.
+- 2026-05-18: matriz de soporte de chart versions añadida: chart
+  `0.1.0` pendiente de tag, OCI chart versionado como `X.Y.Z`, lockstep
+  obligatorio con Cargo/appVersion/imagen y sin referencias movibles.
+- 2026-05-18: matriz de soporte de providers añadida: `noop` siempre,
+  `openai` y `vllm` en imagen por defecto con env/feature gates,
+  `anthropic` como feature probada en CI pero fuera del Dockerfile por
+  defecto, y credenciales fuera de descriptores.
+- 2026-05-18: matriz de postura Kubernetes añadida: perfiles mínimos,
+  embedded NATS, Postgres secret, provider env, TLS/mTLS, Runtime,
+  NetworkPolicy/PDB opt-in y límites explícitos como Ingress no
+  gestionado por el chart y multi-réplica pendiente de state plan.
+- 2026-05-18: rollback operativo documentado con ejemplo concreto:
+  `helm history`, rollback de revisión `7` a `6`, verificación de
+  rollout, imagen restaurada, health checks y consumer smoke posterior.
+- 2026-05-18: upgrade operativo documentado con ejemplo concreto:
+  render previo, `helm upgrade --install` desde checkout, variante OCI
+  versionada, imagen por digest, `--atomic`, smoke posterior y checks
+  de Secrets/Postgres/TLS/Runtime.
+- 2026-05-18: primer gate de RC pasado con
+  `bash scripts/ci/quality-gate.sh`: contrato, formato, clippy,
+  tests workspace y bench compile. Se eliminó ruido de warnings en
+  `crates/choreo-adapters/src/agents/factory.rs` para que
+  bench-compile cierre limpio.
+- 2026-05-18: gate Helm de RC pasado con
+  `bash scripts/ci/helm-lint.sh`.
+- 2026-05-18: gate de integración de RC pasado con
+  `bash scripts/ci/integration-nats.sh` y
+  `bash scripts/ci/integration-postgres.sh`; ambos usaron daemon Docker
+  para testcontainers y cerraron verde.
+- 2026-05-18: gate compose de RC pasado con `make e2e-compose`:
+  build de imágenes, stack Docker Compose completo, escenarios 1-9,
+  providers shape OpenAI/vLLM con `Report` válido y cierre con
+  `E2E scenarios passed`.
+- 2026-05-18: build/push de imagen validado con Podman y GHCR:
+  `underpass-choreographer:sha-c74aac2` y
+  `underpass-choreographer-e2e-runner:sha-c74aac2` publicados en
+  `ghcr.io/underpass-ai` usando el token local de `/tmp/github.txt`.
+- 2026-05-18: Kubernetes smoke de RC pasado contra namespace temporal
+  `choreographer-e2e`: `make e2e-kubernetes` con imágenes GHCR
+  `sha-c74aac2`, `ghcr-pull`, escenarios seleccionados 1-4,
+  propagación causal por NATS y cierre con
+  `E2E kubernetes scenarios passed`; namespace temporal eliminado.
+- 2026-05-18: `make consumer-smoke` rejection-path validado contra
+  RC temporal `sha-c74aac2` en namespace
+  `choreographer-consumer-smoke`: la release antigua en
+  `underpass-runtime` devolvía `RegisterContract=Unimplemented`, por
+  eso se ejecutó contra el RC; `CONSUMER_SMOKE_CHAIN=two` pasó con
+  `report_schema_registered` y
+  `report_contract_rejects_freeform_text` en PASS.
+- 2026-05-18: consumer-smoke positive-path validado contra el mismo
+  RC temporal con `stub-llm` desplegado en Kubernetes y provider
+  `openai` habilitado por env dummy; `CONSUMER_SMOKE_CHAIN=positive-path`
+  pasó con 7/8 assertions, incluyendo `report_payload_validates` y
+  `report_validation_summary_passed`; la assertion de bus quedó
+  `Skipped` porque el CLI se ejecutó sin `CHOREO_NATS_URL`.
+- 2026-05-18: la estrategia de publicación MCP queda reconciliada con
+  `feat/bundle-b-mcp-distribution`: `choreo-mcp` depende del crate
+  vendorizado `choreo-mcp-proto`, no del crate interno
+  `choreo-proto`.
+- 2026-05-18: `cargo publish --dry-run --allow-dirty -p choreo-mcp`
+  queda pendiente porque `choreo-mcp-proto v0.1.0` aún no está en
+  crates.io. El workflow de publicación debe publicar primero
+  `choreo-mcp-proto`, esperar propagación del índice y después
+  publicar `choreo-mcp`.
+- 2026-05-18: dry-run de chart validado: `helm package` generó
+  `/tmp/choreographer-chart-dry-run/choreographer-0.1.0.tgz`,
+  `helm lint charts/choreographer` pasó y `helm registry login
+  ghcr.io` funcionó con el token local. No se ejecutó `helm push`
+  porque Helm no ofrece dry-run para OCI push y la publicación real
+  debe esperar tag/release.
+- 2026-05-18: release notes completadas con límites explícitos en
+  `CHANGELOG.md`: ausencia de tag/artifact estable, dependencia de
+  `choreo-mcp-proto` para publicar `choreo-mcp`, smokes provider con
+  stub salvo wiring real del operador, e Ingress/egress/multi-réplica
+  fuera del alcance actual del chart.
+- 2026-05-18: `make e2e-provider-vllm` validado contra vLLM real en
+  `https://vllm.underpassai.com` con modelo `google/gemma-4-31B-it`,
+  imagen
+  `ghcr.io/underpass-ai/underpass-choreographer-e2e-provider:sha-c74aac2`,
+  secreto mTLS `underpass-demo-client-tls` y pull secret `ghcr-pull`;
+  el Job terminó con `Job completed successfully`. Queda anotado como
+  siguiente bloque el E2E de council multiagente con vLLM real.
+- 2026-05-18: ceremonia E2E peer-review 360 añadida para vLLM real:
+  registra varios agentes `kind=vllm`, crea council, ejecuta
+  `RunCouncilDecision` en Strict y falla si no hay candidatos de
+  autores distintos, winner schema-valid y `revision_count > 0`.
+  También se expuso `revision_count` en gRPC y MCP JSON para que la
+  interacción entre agentes sea observable. Validado con `cargo check`
+  y `cargo test` sobre `choreo-e2e-runner`, `choreo-adapters` y
+  `choreo-mcp`. Queda pendiente build/push de imagen y ejecución real
+  del Job, más el E2E equivalente entrando por MCP.

--- a/docs/stack-gap-analysis.md
+++ b/docs/stack-gap-analysis.md
@@ -52,7 +52,8 @@ current implementation state of sibling repositories.
   `Orchestrate -> RuntimeExecutor -> stub-runtime`, strict schema
   rejection, `ExternalContextBundle` round-trip, positive structured
   output through a stub OpenAI-compatible agent, and the same Report
-  contract through the vLLM adapter shape.
+  contract through the vLLM adapter shape. The operator-facing map
+  lives in [`operations/compose-e2e.md`](./operations/compose-e2e.md).
 - The stdio MCP adapter exposes all 16 gRPC RPCs as `choreo_*` tools
   and has fixture + live gRPC backends.
 
@@ -80,31 +81,20 @@ That is sufficient for repository CI, but a product deployment still
 needs to run its own provider smoke with its model, credentials,
 network policy, TLS posture, and latency budget.
 
-### 3. Consumer-smoke positive path is not the default path
+### 3. Consumer-smoke positive path is opt-in
 
 `choreo-consumer-smoke` exercises the public gRPC + optional NATS
 surface and proves the strict rejection path against a NoopAgent stack.
-The positive structured-output path exists in compose scenario 8, but
-the smoke harness does not yet ship a first-class mode that registers
-the stub-LLM-backed structured JSON agent and flips
-`report_payload_validates` to `Passed`.
+The positive structured-output path now ships as
+`--chain positive-path`: it registers an `openai` or `vllm` agent
+against an OpenAI-compatible endpoint, runs `RunCouncilDecision` in
+Strict mode, and flips `report_payload_validates` to `Passed`.
 
-This is a harness ergonomics gap, not a missing Choreographer feature.
+It intentionally remains opt-in because a real deployment must choose
+its provider endpoint, model, credentials, network policy, TLS posture,
+and latency budget.
 
-### 4. Compose E2E operations doc is missing
-
-The compose stack now includes both `stub-runtime` and `stub-llm`, but
-there is no dedicated operations document for:
-
-- the nine scenarios and what each proves
-- the stub-LLM OpenAI-compatible surface
-- the hard-coded Report payload
-- `STUB_LLM_LISTEN`
-- when to use `make e2e-compose` versus `make e2e-provider-vllm`
-
-The backlog tracks this as `docs/operations/compose-e2e.md`.
-
-### 5. Streaming remains phase-level
+### 4. Streaming remains phase-level
 
 `StreamDeliberation` emits phase transitions and a final winner frame.
 The proto shape reserves payload variants for proposal, critique, and
@@ -115,18 +105,16 @@ callers can use `Deliberate` or the buffered MCP wrapper today.
 
 ## Recommended Hardening Plan
 
-1. Add `docs/operations/compose-e2e.md` so operators can interpret the
-   repo-owned E2E stack without reading the runner source.
-2. Add a consumer-smoke positive-path mode that registers an
-   OpenAI-compatible structured JSON agent when a stub or provider
-   endpoint is available.
-3. Keep `make e2e-provider-vllm` as the explicit external-provider
+1. Keep the consumer-smoke positive-path mode opt-in and require
+   downstream deployments to supply their own OpenAI-compatible stub or
+   provider endpoint.
+2. Keep `make e2e-provider-vllm` as the explicit external-provider
    validation path and require downstream deployments to run it, or an
    equivalent provider smoke, before claiming provider readiness.
-4. Only add a Choreographer-owned context adapter if a concrete product
+3. Only add a Choreographer-owned context adapter if a concrete product
    needs that ownership boundary. Otherwise keep caller-materialized
    context as the documented contract.
-5. Treat per-proposal/per-critique/per-revision streaming as a separate
+4. Treat per-proposal/per-critique/per-revision streaming as a separate
    additive feature, with tests that prove frame ordering and backpressure.
 
 ## Honest Current Position

--- a/scripts/ci/e2e-council-vllm.sh
+++ b/scripts/ci/e2e-council-vllm.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Launches the Choreographer multi-agent vLLM E2E Job, waits for
+# completion, tails logs, and cleans up. Namespace defaults to the
+# Underpass runtime namespace because that is where the shared
+# Choreographer + vLLM services run in the operator environment.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+NAMESPACE="${NAMESPACE:-underpass-runtime}"
+JOB_NAME="${JOB_NAME:-choreographer-e2e-council-vllm}"
+MANIFEST="${ROOT_DIR}/tests/e2e/kubernetes/council-vllm-job.yaml"
+TIMEOUT="${TIMEOUT:-600s}"
+RUNNER_IMAGE="${RUNNER_IMAGE:-ghcr.io/underpass-ai/underpass-choreographer-e2e-runner:latest}"
+CHOREOGRAPHER_ENDPOINT="${CHOREOGRAPHER_ENDPOINT:-http://choreographer:50055}"
+VLLM_ENDPOINT="${CHOREO_VLLM_ENDPOINT:-http://underpass-llm-gemma-4-31b-structured:8000}"
+VLLM_MODEL="${CHOREO_VLLM_MODEL:-google/gemma-4-31B-it}"
+VLLM_AGENT_COUNT="${CHOREO_VLLM_AGENT_COUNT:-3}"
+VLLM_MAX_TOKENS="${CHOREO_VLLM_MAX_TOKENS:-512}"
+VLLM_TIMEOUT_SECS="${CHOREO_VLLM_TIMEOUT_SECS:-300}"
+IMAGE_PULL_SECRET="${E2E_IMAGE_PULL_SECRET:-}"
+RENDERED_MANIFEST=""
+
+cleanup() {
+    kubectl -n "${NAMESPACE}" delete job "${JOB_NAME}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+    if [ -n "${RENDERED_MANIFEST}" ] && [ -f "${RENDERED_MANIFEST}" ]; then
+        rm -f "${RENDERED_MANIFEST}"
+    fi
+}
+
+cleanup
+trap cleanup EXIT
+
+RENDERED_MANIFEST="$(mktemp)"
+awk \
+    -v image="${RUNNER_IMAGE}" \
+    -v choreographer_endpoint="${CHOREOGRAPHER_ENDPOINT}" \
+    -v vllm_endpoint="${VLLM_ENDPOINT}" \
+    -v vllm_model="${VLLM_MODEL}" \
+    -v agent_count="${VLLM_AGENT_COUNT}" \
+    -v max_tokens="${VLLM_MAX_TOKENS}" \
+    -v timeout_secs="${VLLM_TIMEOUT_SECS}" \
+    -v pull_secret="${IMAGE_PULL_SECRET}" '
+      {
+        gsub("image: ghcr.io/underpass-ai/underpass-choreographer-e2e-runner:latest", "image: " image);
+      }
+      /- name: CHOREOGRAPHER_ENDPOINT/ {
+        print;
+        getline;
+        sub(/value:.*/, "value: " choreographer_endpoint);
+        print;
+        next;
+      }
+      /- name: CHOREO_VLLM_ENDPOINT/ {
+        print;
+        getline;
+        sub(/value:.*/, "value: " vllm_endpoint);
+        print;
+        next;
+      }
+      /- name: CHOREO_VLLM_MODEL/ {
+        print;
+        getline;
+        sub(/value:.*/, "value: " vllm_model);
+        print;
+        next;
+      }
+      /- name: CHOREO_VLLM_AGENT_COUNT/ {
+        print;
+        getline;
+        sub(/value:.*/, "value: \"" agent_count "\"");
+        print;
+        next;
+      }
+      /- name: CHOREO_VLLM_MAX_TOKENS/ {
+        print;
+        getline;
+        sub(/value:.*/, "value: \"" max_tokens "\"");
+        print;
+        next;
+      }
+      /- name: CHOREO_VLLM_TIMEOUT_SECS/ {
+        print;
+        getline;
+        sub(/value:.*/, "value: \"" timeout_secs "\"");
+        print;
+        next;
+      }
+      /restartPolicy: Never/ {
+        print;
+        if (pull_secret != "") {
+          print "      imagePullSecrets:";
+          print "        - name: " pull_secret;
+        }
+        next;
+      }
+      { print }
+    ' "${MANIFEST}" > "${RENDERED_MANIFEST}"
+
+kubectl apply -n "${NAMESPACE}" -f "${RENDERED_MANIFEST}"
+
+echo ">>> waiting for pod"
+for _ in $(seq 1 30); do
+    pod=$(kubectl -n "${NAMESPACE}" get pod \
+        -l "job-name=${JOB_NAME}" \
+        -o=jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+    if [ -n "${pod:-}" ]; then
+        break
+    fi
+    sleep 2
+done
+
+if [ -z "${pod:-}" ]; then
+    echo "error: Job ${JOB_NAME} produced no pod" >&2
+    kubectl -n "${NAMESPACE}" get job "${JOB_NAME}" -o yaml >&2 || true
+    exit 1
+fi
+
+echo ">>> tailing ${pod}"
+kubectl -n "${NAMESPACE}" wait --for=condition=Ready \
+    --timeout=120s "pod/${pod}" >/dev/null 2>&1 || true
+kubectl -n "${NAMESPACE}" logs -f "${pod}" --pod-running-timeout=120s || true
+
+if kubectl -n "${NAMESPACE}" wait --for=condition=failed \
+    --timeout=1s "job/${JOB_NAME}" >/dev/null 2>&1; then
+    echo ">>> Job failed — dumping status" >&2
+    kubectl -n "${NAMESPACE}" describe job "${JOB_NAME}" >&2 || true
+    kubectl -n "${NAMESPACE}" describe pod "${pod}" >&2 || true
+    exit 1
+fi
+
+if kubectl -n "${NAMESPACE}" wait --for=condition=complete \
+    --timeout="${TIMEOUT}" "job/${JOB_NAME}" >/dev/null 2>&1; then
+    echo ">>> Job completed successfully"
+    exit 0
+fi
+
+echo ">>> Job did not complete within ${TIMEOUT} — dumping status" >&2
+kubectl -n "${NAMESPACE}" describe job "${JOB_NAME}" >&2 || true
+kubectl -n "${NAMESPACE}" describe pod "${pod}" >&2 || true
+exit 1

--- a/scripts/ci/helm-lint.sh
+++ b/scripts/ci/helm-lint.sh
@@ -3,12 +3,22 @@ set -euo pipefail
 
 CHART_PATH="${1:-charts/choreographer}"
 DEV_VALUES="${CHART_PATH}/values.dev.yaml"
+MINIMAL_VALUES="${CHART_PATH}/values.minimal.yaml"
+EMBEDDED_NATS_VALUES="${CHART_PATH}/values.embedded-nats.yaml"
+POSTGRES_SECRET_VALUES="${CHART_PATH}/values.postgres-secret.yaml"
+PROVIDER_ENV_VALUES="${CHART_PATH}/values.provider-env-secrets.yaml"
+UNDERPASS_RUNTIME_VALUES="${CHART_PATH}/values.underpass-runtime.yaml"
 TMP_DIR="${TMPDIR:-/tmp}"
 DEFAULT_ERR="${TMP_DIR}/choreographer-helm-default.err"
 HARDENED_OUT="${TMP_DIR}/choreographer-helm-hardened.yaml"
 HARDENED_ERR="${TMP_DIR}/choreographer-helm-hardened.err"
 
 helm lint "${CHART_PATH}" -f "${DEV_VALUES}"
+helm lint "${CHART_PATH}" -f "${MINIMAL_VALUES}" --set image.tag=v0
+helm lint "${CHART_PATH}" -f "${EMBEDDED_NATS_VALUES}" --set image.tag=v0
+helm lint "${CHART_PATH}" -f "${POSTGRES_SECRET_VALUES}" --set image.tag=v0
+helm lint "${CHART_PATH}" -f "${EMBEDDED_NATS_VALUES}" -f "${PROVIDER_ENV_VALUES}" --set image.tag=v0
+helm lint "${CHART_PATH}" -f "${UNDERPASS_RUNTIME_VALUES}" --set image.tag=v0
 helm template choreographer "${CHART_PATH}" -f "${DEV_VALUES}" >/tmp/choreographer-helm-template.yaml
 
 # --- Gate 1: default render refuses to produce a manifest without a
@@ -126,6 +136,182 @@ tls_mutual_markers=(
 for marker in "${tls_mutual_markers[@]}"; do
   if ! grep -qF -- "${marker}" "${TLS_MUTUAL_OUT}"; then
     echo "tls=mutual chart manifest missing required marker: ${marker}" >&2
+    exit 1
+  fi
+done
+
+# --- Gate 5: embedded NATS profile. The standalone bus profile must
+# render a release-local NATS deployment and point the choreographer at
+# that service.
+
+EMBEDDED_NATS_OUT="${TMP_DIR}/choreographer-helm-embedded-nats.yaml"
+
+helm template choreographer "${CHART_PATH}" \
+  -f "${EMBEDDED_NATS_VALUES}" \
+  --set image.tag=v0 \
+  > "${EMBEDDED_NATS_OUT}"
+
+embedded_nats_markers=(
+  'name: choreographer-nats'
+  'app.kubernetes.io/component: nats'
+  'image: "docker.io/library/nats:2.10-alpine"'
+  'name: CHOREO_NATS_ENABLED'
+  'value: "true"'
+  'name: CHOREO_NATS_URL'
+  'value: "nats://choreographer-nats:4222"'
+  'name: CHOREO_TRIGGER_SUBJECT'
+  'value: "choreo.trigger.>"'
+  'name: CHOREO_PUBLISH_PREFIX'
+  'value: "choreo"'
+)
+for marker in "${embedded_nats_markers[@]}"; do
+  if ! grep -qF -- "${marker}" "${EMBEDDED_NATS_OUT}"; then
+    echo "embedded NATS chart manifest missing required marker: ${marker}" >&2
+    exit 1
+  fi
+done
+
+# --- Gate 6: Runtime executor render. Runtime mode must fail without
+# an endpoint, must fail when TLS is requested without a secret, and
+# the checked-in underpass-runtime profile must wire endpoint,
+# principal, mTLS paths, and the runtime TLS secret mount.
+
+RUNTIME_MISSING_ENDPOINT_ERR="${TMP_DIR}/choreographer-helm-runtime-missing-endpoint.err"
+RUNTIME_MISSING_TLS_ERR="${TMP_DIR}/choreographer-helm-runtime-missing-tls.err"
+RUNTIME_OUT="${TMP_DIR}/choreographer-helm-runtime.yaml"
+
+if helm template choreographer "${CHART_PATH}" \
+  --set image.tag=v0 \
+  --set executor.kind=runtime \
+  > /dev/null 2>"${RUNTIME_MISSING_ENDPOINT_ERR}"; then
+  echo "executor.kind=runtime without endpoint render unexpectedly succeeded" >&2
+  exit 1
+fi
+grep -q "executor.kind=runtime but executor.runtime.endpoint is empty" "${RUNTIME_MISSING_ENDPOINT_ERR}"
+
+if helm template choreographer "${CHART_PATH}" \
+  --set image.tag=v0 \
+  --set executor.kind=runtime \
+  --set executor.runtime.endpoint=https://underpass-runtime:50053 \
+  --set executor.runtime.tls.mode=server \
+  > /dev/null 2>"${RUNTIME_MISSING_TLS_ERR}"; then
+  echo "runtime TLS without existingSecret render unexpectedly succeeded" >&2
+  exit 1
+fi
+grep -q "executor.runtime.tls.mode != disabled but executor.runtime.tls.existingSecret is empty" "${RUNTIME_MISSING_TLS_ERR}"
+
+helm template choreographer "${CHART_PATH}" \
+  -f "${UNDERPASS_RUNTIME_VALUES}" \
+  --set image.tag=v0 \
+  > "${RUNTIME_OUT}"
+
+runtime_markers=(
+  'name: CHOREO_EXECUTOR_KIND'
+  'value: "runtime"'
+  'name: CHOREO_RUNTIME_GRPC_ENDPOINT'
+  'value: "https://underpass-runtime:50053"'
+  'name: CHOREO_RUNTIME_PRINCIPAL_TENANT_ID'
+  'value: "underpass"'
+  'name: CHOREO_RUNTIME_PRINCIPAL_ACTOR_ID'
+  'value: "choreographer"'
+  'name: CHOREO_RUNTIME_PRINCIPAL_ROLES'
+  'value: "orchestrator"'
+  'name: CHOREO_RUNTIME_TLS_MODE'
+  'value: "mutual"'
+  'name: CHOREO_RUNTIME_TLS_CA_PATH'
+  'value: "/etc/choreographer/runtime-tls/ca.crt"'
+  'name: CHOREO_RUNTIME_TLS_CERT_PATH'
+  'value: "/etc/choreographer/runtime-tls/tls.crt"'
+  'name: CHOREO_RUNTIME_TLS_KEY_PATH'
+  'value: "/etc/choreographer/runtime-tls/tls.key"'
+  'name: CHOREO_RUNTIME_TLS_DOMAIN_NAME'
+  'value: "underpass-runtime"'
+  'name: runtime-tls'
+  'secretName: "choreographer-runtime-client-tls"'
+  'mountPath: /etc/choreographer/runtime-tls'
+)
+for marker in "${runtime_markers[@]}"; do
+  if ! grep -qF -- "${marker}" "${RUNTIME_OUT}"; then
+    echo "runtime executor chart manifest missing required marker: ${marker}" >&2
+    exit 1
+  fi
+done
+
+# --- Gate 7: Postgres secret profile. Persistence must be sourced
+# through valueFrom.secretKeyRef, not through a literal DSN in the
+# rendered Deployment.
+
+POSTGRES_SECRET_OUT="${TMP_DIR}/choreographer-helm-postgres-secret.yaml"
+
+helm template choreographer "${CHART_PATH}" \
+  -f "${POSTGRES_SECRET_VALUES}" \
+  --set image.tag=v0 \
+  > "${POSTGRES_SECRET_OUT}"
+
+postgres_secret_markers=(
+  'name: CHOREO_POSTGRES_URL'
+  'valueFrom:'
+  'secretKeyRef:'
+  'name: "choreographer-postgres-dsn"'
+  'key: "url"'
+)
+for marker in "${postgres_secret_markers[@]}"; do
+  if ! grep -qF -- "${marker}" "${POSTGRES_SECRET_OUT}"; then
+    echo "postgres secret chart manifest missing required marker: ${marker}" >&2
+    exit 1
+  fi
+done
+
+if grep -qF 'postgres://' "${POSTGRES_SECRET_OUT}"; then
+  echo "postgres secret profile rendered a literal Postgres DSN" >&2
+  exit 1
+fi
+
+# --- Gate 8: provider env secret wiring. Provider configuration must
+# support envFrom Secret overlays and per-key secretKeyRef env entries.
+
+PROVIDER_ENVFROM_OUT="${TMP_DIR}/choreographer-helm-provider-envfrom.yaml"
+PROVIDER_ENV_OUT="${TMP_DIR}/choreographer-helm-provider-env.yaml"
+
+helm template choreographer "${CHART_PATH}" \
+  -f "${EMBEDDED_NATS_VALUES}" \
+  -f "${PROVIDER_ENV_VALUES}" \
+  --set image.tag=v0 \
+  > "${PROVIDER_ENVFROM_OUT}"
+
+provider_envfrom_markers=(
+  'envFrom:'
+  'secretRef:'
+  'name: choreographer-provider-env'
+)
+for marker in "${provider_envfrom_markers[@]}"; do
+  if ! grep -qF -- "${marker}" "${PROVIDER_ENVFROM_OUT}"; then
+    echo "provider envFrom chart manifest missing required marker: ${marker}" >&2
+    exit 1
+  fi
+done
+
+helm template choreographer "${CHART_PATH}" \
+  -f "${EMBEDDED_NATS_VALUES}" \
+  --set image.tag=v0 \
+  --set 'providerEnv[0].name=CHOREO_OPENAI_API_KEY' \
+  --set 'providerEnv[0].valueFrom.secretKeyRef.name=choreographer-openai' \
+  --set 'providerEnv[0].valueFrom.secretKeyRef.key=api-key' \
+  --set 'providerEnv[1].name=CHOREO_OPENAI_MODEL' \
+  --set 'providerEnv[1].value=gpt-4o-mini' \
+  > "${PROVIDER_ENV_OUT}"
+
+provider_env_markers=(
+  'name: CHOREO_OPENAI_API_KEY'
+  'secretKeyRef:'
+  'name: choreographer-openai'
+  'key: api-key'
+  'name: CHOREO_OPENAI_MODEL'
+  'value: gpt-4o-mini'
+)
+for marker in "${provider_env_markers[@]}"; do
+  if ! grep -qF -- "${marker}" "${PROVIDER_ENV_OUT}"; then
+    echo "provider env chart manifest missing required marker: ${marker}" >&2
     exit 1
   fi
 done

--- a/scripts/ci/publish-dry-run.sh
+++ b/scripts/ci/publish-dry-run.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Publish dry-run gate for the two crates that ship to crates.io:
+#   - `choreo-mcp-proto` (vendored proto crate)
+#   - `choreo-mcp`       (stdio MCP adapter)
+#
+# Catches packaging regressions (missing metadata, missing files,
+# accidental path-only deps) before the publish-distribution
+# workflow tries to push to crates.io.
+#
+# `choreo-mcp-proto` uses the full `cargo publish --dry-run` flow:
+# compiles the staged tarball as a stand-alone crate.
+#
+# `choreo-mcp` does NOT — it depends on `choreo-mcp-proto` which is
+# not yet on the registry, so cargo's pre-publish verify step would
+# always fail. The real publish-distribution workflow serializes the
+# two jobs (proto first, then mcp with a 30s wait for index
+# propagation), which is the only way registry-order deps can land.
+# Here we run `cargo package -l` to validate the file list + the
+# `Cargo.toml` metadata; that catches missing keys / accidental
+# excludes without the registry round-trip.
+#
+# No CARGO_REGISTRY_TOKEN required — neither command uploads.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT_DIR}"
+
+echo "::group::cargo publish --dry-run -p choreo-mcp-proto"
+cargo publish --dry-run -p choreo-mcp-proto
+echo "::endgroup::"
+
+echo "::group::cargo package -l -p choreo-mcp"
+cargo package --list -p choreo-mcp
+echo "::endgroup::"

--- a/scripts/mcp/install-choreo-mcp.sh
+++ b/scripts/mcp/install-choreo-mcp.sh
@@ -1,44 +1,70 @@
 #!/usr/bin/env bash
 #
-# Install the `choreo-mcp` binary from a Git remote via `cargo install`.
-# Supports pinning to a branch, tag, or revision via env vars (mutually
-# exclusive). Designed as the canonical end-user install path until
-# the crate is published to crates.io.
+# Install the `choreo-mcp` binary.
+#
+# Two modes, controlled by `CHOREO_MCP_INSTALL_MODE`:
+#
+#   - `registry` (default): `cargo install choreo-mcp` from crates.io.
+#                           This is the canonical end-user path. The
+#                           first registry release lands the next time
+#                           a `v*` tag is pushed.
+#   - `git`:                `cargo install --git ...` from the source
+#                           repository. Supports pinning to a branch,
+#                           tag, or revision via env vars (mutually
+#                           exclusive). Use this when validating an
+#                           unreleased change against a checkout.
 #
 # Usage:
-#   bash scripts/mcp/install-choreo-mcp.sh
-#   CHOREO_MCP_TAG=v0.1.0 bash scripts/mcp/install-choreo-mcp.sh
-#   CHOREO_MCP_BRANCH=main bash scripts/mcp/install-choreo-mcp.sh
-#   CHOREO_MCP_REV=<git-sha> bash scripts/mcp/install-choreo-mcp.sh
+#   bash scripts/mcp/install-choreo-mcp.sh                    # registry
+#   CHOREO_MCP_INSTALL_MODE=git    bash scripts/mcp/install-choreo-mcp.sh
+#   CHOREO_MCP_INSTALL_MODE=git CHOREO_MCP_TAG=v0.1.0    bash …
+#   CHOREO_MCP_INSTALL_MODE=git CHOREO_MCP_BRANCH=main   bash …
+#   CHOREO_MCP_INSTALL_MODE=git CHOREO_MCP_REV=<git-sha> bash …
 #
 # CARGO_INSTALL_ROOT (optional): change where cargo writes the binary.
 
 set -euo pipefail
 
-GIT_URL="${CHOREO_MCP_GIT_URL:-https://github.com/underpass-ai/underpass-choreographer}"
-BRANCH="${CHOREO_MCP_BRANCH:-}"
-TAG="${CHOREO_MCP_TAG:-}"
-REV="${CHOREO_MCP_REV:-}"
+MODE="${CHOREO_MCP_INSTALL_MODE:-registry}"
 
-selected_refs=0
-[[ -n "${BRANCH}" ]] && selected_refs=$((selected_refs + 1))
-[[ -n "${TAG}" ]] && selected_refs=$((selected_refs + 1))
-[[ -n "${REV}" ]] && selected_refs=$((selected_refs + 1))
+case "${MODE}" in
+  registry)
+    cmd=(cargo install choreo-mcp --locked --force)
+    if [[ -n "${CHOREO_MCP_VERSION:-}" ]]; then
+      cmd+=(--version "${CHOREO_MCP_VERSION}")
+    fi
+    ;;
+  git)
+    GIT_URL="${CHOREO_MCP_GIT_URL:-https://github.com/underpass-ai/underpass-choreographer}"
+    BRANCH="${CHOREO_MCP_BRANCH:-}"
+    TAG="${CHOREO_MCP_TAG:-}"
+    REV="${CHOREO_MCP_REV:-}"
 
-if [[ "${selected_refs}" -gt 1 ]]; then
-  echo "set only one of CHOREO_MCP_BRANCH, CHOREO_MCP_TAG, or CHOREO_MCP_REV" >&2
-  exit 2
-fi
+    selected_refs=0
+    [[ -n "${BRANCH}" ]] && selected_refs=$((selected_refs + 1))
+    [[ -n "${TAG}" ]] && selected_refs=$((selected_refs + 1))
+    [[ -n "${REV}" ]] && selected_refs=$((selected_refs + 1))
 
-cmd=(cargo install --git "${GIT_URL}" choreo-mcp --locked --force)
+    if [[ "${selected_refs}" -gt 1 ]]; then
+      echo "set only one of CHOREO_MCP_BRANCH, CHOREO_MCP_TAG, or CHOREO_MCP_REV" >&2
+      exit 2
+    fi
 
-if [[ -n "${BRANCH}" ]]; then
-  cmd+=(--branch "${BRANCH}")
-elif [[ -n "${TAG}" ]]; then
-  cmd+=(--tag "${TAG}")
-elif [[ -n "${REV}" ]]; then
-  cmd+=(--rev "${REV}")
-fi
+    cmd=(cargo install --git "${GIT_URL}" choreo-mcp --locked --force)
+
+    if [[ -n "${BRANCH}" ]]; then
+      cmd+=(--branch "${BRANCH}")
+    elif [[ -n "${TAG}" ]]; then
+      cmd+=(--tag "${TAG}")
+    elif [[ -n "${REV}" ]]; then
+      cmd+=(--rev "${REV}")
+    fi
+    ;;
+  *)
+    echo "unknown CHOREO_MCP_INSTALL_MODE: ${MODE} (expected: registry, git)" >&2
+    exit 2
+    ;;
+esac
 
 if [[ -n "${CARGO_INSTALL_ROOT:-}" ]]; then
   cmd+=(--root "${CARGO_INSTALL_ROOT}")

--- a/tests/cluster/e2e-job.yaml
+++ b/tests/cluster/e2e-job.yaml
@@ -1,25 +1,19 @@
 # Runs the `choreo-e2e-runner` binary as a Kubernetes Job against a
 # choreographer deployed in-cluster. Useful as a smoke test after a
-# `helm upgrade --install`: the same scenarios that compose runs
-# locally, now driven through real DNS, real network, and a real
-# `RuntimeExecutor` connection.
+# `helm upgrade --install`: scenarios 1-4 are driven through real DNS,
+# real network, and the cluster's NATS connection.
 #
 # Caveats:
 #
-# - Scenarios 1–4 cover gRPC + NATS + causal metadata against the
+# - Scenarios 1-4 cover gRPC + NATS + causal metadata against the
 #   real deploy. They pass when the choreographer is wired correctly
 #   to its own NATS bus.
 #
-# - Scenarios 5-9 in the current e2e-runner are compose-shaped:
-#   scenario 5 expects a Runtime tool named `stub.echo`, scenarios
-#   8-9 expect the `stub-llm` OpenAI-compatible sidecar, and
-#   scenario 6 asserts strict rejection of free-form NoopAgent
-#   output. Against a real `underpass-runtime`, `stub.echo` is not
-#   normally in the catalog, so scenario 5 can surface
-#   `NotFound: runtime resource` — proving the gRPC mTLS path was
-#   reached, but failing the assertion. Treat this Job as a targeted
-#   connectivity smoke unless the namespace also provides equivalent
-#   test fixtures.
+# - Scenarios 5-9 are fixture-shaped and stay opt-in: scenario 5
+#   expects a Runtime tool named `stub.echo`, and scenarios 8-9 expect
+#   the `stub-llm` OpenAI-compatible sidecar. Run `runtime-stub`,
+#   `structured-output`, or `compose` only in clusters that provide
+#   equivalent fixtures or real matching services.
 #
 # Apply after `helm upgrade --install`. The Job's TTL cleans the
 # resource after 10 min.
@@ -58,5 +52,7 @@ spec:
               value: "nats://choreographer-nats:4222"
             - name: CHOREO_SEED_SPECIALTY
               value: "triage"
+            - name: CHOREO_E2E_SCENARIOS
+              value: "cluster-connectivity"
             - name: RUST_LOG
               value: "info"

--- a/tests/e2e/docker-compose.e2e.yaml
+++ b/tests/e2e/docker-compose.e2e.yaml
@@ -88,6 +88,9 @@ services:
     environment:
       CHOREOGRAPHER_ENDPOINT: "http://choreographer:50055"
       CHOREO_SEED_SPECIALTY: "triage"
+      # Full 1-9 suite by default. Override from the host with, e.g.,
+      # `CHOREO_E2E_SCENARIOS=cluster-connectivity make e2e-compose`.
+      CHOREO_E2E_SCENARIOS: "${CHOREO_E2E_SCENARIOS:-compose}"
       # Pinned to the path that runner.Dockerfile copies into the
       # image. Scenario 8 reads the canonical Report schema from
       # here; failing back to an env-overridable path keeps the

--- a/tests/e2e/kubernetes/council-vllm-job.yaml
+++ b/tests/e2e/kubernetes/council-vllm-job.yaml
@@ -1,0 +1,77 @@
+# Choreographer E2E Job: multi-agent council against real vLLM.
+#
+# Applies into the namespace that already runs Choreographer and vLLM.
+# The Job drives Choreographer over gRPC, registers multiple `kind=vllm`
+# agents, creates a council, and runs `RunCouncilDecision` in Strict mode.
+#
+# Launch: `make e2e-council-vllm` (applies this manifest, waits for
+# completion, tails logs, deletes the Job).
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: choreographer-e2e-council-vllm
+  labels:
+    app.kubernetes.io/name: choreographer-e2e-council-vllm
+    app.kubernetes.io/part-of: underpass
+    provider: vllm
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: choreographer-e2e-council-vllm
+        provider: vllm
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: runner
+          image: ghcr.io/underpass-ai/underpass-choreographer-e2e-runner:latest
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: CHOREO_E2E_SCENARIOS
+              value: vllm-real-multi-agent
+            - name: CHOREOGRAPHER_ENDPOINT
+              value: http://choreographer:50055
+            - name: CHOREO_VLLM_ENDPOINT
+              value: http://underpass-llm-gemma-4-31b-structured:8000
+            - name: CHOREO_VLLM_MODEL
+              value: google/gemma-4-31B-it
+            - name: CHOREO_VLLM_AGENT_COUNT
+              value: "3"
+            - name: CHOREO_VLLM_MAX_TOKENS
+              value: "512"
+            - name: CHOREO_VLLM_TIMEOUT_SECS
+              value: "300"
+            - name: RUST_LOG
+              value: info
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+      volumes:
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 32Mi

--- a/tests/e2e/kubernetes/runner-job.yaml
+++ b/tests/e2e/kubernetes/runner-job.yaml
@@ -32,6 +32,8 @@ spec:
               value: http://choreographer:50055
             - name: CHOREO_SEED_SPECIALTY
               value: triage
+            - name: CHOREO_E2E_SCENARIOS
+              value: cluster-connectivity
             - name: RUST_LOG
               value: info
           resources:


### PR DESCRIPTION
## Summary

This PR packages the local publication-readiness work into four reviewable slices:

- selectable E2E/provider scenarios, including scenario groups, positive consumer smoke, and a real vLLM multi-agent council path
- MCP crates.io distribution readiness through a vendored `choreo-mcp-proto` crate, publish gates, install docs, and a real-kernel integration test
- hardened Helm/Kubernetes deployment profiles for minimal, embedded NATS, Postgres secret, provider env secrets, and Runtime executor modes
- publication support docs: changelog, contributing guide, security policy, support matrix, README/dev-loop/backlog/checklist updates

## Why

The project had the implementation and RC evidence split across local files and the older `feat/bundle-b-mcp-distribution` branch. This reconciles the MCP publishing strategy around `choreo-mcp-proto`, keeps the internal `choreo-proto` crate unpublished, and records the remaining release blockers explicitly.

## Validation

- `cargo check -p choreo-e2e-runner -p choreo-consumer-smoke -p choreo-mcp-proto -p choreo-mcp --locked`
- `cargo check -p choreo-mcp-proto -p choreo-mcp --locked`
- `cargo test -p choreo-mcp --locked`
- `cargo test -p choreo-mcp --locked --features container-tests --no-run`
- `cargo publish --dry-run -p choreo-mcp-proto --allow-dirty`
- `cargo package --list -p choreo-mcp --allow-dirty`
- `cargo fmt --check`
- `git diff --check HEAD~4..HEAD`

## Notes

`cargo publish --dry-run -p choreo-mcp` still requires `choreo-mcp-proto v0.1.0` to exist in crates.io first. The release workflow publishes the proto crate before the MCP crate and waits for registry propagation.