### PR TITLE
[codex] Add vLLM-backed ceremony E2E

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,5 +8,9 @@ docs/
 scripts/
 specs/
 tests/
+!tests/
+!tests/e2e/
+!tests/e2e/ceremonies/
+!tests/e2e/ceremonies/**
 *.md
 !README.md

--- a/crates/choreo-e2e-runner/src/main.rs
+++ b/crates/choreo-e2e-runner/src/main.rs
@@ -16,8 +16,9 @@ use scenario_selection::{
 use scenarios::{
     connect_with_retry, verify_causal_metadata_propagates_over_nats,
     verify_delete_missing_council_returns_false, verify_deliberate_returns_winner,
-    verify_editorial_meeting_ceremony_diagram, verify_external_context_bundle_round_trips,
-    verify_multi_agent_council_against_real_vllm, verify_orchestrate_invokes_runtime_executor,
+    verify_editorial_meeting_ceremony_against_vllm_kind, verify_editorial_meeting_ceremony_diagram,
+    verify_external_context_bundle_round_trips, verify_multi_agent_council_against_real_vllm,
+    verify_orchestrate_invokes_runtime_executor,
     verify_orchestrate_rejects_proposal_violating_json_schema, verify_seeded_council_visible,
     verify_structured_output_against_stub_llm, verify_structured_output_against_vllm_kind,
 };
@@ -132,6 +133,13 @@ async fn main() -> Result<()> {
         verify_editorial_meeting_ceremony_diagram(&mut client)
             .await
             .context("scenario 11 failed")?;
+    }
+
+    if selected_scenarios.contains(&E2eScenario::CeremonyVllm) {
+        info!("scenario 12: four-agent ceremony YAML executes through the vLLM adapter");
+        verify_editorial_meeting_ceremony_against_vllm_kind(&mut client)
+            .await
+            .context("scenario 12 failed")?;
     }
 
     info!("E2E scenarios passed");

--- a/crates/choreo-e2e-runner/src/scenario_selection.rs
+++ b/crates/choreo-e2e-runner/src/scenario_selection.rs
@@ -17,6 +17,7 @@ pub(crate) enum E2eScenario {
     VllmStructuredOutput,
     VllmRealMultiAgent,
     CeremonyDiagram,
+    CeremonyVllm,
 }
 
 impl E2eScenario {
@@ -37,6 +38,8 @@ impl E2eScenario {
     const VLLM_REAL: [Self; 1] = [Self::VllmRealMultiAgent];
 
     const CEREMONY: [Self; 1] = [Self::CeremonyDiagram];
+
+    const CEREMONY_VLLM: [Self; 1] = [Self::CeremonyVllm];
 
     const CLUSTER_CONNECTIVITY: [Self; 4] = [
         Self::SeededCouncil,
@@ -67,6 +70,7 @@ impl E2eScenario {
             Self::VllmStructuredOutput => 9,
             Self::VllmRealMultiAgent => 10,
             Self::CeremonyDiagram => 11,
+            Self::CeremonyVllm => 12,
         }
     }
 }
@@ -116,6 +120,10 @@ fn add_scenario_token(token: &str, selected: &mut BTreeSet<E2eScenario>) -> Resu
             selected.extend(E2eScenario::CEREMONY);
             return Ok(());
         }
+        "ceremony-vllm" | "meeting-ceremony-vllm" | "gemma-ceremony" => {
+            selected.extend(E2eScenario::CEREMONY_VLLM);
+            return Ok(());
+        }
         _ => {}
     }
 
@@ -141,7 +149,7 @@ fn add_scenario_token(token: &str, selected: &mut BTreeSet<E2eScenario>) -> Resu
     }
 
     bail!(
-        "unknown scenario selector `{token}`; expected compose, cluster-connectivity, runtime-stub, structured-output, vllm-real-multi-agent, 1-10, or a range like 1-4"
+        "unknown scenario selector `{token}`; expected compose, cluster-connectivity, runtime-stub, structured-output, vllm-real-multi-agent, ceremony-vllm, 1-12, or a range like 1-4"
     )
 }
 
@@ -158,7 +166,8 @@ fn scenario_from_number(number: u8) -> Result<E2eScenario> {
         9 => Ok(E2eScenario::VllmStructuredOutput),
         10 => Ok(E2eScenario::VllmRealMultiAgent),
         11 => Ok(E2eScenario::CeremonyDiagram),
-        _ => bail!("scenario number {number} is out of range; expected 1-11"),
+        12 => Ok(E2eScenario::CeremonyVllm),
+        _ => bail!("scenario number {number} is out of range; expected 1-12"),
     }
 }
 
@@ -201,6 +210,8 @@ mod tests {
         assert_eq!(numbers(Some("vllm-real-multi-agent")), vec![10]);
         assert_eq!(numbers(Some("council-vllm")), vec![10]);
         assert_eq!(numbers(Some("ceremony-diagram")), vec![11]);
+        assert_eq!(numbers(Some("ceremony-vllm")), vec![12]);
+        assert_eq!(numbers(Some("gemma-ceremony")), vec![12]);
     }
 
     #[test]
@@ -212,11 +223,12 @@ mod tests {
         );
         assert_eq!(numbers(Some("s10")), vec![10]);
         assert_eq!(numbers(Some("s11")), vec![11]);
+        assert_eq!(numbers(Some("s12")), vec![12]);
     }
 
     #[test]
     fn invalid_selection_is_rejected() {
-        assert!(parse_scenario_selection(Some("12")).is_err());
+        assert!(parse_scenario_selection(Some("13")).is_err());
         assert!(parse_scenario_selection(Some("4-1")).is_err());
         assert!(parse_scenario_selection(Some("unknown")).is_err());
     }

--- a/crates/choreo-e2e-runner/src/scenarios/ceremony_vllm.rs
+++ b/crates/choreo-e2e-runner/src/scenarios/ceremony_vllm.rs
@@ -1,0 +1,87 @@
+use anyhow::{bail, Context, Result};
+use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
+use choreo_proto::v1::RunCeremonyRequest;
+use tonic::transport::Channel;
+use tracing::info;
+
+use super::ceremony_vllm_definition::CeremonyVllmDefinition;
+use super::ceremony_vllm_provider_config::CeremonyVllmProviderConfig;
+
+pub(crate) async fn verify_editorial_meeting_ceremony_against_vllm_kind(
+    client: &mut ChoreographerServiceClient<Channel>,
+) -> Result<()> {
+    let provider = CeremonyVllmProviderConfig::from_env()?;
+    let definition = CeremonyVllmDefinition::from_provider_config(&provider)?;
+
+    let response = client
+        .run_ceremony(RunCeremonyRequest {
+            ceremony_id: "e2e-editorial-planning-meeting-vllm".to_owned(),
+            definition_yaml: definition.as_yaml().to_owned(),
+            context: None,
+            lease_owner_id: "e2e-runner".to_owned(),
+            lease_ttl_ms: 60_000,
+        })
+        .await
+        .context("RunCeremony failed for vLLM editorial planning ceremony")?
+        .into_inner();
+
+    if !response.completed {
+        bail!(
+            "expected vLLM ceremony to complete; final_state={}",
+            response.final_state
+        );
+    }
+    if response.final_state != "CLOSED" {
+        bail!(
+            "expected vLLM ceremony final_state CLOSED, got {}",
+            response.final_state
+        );
+    }
+    if response.steps.len() != 4 {
+        bail!(
+            "expected 4 executed vLLM ceremony steps, got {}",
+            response.steps.len()
+        );
+    }
+    for role in [
+        "FACILITATOR",
+        "CUSTOMER_ADVOCATE",
+        "RISK_REVIEWER",
+        "SYNTHESIZER",
+    ] {
+        if !response
+            .steps
+            .iter()
+            .any(|step| step.role_id == role && step.status == "COMPLETED")
+        {
+            bail!("vLLM RunCeremony response is missing completed role {role}");
+        }
+    }
+
+    let diagram = &response.mermaid_sequence;
+    for expected in [
+        "sequenceDiagram",
+        "open_room [facilitation_prompt]",
+        "customer_story [persona_prompt]",
+        "risk_check [challenge_prompt]",
+        "decision_summary [synthesis_prompt]",
+        "decision_written -> CLOSED",
+    ] {
+        if !diagram.contains(expected) {
+            bail!("vLLM ceremony diagram does not contain expected fragment `{expected}`");
+        }
+    }
+
+    info!(
+        ceremony_id = response.ceremony_id,
+        final_state = response.final_state,
+        steps = response.steps.len(),
+        endpoint = provider.endpoint(),
+        model = provider.model(),
+        max_tokens = provider.max_tokens(),
+        timeout_secs = provider.timeout_secs(),
+        diagram = %diagram,
+        "vLLM editorial planning ceremony executed and rendered"
+    );
+    Ok(())
+}

--- a/crates/choreo-e2e-runner/src/scenarios/ceremony_vllm_definition.rs
+++ b/crates/choreo-e2e-runner/src/scenarios/ceremony_vllm_definition.rs
@@ -1,0 +1,81 @@
+use anyhow::{Context, Result};
+
+use super::ceremony_vllm_provider_config::CeremonyVllmProviderConfig;
+
+const TEMPLATE: &str =
+    include_str!("../../../../tests/e2e/ceremonies/editorial-planning-meeting-vllm.yaml");
+const ENDPOINT_PLACEHOLDER: &str = "__CHOREO_VLLM_ENDPOINT__";
+const MODEL_PLACEHOLDER: &str = "__CHOREO_VLLM_MODEL__";
+const MAX_TOKENS_PLACEHOLDER: &str = "__CHOREO_VLLM_MAX_TOKENS__";
+const TIMEOUT_SECS_PLACEHOLDER: &str = "__CHOREO_VLLM_TIMEOUT_SECS__";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CeremonyVllmDefinition {
+    yaml: String,
+}
+
+impl CeremonyVllmDefinition {
+    pub(crate) fn from_provider_config(config: &CeremonyVllmProviderConfig) -> Result<Self> {
+        let yaml = TEMPLATE
+            .replace(ENDPOINT_PLACEHOLDER, &yaml_string(config.endpoint())?)
+            .replace(MODEL_PLACEHOLDER, &yaml_string(config.model())?)
+            .replace(MAX_TOKENS_PLACEHOLDER, &config.max_tokens().to_string())
+            .replace(TIMEOUT_SECS_PLACEHOLDER, &config.timeout_secs().to_string());
+        Ok(Self { yaml })
+    }
+
+    pub(crate) fn as_yaml(&self) -> &str {
+        &self.yaml
+    }
+}
+
+fn yaml_string(value: &str) -> Result<String> {
+    serde_json::to_string(value).context("serialize vLLM provider value as YAML scalar")
+}
+
+#[cfg(test)]
+mod tests {
+    use choreo_adapters::ceremony::CeremonyParticipantPlanAdapter;
+    use choreo_adapters::yaml::CeremonyDefinitionYaml;
+
+    use super::*;
+
+    #[test]
+    fn renders_provider_values_into_yaml_template() {
+        let config =
+            CeremonyVllmProviderConfig::new("http://stub-llm:8000", "stub-report-vllm-v1", 256, 45)
+                .unwrap();
+        let definition = CeremonyVllmDefinition::from_provider_config(&config).unwrap();
+        let yaml = definition.as_yaml();
+
+        assert!(!yaml.contains("__CHOREO_VLLM_"));
+        assert!(yaml.contains(r#"provider.endpoint: "http://stub-llm:8000""#));
+        assert!(yaml.contains(r#"provider.model: "stub-report-vllm-v1""#));
+        assert!(yaml.contains("provider.max_tokens: 256"));
+        assert!(yaml.contains("provider.timeout_secs: 45"));
+        assert!(yaml.contains("agent_kind: vllm"));
+        assert!(yaml.contains("num_agents: 4"));
+        assert!(yaml.contains("rounds: 0"));
+    }
+
+    #[test]
+    fn rendered_yaml_mounts_four_vllm_participants() {
+        let config =
+            CeremonyVllmProviderConfig::new("http://stub-llm:8000", "stub-report-vllm-v1", 256, 45)
+                .unwrap();
+        let definition_yaml = CeremonyVllmDefinition::from_provider_config(&config).unwrap();
+        let definition = CeremonyDefinitionYaml::parse_str(definition_yaml.as_yaml()).unwrap();
+        let participants = CeremonyParticipantPlanAdapter::from_definition(&definition).unwrap();
+
+        assert_eq!(definition.steps().len(), 4);
+        assert_eq!(participants.participants().len(), 4);
+        assert!(participants
+            .participants()
+            .iter()
+            .all(|participant| participant.kind().as_str() == "vllm"));
+        assert!(participants
+            .participants()
+            .iter()
+            .all(|participant| participant.specialty().as_str() == "editorial_meeting_vllm"));
+    }
+}

--- a/crates/choreo-e2e-runner/src/scenarios/ceremony_vllm_provider_config.rs
+++ b/crates/choreo-e2e-runner/src/scenarios/ceremony_vllm_provider_config.rs
@@ -1,0 +1,118 @@
+use anyhow::{anyhow, bail, Context, Result};
+
+const VLLM_ENDPOINT_ENV: &str = "CHOREO_VLLM_ENDPOINT";
+const VLLM_MODEL_ENV: &str = "CHOREO_VLLM_MODEL";
+const VLLM_MAX_TOKENS_ENV: &str = "CHOREO_VLLM_MAX_TOKENS";
+const VLLM_TIMEOUT_SECS_ENV: &str = "CHOREO_VLLM_TIMEOUT_SECS";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CeremonyVllmProviderConfig {
+    endpoint: String,
+    model: String,
+    max_tokens: u32,
+    timeout_secs: u32,
+}
+
+impl CeremonyVllmProviderConfig {
+    const DEFAULT_MAX_TOKENS: u32 = 512;
+    const DEFAULT_TIMEOUT_SECS: u32 = 300;
+
+    pub(crate) fn from_env() -> Result<Self> {
+        Self::new(
+            required_env(VLLM_ENDPOINT_ENV)?,
+            required_env(VLLM_MODEL_ENV)?,
+            env_u32(VLLM_MAX_TOKENS_ENV, Self::DEFAULT_MAX_TOKENS)?,
+            env_u32(VLLM_TIMEOUT_SECS_ENV, Self::DEFAULT_TIMEOUT_SECS)?,
+        )
+    }
+
+    pub(crate) fn new(
+        endpoint: impl Into<String>,
+        model: impl Into<String>,
+        max_tokens: u32,
+        timeout_secs: u32,
+    ) -> Result<Self> {
+        let endpoint = trimmed_nonempty(endpoint.into(), "vllm.endpoint")?;
+        let model = trimmed_nonempty(model.into(), "vllm.model")?;
+        if max_tokens == 0 {
+            bail!("vllm.max_tokens must be greater than zero");
+        }
+        if timeout_secs == 0 {
+            bail!("vllm.timeout_secs must be greater than zero");
+        }
+        Ok(Self {
+            endpoint,
+            model,
+            max_tokens,
+            timeout_secs,
+        })
+    }
+
+    pub(crate) fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    pub(crate) fn model(&self) -> &str {
+        &self.model
+    }
+
+    pub(crate) fn max_tokens(&self) -> u32 {
+        self.max_tokens
+    }
+
+    pub(crate) fn timeout_secs(&self) -> u32 {
+        self.timeout_secs
+    }
+}
+
+fn required_env(name: &str) -> Result<String> {
+    let raw = std::env::var(name).map_err(|_| anyhow!("required env var {name} is not set"))?;
+    trimmed_nonempty(raw, name)
+}
+
+fn env_u32(name: &str, default: u32) -> Result<u32> {
+    std::env::var(name)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .map(|raw| {
+            raw.parse::<u32>()
+                .with_context(|| format!("{name} must parse as u32"))
+        })
+        .transpose()
+        .map(|value| value.unwrap_or(default))
+}
+
+fn trimmed_nonempty(raw: impl Into<String>, field: &str) -> Result<String> {
+    let trimmed = raw.into().trim().to_owned();
+    if trimmed.is_empty() {
+        bail!("{field} must not be empty");
+    }
+    Ok(trimmed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trims_provider_values() {
+        let config = CeremonyVllmProviderConfig::new(
+            " http://stub-llm:8000 ",
+            " stub-report-vllm-v1 ",
+            128,
+            30,
+        )
+        .unwrap();
+
+        assert_eq!(config.endpoint(), "http://stub-llm:8000");
+        assert_eq!(config.model(), "stub-report-vllm-v1");
+        assert_eq!(config.max_tokens(), 128);
+        assert_eq!(config.timeout_secs(), 30);
+    }
+
+    #[test]
+    fn rejects_zero_bounds() {
+        assert!(CeremonyVllmProviderConfig::new("http://stub-llm:8000", "model", 0, 30).is_err());
+        assert!(CeremonyVllmProviderConfig::new("http://stub-llm:8000", "model", 128, 0).is_err());
+    }
+}

--- a/crates/choreo-e2e-runner/src/scenarios/mod.rs
+++ b/crates/choreo-e2e-runner/src/scenarios/mod.rs
@@ -1,4 +1,7 @@
 mod ceremony_diagram;
+mod ceremony_vllm;
+mod ceremony_vllm_definition;
+mod ceremony_vllm_provider_config;
 mod connectivity;
 mod runtime;
 mod structured_output;
@@ -12,6 +15,7 @@ use tonic::transport::{Channel, Endpoint};
 use tracing::{info, warn};
 
 pub(crate) use ceremony_diagram::verify_editorial_meeting_ceremony_diagram;
+pub(crate) use ceremony_vllm::verify_editorial_meeting_ceremony_against_vllm_kind;
 pub(crate) use connectivity::{
     verify_causal_metadata_propagates_over_nats, verify_delete_missing_council_returns_false,
     verify_deliberate_returns_winner, verify_seeded_council_visible,

--- a/docs/operations/compose-e2e.md
+++ b/docs/operations/compose-e2e.md
@@ -45,6 +45,7 @@ keeps `make e2e-compose` on the full 1-9 suite. To run a subset:
 ```sh
 CHOREO_E2E_SCENARIOS=cluster-connectivity make e2e-compose
 CHOREO_E2E_SCENARIOS=structured-output make e2e-compose
+CHOREO_E2E_SCENARIOS=ceremony-vllm make e2e-compose
 CHOREO_E2E_SCENARIOS=1-4,8 make e2e-compose
 ```
 
@@ -56,6 +57,8 @@ Supported selectors:
 | `cluster-connectivity` | 1-4 | gRPC, seeded council, delete-idempotence, NATS trigger/envelope smoke. |
 | `runtime-stub` | 5 | Runtime executor adapter against `stub-runtime`. |
 | `structured-output` | 6-9 | Strict schema rejection plus positive Report contracts through `stub-llm`. |
+| `ceremony` / `ceremony-diagram` | 11 | YAML ceremony execution and Mermaid trace with deterministic agents. |
+| `ceremony-vllm` / `gemma-ceremony` | 12 | YAML ceremony execution through `kind=vllm`; compose uses `stub-llm`, Kubernetes uses the configured real vLLM/Gemma endpoint. |
 | `1`, `scenario-5`, `s8`, `1-4` | selected numbers | Targeted debugging. |
 
 The script writes compose logs to `tests/e2e/compose.log` during
@@ -233,7 +236,8 @@ For a real vLLM endpoint, use the operator-run flow:
 make e2e-provider-vllm
 ```
 
-For a full Choreographer council against real vLLM, use:
+For a full Choreographer council plus YAML-mounted ceremony against real
+vLLM, use:
 
 ```sh
 make e2e-council-vllm
@@ -260,7 +264,7 @@ provider".
 |---|---|---|
 | `make e2e-compose` | Repo-owned stack proof with deterministic fixtures. | Local container runtime only. |
 | `make e2e-provider-vllm` | Adapter-level validation against a real vLLM endpoint. | Kubernetes access plus real vLLM endpoint configuration. |
-| `make e2e-council-vllm` | gRPC council validation against multiple real vLLM agents. | Deployed Choreographer with `kind=vllm`, plus real vLLM endpoint configuration. |
+| `make e2e-council-vllm` | gRPC council validation and YAML ceremony execution against multiple real vLLM agents. | Deployed Choreographer with `kind=vllm`, plus real vLLM endpoint configuration. |
 | `make e2e-mcp-council-vllm` | MCP parity validation for the same multi-agent vLLM ceremony. | Deployed Choreographer reachable from `choreo-mcp`, plus real vLLM endpoint configuration. |
 | Kubernetes smoke job | Connectivity smoke after Helm install. | Cluster, deployed Choreographer, and matching runtime/provider fixtures if running compose-shaped scenarios. |
 

--- a/scripts/ci/e2e-council-vllm.sh
+++ b/scripts/ci/e2e-council-vllm.sh
@@ -18,6 +18,7 @@ VLLM_MODEL="${CHOREO_VLLM_MODEL:-google/gemma-4-31B-it}"
 VLLM_AGENT_COUNT="${CHOREO_VLLM_AGENT_COUNT:-3}"
 VLLM_MAX_TOKENS="${CHOREO_VLLM_MAX_TOKENS:-512}"
 VLLM_TIMEOUT_SECS="${CHOREO_VLLM_TIMEOUT_SECS:-300}"
+SCENARIOS="${CHOREO_E2E_SCENARIOS:-vllm-real-multi-agent,ceremony-vllm}"
 IMAGE_PULL_SECRET="${E2E_IMAGE_PULL_SECRET:-}"
 RENDERED_MANIFEST=""
 
@@ -40,9 +41,17 @@ awk \
     -v agent_count="${VLLM_AGENT_COUNT}" \
     -v max_tokens="${VLLM_MAX_TOKENS}" \
     -v timeout_secs="${VLLM_TIMEOUT_SECS}" \
+    -v scenarios="${SCENARIOS}" \
     -v pull_secret="${IMAGE_PULL_SECRET}" '
       {
         gsub("image: ghcr.io/underpass-ai/underpass-choreographer-e2e-runner:latest", "image: " image);
+      }
+      /- name: CHOREO_E2E_SCENARIOS/ {
+        print;
+        getline;
+        sub(/value:.*/, "value: " scenarios);
+        print;
+        next;
       }
       /- name: CHOREOGRAPHER_ENDPOINT/ {
         print;

--- a/tests/e2e/ceremonies/editorial-planning-meeting-vllm.yaml
+++ b/tests/e2e/ceremonies/editorial-planning-meeting-vllm.yaml
@@ -1,0 +1,137 @@
+version: "1.0"
+name: "editorial_planning_meeting_vllm"
+description: "Non-technical four-agent editorial planning ceremony backed by vLLM"
+inputs:
+  required:
+    - meeting_brief
+  optional:
+    - audience_notes
+outputs:
+  decision_summary:
+    type: object
+states:
+  - id: OPENING
+    initial: true
+  - id: DIVERGING
+  - id: REVIEWING
+  - id: SYNTHESIZING
+  - id: CLOSED
+    terminal: true
+transitions:
+  - from: OPENING
+    to: DIVERGING
+    trigger: context_shared
+    guards:
+      - open_room_completed
+  - from: DIVERGING
+    to: REVIEWING
+    trigger: options_collected
+    guards:
+      - customer_story_completed
+  - from: REVIEWING
+    to: SYNTHESIZING
+    trigger: risks_reviewed
+    guards:
+      - risk_check_completed
+  - from: SYNTHESIZING
+    to: CLOSED
+    trigger: decision_written
+    guards:
+      - decision_summary_completed
+steps:
+  - id: open_room
+    state: OPENING
+    handler: facilitation_prompt
+    config:
+      specialty: editorial_meeting_vllm
+      agent_kind: vllm
+      participants: &editorial_meeting_participants
+        - facilitator
+        - customer_advocate
+        - risk_reviewer
+        - synthesizer
+      rounds: 0
+      num_agents: 4
+      provider.endpoint: __CHOREO_VLLM_ENDPOINT__
+      provider.model: __CHOREO_VLLM_MODEL__
+      provider.max_tokens: __CHOREO_VLLM_MAX_TOKENS__
+      provider.timeout_secs: __CHOREO_VLLM_TIMEOUT_SECS__
+      prompt: "Open the meeting, restate the brief, and invite perspectives."
+  - id: customer_story
+    state: DIVERGING
+    handler: persona_prompt
+    config:
+      specialty: editorial_meeting_vllm
+      agent_kind: vllm
+      participants: *editorial_meeting_participants
+      rounds: 0
+      num_agents: 4
+      provider.endpoint: __CHOREO_VLLM_ENDPOINT__
+      provider.model: __CHOREO_VLLM_MODEL__
+      provider.max_tokens: __CHOREO_VLLM_MAX_TOKENS__
+      provider.timeout_secs: __CHOREO_VLLM_TIMEOUT_SECS__
+      prompt: "Describe what the audience needs to understand and remember."
+  - id: risk_check
+    state: REVIEWING
+    handler: challenge_prompt
+    config:
+      specialty: editorial_meeting_vllm
+      agent_kind: vllm
+      participants: *editorial_meeting_participants
+      rounds: 0
+      num_agents: 4
+      provider.endpoint: __CHOREO_VLLM_ENDPOINT__
+      provider.model: __CHOREO_VLLM_MODEL__
+      provider.max_tokens: __CHOREO_VLLM_MAX_TOKENS__
+      provider.timeout_secs: __CHOREO_VLLM_TIMEOUT_SECS__
+      prompt: "Challenge weak assumptions and name risks in the plan."
+  - id: decision_summary
+    state: SYNTHESIZING
+    handler: synthesis_prompt
+    config:
+      specialty: editorial_meeting_vllm
+      agent_kind: vllm
+      participants: *editorial_meeting_participants
+      rounds: 0
+      num_agents: 4
+      provider.endpoint: __CHOREO_VLLM_ENDPOINT__
+      provider.model: __CHOREO_VLLM_MODEL__
+      provider.max_tokens: __CHOREO_VLLM_MAX_TOKENS__
+      provider.timeout_secs: __CHOREO_VLLM_TIMEOUT_SECS__
+      prompt: "Summarize the decision, owner, and next action."
+guards:
+  open_room_completed:
+    type: automated
+    check: "step_status:open_room:COMPLETED"
+  customer_story_completed:
+    type: automated
+    check: "step_status:customer_story:COMPLETED"
+  risk_check_completed:
+    type: automated
+    check: "step_status:risk_check:COMPLETED"
+  decision_summary_completed:
+    type: automated
+    check: "step_status:decision_summary:COMPLETED"
+roles:
+  - id: FACILITATOR
+    allowed_actions:
+      - open_room
+      - context_shared
+  - id: CUSTOMER_ADVOCATE
+    allowed_actions:
+      - customer_story
+      - options_collected
+  - id: RISK_REVIEWER
+    allowed_actions:
+      - risk_check
+      - risks_reviewed
+  - id: SYNTHESIZER
+    allowed_actions:
+      - decision_summary
+      - decision_written
+timeouts:
+  step_default: 120
+retry_policies:
+  default:
+    max_attempts: 2
+    backoff_seconds: 1

--- a/tests/e2e/docker-compose.e2e.yaml
+++ b/tests/e2e/docker-compose.e2e.yaml
@@ -97,6 +97,13 @@ services:
       # runner robust against operators who run the binary outside
       # the container.
       CHOREO_REPORT_SCHEMA_PATH: "/etc/choreo/report.schema.json"
+      # Allows opt-in `CHOREO_E2E_SCENARIOS=ceremony-vllm make
+      # e2e-compose` to render the vLLM-backed ceremony against the
+      # deterministic stub-llm sidecar.
+      CHOREO_VLLM_MODEL: "stub-report-vllm-v1"
+      CHOREO_VLLM_ENDPOINT: "http://stub-llm:8000"
+      CHOREO_VLLM_MAX_TOKENS: "512"
+      CHOREO_VLLM_TIMEOUT_SECS: "30"
       RUST_LOG: "info"
     depends_on:
       - choreographer

--- a/tests/e2e/kubernetes/council-vllm-job.yaml
+++ b/tests/e2e/kubernetes/council-vllm-job.yaml
@@ -1,8 +1,9 @@
-# Choreographer E2E Job: multi-agent council against real vLLM.
+# Choreographer E2E Job: multi-agent council and ceremony against real vLLM.
 #
 # Applies into the namespace that already runs Choreographer and vLLM.
 # The Job drives Choreographer over gRPC, registers multiple `kind=vllm`
-# agents, creates a council, and runs `RunCouncilDecision` in Strict mode.
+# agents, creates a council, runs `RunCouncilDecision` in Strict mode, then
+# executes the YAML-mounted four-agent ceremony through the same provider.
 #
 # Launch: `make e2e-council-vllm` (applies this manifest, waits for
 # completion, tails logs, deletes the Job).
@@ -45,7 +46,7 @@ spec:
                 - ALL
           env:
             - name: CHOREO_E2E_SCENARIOS
-              value: vllm-real-multi-agent
+              value: vllm-real-multi-agent,ceremony-vllm
             - name: CHOREOGRAPHER_ENDPOINT
               value: http://choreographer:50055
             - name: CHOREO_VLLM_ENDPOINT

--- a/tests/e2e/runner.Dockerfile
+++ b/tests/e2e/runner.Dockerfile
@@ -27,6 +27,7 @@ WORKDIR /src
 COPY Cargo.toml Cargo.lock ./
 COPY rust-toolchain.toml ./
 COPY crates ./crates
+COPY tests/e2e/ceremonies ./tests/e2e/ceremonies
 # Ship the canonical Report JSON Schema alongside the runner binary
 # so scenario 8 can read it inside the container. Pinned to a stable
 # path; compose sets `CHOREO_REPORT_SCHEMA_PATH=/etc/choreo/report.schema.json`


### PR DESCRIPTION
## Summary

- Adds scenario 12, `ceremony-vllm`, which runs the editorial planning ceremony through `kind=vllm`.
- Adds a vLLM-backed ceremony YAML fixture with four named participants mounted from YAML.
- Wires compose opt-in execution through `stub-llm` and extends the Kubernetes Gemma/vLLM job to run both the real council E2E and the ceremony E2E.
- Copies ceremony fixtures into the runner Docker build context so `include_str!` works in container builds.

## Why

The ceremony engine can now prepare participants from YAML, but the E2E suite did not prove that a YAML ceremony can mount a real provider-backed multi-agent council. This closes that gap for the Choreographer extraction path.

## Validation

- `cargo test -p choreo-e2e-runner --locked`
- `cargo clippy -p choreo-e2e-runner --locked -- -D warnings`
- `bash -n scripts/ci/e2e-council-vllm.sh`
- `CHOREO_E2E_SCENARIOS=ceremony-vllm make e2e-compose`
