### PR TITLE
[codex] Use published E2E runner tag

### DIFF
--- a/scripts/ci/e2e-council-vllm.sh
+++ b/scripts/ci/e2e-council-vllm.sh
@@ -11,7 +11,7 @@ NAMESPACE="${NAMESPACE:-underpass-runtime}"
 JOB_NAME="${JOB_NAME:-choreographer-e2e-council-vllm}"
 MANIFEST="${ROOT_DIR}/tests/e2e/kubernetes/council-vllm-job.yaml"
 TIMEOUT="${TIMEOUT:-600s}"
-RUNNER_IMAGE="${RUNNER_IMAGE:-ghcr.io/underpass-ai/underpass-choreographer-e2e-runner:latest}"
+RUNNER_IMAGE="${RUNNER_IMAGE:-ghcr.io/underpass-ai/underpass-choreographer-e2e-runner:e2e-latest}"
 CHOREOGRAPHER_ENDPOINT="${CHOREOGRAPHER_ENDPOINT:-http://choreographer:50055}"
 VLLM_ENDPOINT="${CHOREO_VLLM_ENDPOINT:-http://underpass-llm-gemma-4-31b-structured:8000}"
 VLLM_MODEL="${CHOREO_VLLM_MODEL:-google/gemma-4-31B-it}"
@@ -44,7 +44,7 @@ awk \
     -v scenarios="${SCENARIOS}" \
     -v pull_secret="${IMAGE_PULL_SECRET}" '
       {
-        gsub("image: ghcr.io/underpass-ai/underpass-choreographer-e2e-runner:latest", "image: " image);
+        gsub("image: ghcr.io/underpass-ai/underpass-choreographer-e2e-runner:e2e-latest", "image: " image);
       }
       /- name: CHOREO_E2E_SCENARIOS/ {
         print;

--- a/tests/e2e/kubernetes/council-vllm-job.yaml
+++ b/tests/e2e/kubernetes/council-vllm-job.yaml
@@ -36,7 +36,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: runner
-          image: ghcr.io/underpass-ai/underpass-choreographer-e2e-runner:latest
+          image: ghcr.io/underpass-ai/underpass-choreographer-e2e-runner:e2e-latest
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary

- Updates the real vLLM/Gemma council job to use the published E2E runner tag, `e2e-latest`.
- Aligns the `make e2e-council-vllm` default `RUNNER_IMAGE` and manifest replacement logic with the publish workflow.

## Why

The publish workflow tags `ghcr.io/underpass-ai/underpass-choreographer-e2e-runner` as `e2e-latest`, not `latest`. Using `latest` risks running an older runner image that does not know about the new `ceremony-vllm` scenario.

## Validation

- `bash -n scripts/ci/e2e-council-vllm.sh`
- `git diff --check`
