### PR TITLE
fix(ceremony): fail fast on lease TTL overflow instead of clamping

### DIFF
--- a/crates/choreo-app/src/usecases/run_ceremony_step_use_case.rs
+++ b/crates/choreo-app/src/usecases/run_ceremony_step_use_case.rs
@@ -8,7 +8,6 @@ use choreo_core::ports::{
     CeremonyStepHandlerRequest, ClockPort,
 };
 use choreo_core::value_objects::{StepErrorMessage, StepLease, StepResult};
-use time::Duration;
 
 use super::run_ceremony_step_input::RunCeremonyStepInput;
 use super::run_ceremony_step_output::RunCeremonyStepOutput;
@@ -64,11 +63,11 @@ impl RunCeremonyStepUseCase {
             })?;
 
         let now = self.clock.now();
-        let lease = StepLease::new(
+        let lease = StepLease::acquire(
             input.lease_owner_id,
             input.idempotency_key,
             now,
-            now + Duration::milliseconds(i64::try_from(input.lease_ttl.get()).unwrap_or(i64::MAX)),
+            input.lease_ttl,
         )?;
         let attempt =
             instance.start_step_as(&definition, &input.role_id, &input.step_id, lease, now)?;

--- a/crates/choreo-app/src/usecases/run_ceremony_use_case.rs
+++ b/crates/choreo-app/src/usecases/run_ceremony_use_case.rs
@@ -12,7 +12,6 @@ use choreo_core::value_objects::{
     DurationMs, IdempotencyKey, LeaseOwnerId, RoleAction, RoleId, StepAttempt, StepErrorMessage,
     StepId, StepLease, StepResult, TransitionTrigger,
 };
-use time::Duration;
 
 use super::ceremony_step_trace::CeremonyStepTrace;
 use super::run_ceremony_input::RunCeremonyInput;
@@ -161,7 +160,7 @@ impl RunCeremonyUseCase {
                 what: "ceremony_step",
             })?;
         let now = self.clock.now();
