### PR TITLE
Run ceremony steps through councils

### DIFF
--- a/crates/choreo-adapters/src/ceremony/deliberating_ceremony_step_handler.rs
+++ b/crates/choreo-adapters/src/ceremony/deliberating_ceremony_step_handler.rs
@@ -1,0 +1,275 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use choreo_app::usecases::DeliberateUseCase;
+use choreo_core::entities::{Task, TaskConstraints};
+use choreo_core::error::DomainError;
+use choreo_core::ports::{CeremonyStepHandlerPort, CeremonyStepHandlerRequest};
+use choreo_core::value_objects::{Attributes, StepOutput, StepResult, TaskId};
+use serde_json::{json, Value};
+use tracing::info;
+
+use super::DeliberationStepConfig;
+
+#[derive(Debug, Clone)]
+pub struct DeliberatingCeremonyStepHandler {
+    deliberate: Arc<DeliberateUseCase>,
+}
+
+impl DeliberatingCeremonyStepHandler {
+    #[must_use]
+    pub fn new(deliberate: Arc<DeliberateUseCase>) -> Self {
+        Self { deliberate }
+    }
+}
+
+#[async_trait]
+impl CeremonyStepHandlerPort for DeliberatingCeremonyStepHandler {
+    async fn execute(
+        &self,
+        request: CeremonyStepHandlerRequest,
+    ) -> Result<StepResult, DomainError> {
+        let config = DeliberationStepConfig::from_request(&request)?;
+        let task = task_from(&request, &config)?;
+        let output = self.deliberate.execute(task).await?;
+        let ranked = output.deliberation.ranked_outcomes()?;
+        let winner = ranked
+            .iter()
+            .find(|candidate| candidate.proposal().id() == &output.winner_proposal_id)
+            .ok_or(DomainError::InvariantViolated {
+                reason: "ceremony step winner proposal is missing from ranked outcomes",
+            })?;
+
+        info!(
+            ceremony_id = request.instance_id().as_str(),
+            step_id = request.step_id().as_str(),
+            specialty = config.specialty().as_str(),
+            winner_proposal_id = winner.proposal().id().as_str(),
+            "ceremony step deliberation completed"
+        );
+
+        StepResult::completed(StepOutput::new(Attributes::new(output_attributes(
+            &request,
+            &output.winner_proposal_id,
+            winner.proposal().content(),
+            ranked.len(),
+        ))?))
+    }
+}
+
+fn task_from(
+    request: &CeremonyStepHandlerRequest,
+    config: &DeliberationStepConfig,
+) -> Result<Task, DomainError> {
+    Ok(Task::new(
+        task_id_from(request)?,
+        config.specialty().clone(),
+        config.task_description().clone(),
+        TaskConstraints::new(
+            choreo_core::value_objects::Rubric::empty(),
+            config.rounds(),
+            config.num_agents(),
+            None,
+        ),
+        Attributes::new(task_attributes(request, config))?,
+    ))
+}
+
+fn task_id_from(request: &CeremonyStepHandlerRequest) -> Result<TaskId, DomainError> {
+    TaskId::new(format!(
+        "ceremony-{}-{}-{}",
+        request.instance_id().as_str(),
+        request.step_id().as_str(),
+        request.attempt().get()
+    ))
+}
+
+fn task_attributes(
+    request: &CeremonyStepHandlerRequest,
+    config: &DeliberationStepConfig,
+) -> BTreeMap<String, Value> {
+    let mut attributes = request.context().attributes().as_map().clone();
+    attributes.insert(
+        "ceremony.instance_id".to_owned(),
+        json!(request.instance_id().as_str()),
+    );
+    attributes.insert(
+        "ceremony.definition_name".to_owned(),
+        json!(request.definition_name().as_str()),
+    );
+    attributes.insert(
+        "ceremony.definition_version".to_owned(),
+        json!(request.definition_version().as_str()),
+    );
+    attributes.insert(
+        "ceremony.current_state".to_owned(),
+        json!(request.current_state().as_str()),
+    );
+    attributes.insert(
+        "ceremony.step_id".to_owned(),
+        json!(request.step_id().as_str()),
+    );
+    attributes.insert(
+        "ceremony.handler_kind".to_owned(),
+        json!(request.handler_kind().as_str()),
+    );
+    attributes.insert(
+        "ceremony.deliberation_specialty".to_owned(),
+        json!(config.specialty().as_str()),
+    );
+    attributes.insert(
+        "ceremony.attempt".to_owned(),
+        json!(request.attempt().get()),
+    );
+    attributes
+}
+
+fn output_attributes(
+    request: &CeremonyStepHandlerRequest,
+    winner_proposal_id: &choreo_core::value_objects::ProposalId,
+    winner_content: &str,
+    candidates_total: usize,
+) -> BTreeMap<String, Value> {
+    BTreeMap::from([
+        (
+            "task_id".to_owned(),
+            json!(format!(
+                "ceremony-{}-{}-{}",
+                request.instance_id().as_str(),
+                request.step_id().as_str(),
+                request.attempt().get()
+            )),
+        ),
+        (
+            "winner_proposal_id".to_owned(),
+            json!(winner_proposal_id.as_str()),
+        ),
+        ("winner_content".to_owned(), json!(winner_content)),
+        (
+            "candidates_total".to_owned(),
+            json!(u64::try_from(candidates_total).unwrap_or(u64::MAX)),
+        ),
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    use choreo_app::usecases::DeliberateUseCase;
+    use choreo_core::entities::Council;
+    use choreo_core::ports::{ClockPort, CouncilRegistryPort, StatisticsPort};
+    use choreo_core::value_objects::{
+        AgentId, Attributes, CeremonyContext, CeremonyId, CeremonyName, CeremonyVersion, CouncilId,
+        Specialty, StateId, StepAttempt, StepHandlerConfig, StepHandlerKind, StepId, StepStatus,
+    };
+    use serde_json::json;
+
+    use crate::clock::SystemClock;
+    use crate::memory::{
+        InMemoryAgentRegistry, InMemoryCouncilRegistry, InMemoryDeliberationRepository,
+        InMemoryStatistics,
+    };
+    use crate::noop::{NoopAgent, NoopMessaging};
+    use crate::scoring::UniformScoring;
+    use crate::validators::ContentNonEmptyValidator;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn executes_step_by_running_deliberation_for_configured_specialty() {
+        let specialty = Specialty::new("facilitation_prompt").unwrap();
+        let agent_id = AgentId::new("agent-facilitation_prompt-0").unwrap();
+        let agent_registry = Arc::new(InMemoryAgentRegistry::new());
+        agent_registry
+            .insert(Arc::new(NoopAgent::new(
+                agent_id.clone(),
+                specialty.clone(),
+            )))
+            .await
+            .unwrap();
+
+        let council_registry = Arc::new(InMemoryCouncilRegistry::new());
+        council_registry
+            .register(
+                Council::new(
+                    CouncilId::new("council-facilitation_prompt").unwrap(),
+                    specialty.clone(),
+                    vec![agent_id],
+                    SystemClock::new().now(),
+                )
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let statistics = Arc::new(InMemoryStatistics::new());
+        let deliberate = Arc::new(DeliberateUseCase::new(
+            Arc::new(SystemClock::new()),
+            council_registry,
+            agent_registry,
+            vec![Arc::new(ContentNonEmptyValidator::new())],
+            Arc::new(UniformScoring::new()),
+            Arc::new(InMemoryDeliberationRepository::new()),
+            Arc::new(NoopMessaging::new()),
+            statistics.clone(),
+            "ceremony-step-handler-test",
+        ));
+        let handler = DeliberatingCeremonyStepHandler::new(deliberate);
+
+        let result = handler.execute(request_with_prompt()).await.unwrap();
+
+        assert_eq!(result.status(), StepStatus::Completed);
+        let attributes = result.output().attributes();
+        assert_eq!(
+            attributes.get("task_id").and_then(|value| value.as_str()),
+            Some("ceremony-ceremony-1-open_room-1")
+        );
+        assert!(attributes
+            .get("winner_proposal_id")
+            .and_then(|value| value.as_str())
+            .is_some());
+        assert!(attributes
+            .get("winner_content")
+            .and_then(|value| value.as_str())
+            .is_some_and(|content| content.contains("Open the meeting")));
+        assert_eq!(
+            attributes
+                .get("candidates_total")
+                .and_then(serde_json::Value::as_u64),
+            Some(1)
+        );
+        assert_eq!(
+            statistics
+                .snapshot()
+                .await
+                .unwrap()
+                .per_specialty()
+                .get(&specialty)
+                .copied(),
+            Some(1)
+        );
+    }
+
+    fn request_with_prompt() -> CeremonyStepHandlerRequest {
+        CeremonyStepHandlerRequest::new(
+            CeremonyId::new("ceremony-1").unwrap(),
+            CeremonyName::new("editorial").unwrap(),
+            CeremonyVersion::v1(),
+            StateId::new("OPENING").unwrap(),
+            StepId::new("open_room").unwrap(),
+            StepHandlerKind::new("facilitation_prompt").unwrap(),
+            StepHandlerConfig::new(
+                Attributes::new(BTreeMap::from([
+                    ("prompt".to_owned(), json!("Open the meeting")),
+                    ("num_agents".to_owned(), json!(1)),
+                ]))
+                .unwrap(),
+            ),
+            CeremonyContext::empty(),
+            StepAttempt::FIRST,
+        )
+    }
+}

--- a/crates/choreo-adapters/src/ceremony/deliberation_step_config.rs
+++ b/crates/choreo-adapters/src/ceremony/deliberation_step_config.rs
@@ -1,0 +1,167 @@
+use choreo_core::error::DomainError;
+use choreo_core::ports::CeremonyStepHandlerRequest;
+use choreo_core::value_objects::{NumAgents, Rounds, Specialty, TaskDescription};
+use serde_json::Value;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeliberationStepConfig {
+    specialty: Specialty,
+    task_description: TaskDescription,
+    rounds: Rounds,
+    num_agents: Option<NumAgents>,
+}
+
+impl DeliberationStepConfig {
+    pub fn from_request(request: &CeremonyStepHandlerRequest) -> Result<Self, DomainError> {
+        let attributes = request.handler_config().attributes();
+        let task_description = TaskDescription::new(required_string(
+            attributes.get("prompt"),
+            "ceremony_step.config.prompt",
+        )?)?;
+        let specialty = Specialty::new(
+            optional_string(attributes.get("specialty")).unwrap_or(request.handler_kind().as_str()),
+        )?;
+        let rounds = optional_u32(attributes.get("rounds"), "ceremony_step.config.rounds")?
+            .map(Rounds::new)
+            .transpose()?
+            .unwrap_or_default();
+        let num_agents = optional_u32(
+            attributes.get("num_agents"),
+            "ceremony_step.config.num_agents",
+        )?
+        .map(NumAgents::new)
+        .transpose()?;
+
+        Ok(Self {
+            specialty,
+            task_description,
+            rounds,
+            num_agents,
+        })
+    }
+
+    #[must_use]
+    pub fn specialty(&self) -> &Specialty {
+        &self.specialty
+    }
+
+    #[must_use]
+    pub fn task_description(&self) -> &TaskDescription {
+        &self.task_description
+    }
+
+    #[must_use]
+    pub fn rounds(&self) -> Rounds {
+        self.rounds
+    }
+
+    #[must_use]
+    pub fn num_agents(&self) -> Option<NumAgents> {
+        self.num_agents
+    }
+}
+
+fn required_string(value: Option<&Value>, field: &'static str) -> Result<String, DomainError> {
+    let Some(value) = value else {
+        return Err(DomainError::EmptyField { field });
+    };
+    let Some(raw) = value.as_str() else {
+        return Err(DomainError::InvalidCharacters { field });
+    };
+    if raw.trim().is_empty() {
+        return Err(DomainError::EmptyField { field });
+    }
+    Ok(raw.to_owned())
+}
+
+fn optional_string(value: Option<&Value>) -> Option<&str> {
+    value
+        .and_then(Value::as_str)
+        .filter(|raw| !raw.trim().is_empty())
+}
+
+fn optional_u32(value: Option<&Value>, field: &'static str) -> Result<Option<u32>, DomainError> {
+    let Some(value) = value else { return Ok(None) };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let Some(raw) = value.as_u64() else {
+        return Err(DomainError::InvalidCharacters { field });
+    };
+    u32::try_from(raw)
+        .map(Some)
+        .map_err(|_| DomainError::OutOfRange {
+            field,
+            value: raw as f64,
+            min: 0.0,
+            max: f64::from(u32::MAX),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use choreo_core::value_objects::{
+        Attributes, CeremonyContext, CeremonyId, CeremonyName, CeremonyVersion, StateId,
+        StepAttempt, StepHandlerConfig, StepHandlerKind, StepId,
+    };
+    use serde_json::json;
+
+    use super::*;
+
+    fn request(config: BTreeMap<String, Value>) -> CeremonyStepHandlerRequest {
+        CeremonyStepHandlerRequest::new(
+            CeremonyId::new("ceremony-1").unwrap(),
+            CeremonyName::new("editorial").unwrap(),
+            CeremonyVersion::v1(),
+            StateId::new("OPENING").unwrap(),
+            StepId::new("open_room").unwrap(),
+            StepHandlerKind::new("facilitation_prompt").unwrap(),
+            StepHandlerConfig::new(Attributes::new(config).unwrap()),
+            CeremonyContext::empty(),
+            StepAttempt::FIRST,
+        )
+    }
+
+    #[test]
+    fn defaults_specialty_to_handler_kind() {
+        let config = DeliberationStepConfig::from_request(&request(BTreeMap::from([(
+            "prompt".to_owned(),
+            json!("Open the meeting"),
+        )])))
+        .unwrap();
+
+        assert_eq!(config.specialty().as_str(), "facilitation_prompt");
+        assert_eq!(config.task_description().as_str(), "Open the meeting");
+        assert_eq!(config.rounds().get(), 1);
+        assert!(config.num_agents().is_none());
+    }
+
+    #[test]
+    fn accepts_explicit_specialty_and_bounds() {
+        let config = DeliberationStepConfig::from_request(&request(BTreeMap::from([
+            ("prompt".to_owned(), json!("Open the meeting")),
+            ("specialty".to_owned(), json!("facilitator")),
+            ("rounds".to_owned(), json!(0)),
+            ("num_agents".to_owned(), json!(1)),
+        ])))
+        .unwrap();
+
+        assert_eq!(config.specialty().as_str(), "facilitator");
+        assert_eq!(config.rounds().get(), 0);
+        assert_eq!(config.num_agents().unwrap().get(), 1);
+    }
+
+    #[test]
+    fn rejects_missing_prompt() {
+        let err = DeliberationStepConfig::from_request(&request(BTreeMap::new())).unwrap_err();
+
+        assert!(matches!(
+            err,
+            DomainError::EmptyField {
+                field: "ceremony_step.config.prompt"
+            }
+        ));
+    }
+}

--- a/crates/choreo-adapters/src/ceremony/mod.rs
+++ b/crates/choreo-adapters/src/ceremony/mod.rs
@@ -1,0 +1,5 @@
+mod deliberating_ceremony_step_handler;
+mod deliberation_step_config;
+
+pub use deliberating_ceremony_step_handler::DeliberatingCeremonyStepHandler;
+pub use deliberation_step_config::DeliberationStepConfig;

--- a/crates/choreo-adapters/src/lib.rs
+++ b/crates/choreo-adapters/src/lib.rs
@@ -35,6 +35,7 @@
 
 #![deny(missing_debug_implementations)]
 
+pub mod ceremony;
 pub mod clock;
 pub mod config;
 pub mod memory;

--- a/crates/choreo-e2e-runner/src/scenarios/ceremony_diagram.rs
+++ b/crates/choreo-e2e-runner/src/scenarios/ceremony_diagram.rs
@@ -1,7 +1,10 @@
 use anyhow::{bail, Context, Result};
 use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
-use choreo_proto::v1::RunCeremonyRequest;
+use choreo_proto::v1::{
+    AgentSummary, CreateCouncilRequest, RegisterAgentRequest, RunCeremonyRequest,
+};
 use tonic::transport::Channel;
+use tonic::Code;
 use tracing::info;
 
 const EDITORIAL_MEETING_CEREMONY: &str =
@@ -10,6 +13,15 @@ const EDITORIAL_MEETING_CEREMONY: &str =
 pub(crate) async fn verify_editorial_meeting_ceremony_diagram(
     client: &mut ChoreographerServiceClient<Channel>,
 ) -> Result<()> {
+    for specialty in [
+        "facilitation_prompt",
+        "persona_prompt",
+        "challenge_prompt",
+        "synthesis_prompt",
+    ] {
+        seed_single_noop_agent_council(client, specialty).await?;
+    }
+
     let response = client
         .run_ceremony(RunCeremonyRequest {
             ceremony_id: "e2e-editorial-planning-meeting".to_owned(),
@@ -70,4 +82,41 @@ pub(crate) async fn verify_editorial_meeting_ceremony_diagram(
         "editorial planning ceremony executed and rendered"
     );
     Ok(())
+}
+
+async fn seed_single_noop_agent_council(
+    client: &mut ChoreographerServiceClient<Channel>,
+    specialty: &str,
+) -> Result<()> {
+    let agent_id = format!("agent-{specialty}-0");
+    let register_agent = client
+        .register_agent(RegisterAgentRequest {
+            specialty: specialty.to_owned(),
+            agent: Some(AgentSummary {
+                agent_id,
+                specialty: specialty.to_owned(),
+                kind: "noop".to_owned(),
+                attributes: None,
+            }),
+            agent_config: None,
+        })
+        .await;
+    match register_agent {
+        Ok(_) => {}
+        Err(status) if status.code() == Code::AlreadyExists => {}
+        Err(status) => return Err(status).context("RegisterAgent failed for ceremony step"),
+    }
+
+    let create_council = client
+        .create_council(CreateCouncilRequest {
+            specialty: specialty.to_owned(),
+            num_agents: 1,
+            agent_config: None,
+        })
+        .await;
+    match create_council {
+        Ok(_) => Ok(()),
+        Err(status) if status.code() == Code::AlreadyExists => Ok(()),
+        Err(status) => Err(status).context("CreateCouncil failed for ceremony step"),
+    }
 }

--- a/crates/choreo-tests-integration/src/grpc_fixture.rs
+++ b/crates/choreo-tests-integration/src/grpc_fixture.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use choreo_adapters::agents::DispatchingAgentFactory;
+use choreo_adapters::ceremony::DeliberatingCeremonyStepHandler;
 use choreo_adapters::clock::SystemClock;
 use choreo_adapters::grpc::ChoreographerGrpcService;
 use choreo_adapters::memory::{
@@ -27,7 +28,7 @@ use choreo_adapters::memory::{
     InMemoryCeremonyInstanceRepository, InMemoryContractRegistry, InMemoryCouncilRegistry,
     InMemoryDeliberationRepository, InMemoryStatistics,
 };
-use choreo_adapters::noop::{NoopCeremonyStepHandler, NoopExecutor, NoopMessaging};
+use choreo_adapters::noop::{NoopExecutor, NoopMessaging};
 use choreo_adapters::scoring::UniformScoring;
 use choreo_adapters::validators::{
     AllowedStringValuesValidator, ContentNonEmptyValidator, JsonObjectOutputValidator,
@@ -107,8 +108,6 @@ impl GrpcFixture {
             Arc::new(InMemoryCeremonyDefinitionRepository::new());
         let ceremony_instances: Arc<dyn CeremonyInstanceRepositoryPort> =
             Arc::new(InMemoryCeremonyInstanceRepository::new());
-        let ceremony_step_handler: Arc<dyn CeremonyStepHandlerPort> =
-            Arc::new(NoopCeremonyStepHandler::new());
         let agent_registry = Arc::new(InMemoryAgentRegistry::new());
         let agent_resolver: Arc<dyn AgentResolverPort> = agent_registry.clone();
         // `new()` yields a factory that supports only the always-on
@@ -126,6 +125,8 @@ impl GrpcFixture {
             statistics.clone(),
             "choreographer-tests",
         ));
+        let ceremony_step_handler: Arc<dyn CeremonyStepHandlerPort> =
+            Arc::new(DeliberatingCeremonyStepHandler::new(deliberate.clone()));
         let orchestrate = Arc::new(OrchestrateUseCase::new(
             deliberate.clone(),
             executor,
@@ -259,8 +260,6 @@ impl GrpcFixture {
             Arc::new(InMemoryCeremonyDefinitionRepository::new());
         let ceremony_instances: Arc<dyn CeremonyInstanceRepositoryPort> =
             Arc::new(InMemoryCeremonyInstanceRepository::new());
-        let ceremony_step_handler: Arc<dyn CeremonyStepHandlerPort> =
-            Arc::new(NoopCeremonyStepHandler::new());
         let agent_registry = Arc::new(InMemoryAgentRegistry::new());
         let agent_resolver: Arc<dyn AgentResolverPort> = agent_registry.clone();
         let agent_factory = Arc::new(DispatchingAgentFactory::new());
@@ -276,6 +275,8 @@ impl GrpcFixture {
             statistics.clone(),
             "choreographer-tests",
         ));
+        let ceremony_step_handler: Arc<dyn CeremonyStepHandlerPort> =
+            Arc::new(DeliberatingCeremonyStepHandler::new(deliberate.clone()));
         let orchestrate = Arc::new(OrchestrateUseCase::new(
             deliberate.clone(),
             executor,

--- a/crates/choreo-tests-integration/tests/run_ceremony_rpc.rs
+++ b/crates/choreo-tests-integration/tests/run_ceremony_rpc.rs
@@ -1,5 +1,7 @@
 use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
-use choreo_proto::v1::RunCeremonyRequest;
+use choreo_proto::v1::{
+    AgentSummary, CreateCouncilRequest, RegisterAgentRequest, RunCeremonyRequest,
+};
 use choreo_tests_integration::grpc_fixture::GrpcFixture;
 
 const EDITORIAL_MEETING_CEREMONY: &str =
@@ -9,6 +11,14 @@ const EDITORIAL_MEETING_CEREMONY: &str =
 async fn run_ceremony_executes_yaml_and_returns_trace_diagram() {
     let fixture = GrpcFixture::start().await;
     let mut client = ChoreographerServiceClient::new(fixture.channel);
+    for specialty in [
+        "facilitation_prompt",
+        "persona_prompt",
+        "challenge_prompt",
+        "synthesis_prompt",
+    ] {
+        seed_single_noop_agent_council(&mut client, specialty).await;
+    }
 
     let response = client
         .run_ceremony(RunCeremonyRequest {
@@ -49,4 +59,32 @@ async fn run_ceremony_executes_yaml_and_returns_trace_diagram() {
     assert!(response
         .mermaid_sequence
         .contains("decision_summary [synthesis_prompt]"));
+}
+
+async fn seed_single_noop_agent_council(
+    client: &mut ChoreographerServiceClient<tonic::transport::Channel>,
+    specialty: &str,
+) {
+    let agent_id = format!("agent-{specialty}-0");
+    client
+        .register_agent(RegisterAgentRequest {
+            specialty: specialty.to_owned(),
+            agent: Some(AgentSummary {
+                agent_id,
+                specialty: specialty.to_owned(),
+                kind: "noop".to_owned(),
+                attributes: None,
+            }),
+            agent_config: None,
+        })
+        .await
+        .expect("RegisterAgent should seed ceremony agent");
+    client
+        .create_council(CreateCouncilRequest {
+            specialty: specialty.to_owned(),
+            num_agents: 1,
+            agent_config: None,
+        })
+        .await
+        .expect("CreateCouncil should seed ceremony council");
 }

--- a/crates/choreo/src/compose.rs
+++ b/crates/choreo/src/compose.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use choreo_adapters::agents::DispatchingAgentFactory;
+use choreo_adapters::ceremony::DeliberatingCeremonyStepHandler;
 use choreo_adapters::clock::SystemClock;
 use choreo_adapters::config::EnvConfiguration;
 use choreo_adapters::memory::{
@@ -11,7 +12,7 @@ use choreo_adapters::memory::{
     InMemoryDeliberationRepository, InMemoryStatistics,
 };
 use choreo_adapters::nats::{NatsConfig, NatsMessaging, NatsTriggerSubscriber};
-use choreo_adapters::noop::{NoopCeremonyStepHandler, NoopExecutor, NoopMessaging};
+use choreo_adapters::noop::{NoopExecutor, NoopMessaging};
 use choreo_adapters::postgres::{
     PostgresAgentRegistry, PostgresConfig, PostgresCouncilRegistry, PostgresDeliberationRepository,
     PostgresPool, PostgresPoolError, PostgresStatistics,
@@ -141,8 +142,6 @@ pub async fn compose() -> Result<Application, ComposeError> {
         Arc::new(InMemoryCeremonyDefinitionRepository::new());
     let ceremony_instances: Arc<dyn CeremonyInstanceRepositoryPort> =
         Arc::new(InMemoryCeremonyInstanceRepository::new());
-    let ceremony_step_handler: Arc<dyn CeremonyStepHandlerPort> =
-        Arc::new(NoopCeremonyStepHandler::new());
 
     let MessagingWiring {
         port: messaging,
@@ -161,6 +160,9 @@ pub async fn compose() -> Result<Application, ComposeError> {
         statistics.clone(),
         "choreographer",
     ));
+
+    let ceremony_step_handler: Arc<dyn CeremonyStepHandlerPort> =
+        Arc::new(DeliberatingCeremonyStepHandler::new(deliberate.clone()));
 
     let orchestrate = Arc::new(OrchestrateUseCase::new(
         deliberate.clone(),


### PR DESCRIPTION
## Summary
- add a ceremony step handler adapter that maps YAML step config to DeliberateUseCase tasks
- wire production and integration composition to use the deliberating handler instead of the no-op handler
- seed noop councils in ceremony gRPC/e2e tests so the four-step ceremony runs real deliberations

## Tests
- cargo test -p choreo-adapters --locked
- cargo test -p choreo-tests-integration --locked run_ceremony_executes_yaml_and_returns_trace_diagram
- cargo test -p choreo-e2e-runner --locked
- cargo test -p choreo --locked
- cargo clippy -p choreo-adapters -p choreo-tests-integration -p choreo-e2e-runner -p choreo --locked -- -D warnings