-        let lease = StepLease::new(
+        let lease = StepLease::acquire(
             lease_owner_id.clone(),
             IdempotencyKey::new(format!(
                 "{}:{}:{}",
@@ -170,7 +169,7 @@ impl RunCeremonyUseCase {
                 trace_index + 1
             ))?,
             now,
-            now + Duration::milliseconds(i64::try_from(lease_ttl.get()).unwrap_or(i64::MAX)),
+            lease_ttl,
         )?;
         let attempt = instance.start_step_as(definition, role_id, step_id, lease, now)?;
         self.instances.save(instance).await?;

--- a/crates/choreo-app/src/usecases/start_ceremony_step_use_case.rs
+++ b/crates/choreo-app/src/usecases/start_ceremony_step_use_case.rs
@@ -7,7 +7,6 @@ use choreo_core::ports::{
     CeremonyDefinitionRepositoryPort, CeremonyInstanceRepositoryPort, ClockPort,
 };
 use choreo_core::value_objects::{StepAttempt, StepLease};
-use time::Duration;
 
 use super::start_ceremony_step_input::StartCeremonyStepInput;
 
@@ -49,11 +48,11 @@ impl StartCeremonyStepUseCase {
             .await?;
         let mut instance = self.instances.get(&input.instance_id).await?;
         let now = self.clock.now();
-        let lease = StepLease::new(
+        let lease = StepLease::acquire(
             input.lease_owner_id,
             input.idempotency_key,
             now,
-            now + Duration::milliseconds(i64::try_from(input.lease_ttl.get()).unwrap_or(i64::MAX)),
+            input.lease_ttl,
         )?;
         let attempt =
             instance.start_step_as(&definition, &input.role_id, &input.step_id, lease, now)?;

--- a/crates/choreo-core/src/value_objects/ceremony/step_lease.rs
+++ b/crates/choreo-core/src/value_objects/ceremony/step_lease.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
+use time::{Duration, OffsetDateTime};
 
 use crate::error::DomainError;
+use crate::value_objects::DurationMs;
 
 use super::{IdempotencyKey, LeaseOwnerId};
 
@@ -35,6 +36,38 @@ impl StepLease {
         })
     }
 
+    /// Acquire a lease that expires `ttl` after `acquired_at`.
+    ///
+    /// Unlike [`StepLease::new`], which takes an already-computed expiry
+    /// instant, this constructor derives the expiry from a typed
+    /// [`DurationMs`] and **fails fast** with [`DomainError::OutOfRange`]
+    /// when the requested lifetime cannot be honoured — either because it
+    /// exceeds the signed-millisecond range the clock accepts or because
+    /// adding it to `acquired_at` overflows the representable calendar.
+    /// The requested TTL is never silently clamped.
+    pub fn acquire(
+        owner_id: LeaseOwnerId,
+        idempotency_key: IdempotencyKey,
+        acquired_at: OffsetDateTime,
+        ttl: DurationMs,
+    ) -> Result<Self, DomainError> {
+        let ttl_millis = i64::try_from(ttl.get()).map_err(|_| DomainError::OutOfRange {
+            field: "step_lease.ttl_ms",
+            value: ttl.get() as f64,
+            min: 0.0,
+            max: i64::MAX as f64,
+        })?;
+        let expires_at = acquired_at
+            .checked_add(Duration::milliseconds(ttl_millis))
+            .ok_or(DomainError::OutOfRange {
+                field: "step_lease.expires_at",
+                value: ttl.get() as f64,
+                min: 0.0,
+                max: i64::MAX as f64,
+            })?;
+        Self::new(owner_id, idempotency_key, acquired_at, expires_at)
+    }
+
     #[must_use]
     pub fn owner_id(&self) -> &LeaseOwnerId {
         &self.owner_id
@@ -58,5 +91,100 @@ impl StepLease {
     #[must_use]
     pub fn is_expired_at(&self, now: OffsetDateTime) -> bool {
         now >= self.expires_at
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use time::{Duration, OffsetDateTime};
+
+    use super::*;
+
+    fn owner() -> LeaseOwnerId {
+        LeaseOwnerId::new("runner-1").unwrap()
+    }
+
+    fn key() -> IdempotencyKey {
+        IdempotencyKey::new("ceremony-1:open_room:1").unwrap()
+    }
+
+    #[test]
+    fn acquire_expires_ttl_after_acquired_at() {
+        let acquired_at = OffsetDateTime::UNIX_EPOCH;
+        let lease =
+            StepLease::acquire(owner(), key(), acquired_at, DurationMs::from_millis(60_000))
+                .unwrap();
+
+        assert_eq!(lease.acquired_at(), acquired_at);
+        assert_eq!(
+            lease.expires_at(),
+            acquired_at + Duration::milliseconds(60_000)
+        );
+        assert_eq!(lease.owner_id(), &owner());
+        assert_eq!(lease.idempotency_key(), &key());
+    }
+
+    #[test]
+    fn acquire_lease_is_not_expired_before_ttl_elapses() {
+        let acquired_at = OffsetDateTime::UNIX_EPOCH;
+        let lease = StepLease::acquire(owner(), key(), acquired_at, DurationMs::from_millis(1_000))
+            .unwrap();
+
+        assert!(!lease.is_expired_at(acquired_at + Duration::milliseconds(999)));
+        assert!(lease.is_expired_at(acquired_at + Duration::milliseconds(1_000)));
+    }
+
+    #[test]
+    fn acquire_rejects_zero_ttl_as_non_positive_lifetime() {
+        let err = StepLease::acquire(owner(), key(), OffsetDateTime::UNIX_EPOCH, DurationMs::ZERO)
+            .unwrap_err();
+
+        assert!(matches!(err, DomainError::InvariantViolated { .. }));
+    }
+
+    #[test]
+    fn acquire_rejects_ttl_exceeding_signed_millisecond_range() {
+        let err = StepLease::acquire(
+            owner(),
+            key(),
+            OffsetDateTime::UNIX_EPOCH,
+            DurationMs::from_millis(u64::MAX),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DomainError::OutOfRange {
+                field: "step_lease.ttl_ms",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn acquire_rejects_ttl_that_overflows_the_calendar() {
+        let err = StepLease::acquire(
+            owner(),
+            key(),
+            OffsetDateTime::UNIX_EPOCH,
+            DurationMs::from_millis(i64::MAX as u64),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DomainError::OutOfRange {
+                field: "step_lease.expires_at",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn new_rejects_expiry_not_after_acquired_at() {
+        let now = OffsetDateTime::UNIX_EPOCH;
+        let err = StepLease::new(owner(), key(), now, now).unwrap_err();
+
+        assert!(matches!(err, DomainError::InvariantViolated { .. }));
     }
 }


### PR DESCRIPTION
## Quality slice 1/7 — fail-fast (ceremony engine audit)

First slice of the ceremony-engine quality pass. The engine already runs end-to-end against real vLLM (gemma); this hardens it against the audit's findings without changing any public API, proto, or YAML shape.

### Problem
Three ceremony lease call sites computed the lease expiry as:

```rust
now + Duration::milliseconds(i64::try_from(ttl.get()).unwrap_or(i64::MAX))
```

`unwrap_or(i64::MAX)` **silently clamps** any TTL beyond `i64::MAX` ms instead of rejecting it — a fail-fast violation on request-supplied input (audit findings F7/F8/F9).

### Fix
New domain constructor `StepLease::acquire(owner, key, acquired_at, ttl: DurationMs)` derives `expires_at` from the typed `DurationMs` and **fails fast** with `DomainError::OutOfRange` when the TTL exceeds the signed-millisecond range or overflows the representable calendar. Lease-expiry computation now lives in the value object (de-anemizes the domain) and the duplicated cast is gone from all three use cases.

### Changes
- `StepLease::acquire` + 6 unit tests (the VO previously had **no** tests): happy path, not-expired-before-TTL, zero TTL, out-of-`i64` TTL, calendar overflow, and the `new()` invariant.
- `run_ceremony_use_case`, `run_ceremony_step_use_case`, `start_ceremony_step_use_case` call `acquire` and drop dead `time::Duration` imports.

### Validation
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets` + provider features `-- -D warnings` ✅
- `cargo test --workspace` + provider features ✅ (all green, incl. 6 new)

**Breaking:** none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)