### PR TITLE
test(ceremony): cover RunCeremonyUseCase failure paths

### DIFF
--- a/crates/choreo-app/src/usecases/run_ceremony_use_case.rs
+++ b/crates/choreo-app/src/usecases/run_ceremony_use_case.rs
@@ -213,8 +213,9 @@ mod tests {
 
     use super::*;
     use crate::usecases::ceremony_test_support::{
-        ceremony_id, definition, lease_owner, lease_ttl, now, started_instance, step_id,
-        DefinitionRepositoryFake, FixedClock, InstanceRepositoryFake, StepHandlerFake,
+        approval_definition, ceremony_id, definition, lease_owner, lease_ttl, now,
+        started_instance, step_id, DefinitionRepositoryFake, FixedClock, InstanceRepositoryFake,
+        StepHandlerFake,
     };
 
     #[tokio::test]
@@ -252,6 +253,86 @@ mod tests {
             .saved(&ceremony_id())
             .await
             .is_completed(&definition));
+    }
+
+    #[tokio::test]
+    async fn aborts_when_a_step_does_not_complete_successfully() {
+        let definition = definition();
+        let definitions = Arc::new(DefinitionRepositoryFake::default());
+        let instances = Arc::new(InstanceRepositoryFake::default());
+        let handler = Arc::new(StepHandlerFake::failing(DomainError::InvariantViolated {
+            reason: "handler rejected step",
+        }));
+        let usecase = RunCeremonyUseCase::new(
+            definitions,
+            instances.clone(),
+            handler,
+            Arc::new(FixedClock::new(now())),
+        );
+
+        let err = usecase
+            .execute(RunCeremonyInput::new(
+                ceremony_id(),
+                definition.clone(),
+                CeremonyContext::empty(),
+                lease_owner(),
+                lease_ttl(),
+            ))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DomainError::InvariantViolated {
+                reason: "ceremony step did not complete successfully"
+            }
+        ));
+        // The failed step is recorded; the ceremony did not reach its
+        // terminal state.
+        assert!(!instances
+            .saved(&ceremony_id())
+            .await
+            .is_completed(&definition));
+    }
+
+    #[tokio::test]
+    async fn fails_when_no_outgoing_transition_is_satisfied() {
+        // The approval ceremony can only advance through a human-approval
+        // guard; with no approval in the context, no transition is
+        // enabled out of the initial state.
+        let definition = approval_definition();
+        let definitions = Arc::new(DefinitionRepositoryFake::default());
+        let instances = Arc::new(InstanceRepositoryFake::default());
+        let handler = Arc::new(StepHandlerFake::succeeding(
+            StepResult::completed(StepOutput::empty()).unwrap(),
+        ));
+        let usecase = RunCeremonyUseCase::new(
+            definitions,
+            instances,
+            handler.clone(),
+            Arc::new(FixedClock::new(now())),
+        );
+
+        let err = usecase
+            .execute(RunCeremonyInput::new(
+                ceremony_id(),
+                definition,
+                CeremonyContext::empty(),
+                lease_owner(),
+                lease_ttl(),
+            ))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DomainError::InvariantViolated {
+                reason: "no satisfied ceremony transition is available"
+            }
+        ));
+        // The approval ceremony declares no steps, so the handler is
+        // never invoked.
+        assert!(handler.requests().await.is_empty());
     }
 
     #[tokio::test]

--- a/crates/choreo-core/src/entities/ceremony_definition.rs
+++ b/crates/choreo-core/src/entities/ceremony_definition.rs
@@ -647,6 +647,192 @@ mod tests {
     }
 
     #[test]
+    fn rejects_empty_states_collection() {
+        let err =
+            definition(Vec::new(), Vec::new(), Vec::new(), Vec::new(), Vec::new()).unwrap_err();
+
+        assert!(matches!(
+            err,
+            DomainError::EmptyCollection {
+                field: "ceremony_definition.states"
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_transition_referencing_unknown_from_state() {
+        let transition = CeremonyTransition::new(
+            state_id("ghost"),
+            state_id("done"),
+            trigger("finish"),
+            Vec::new(),
+        )
+        .unwrap();
+
+        let err = definition(
+            vec![
+                CeremonyState::initial(state_id("drafting")),
+                CeremonyState::terminal(state_id("done")),
+            ],
+            vec![transition],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DomainError::NotFound {
+                what: "ceremony_transition.from_state"
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_transition_referencing_unknown_to_state() {
+        let transition = CeremonyTransition::new(
+            state_id("drafting"),
+            state_id("ghost"),
+            trigger("finish"),
+            Vec::new(),
+        )
+        .unwrap();
+
+        let err = definition(
+            vec![
+                CeremonyState::initial(state_id("drafting")),
+                CeremonyState::terminal(state_id("done")),
+            ],
+            vec![transition],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DomainError::NotFound {
+                what: "ceremony_transition.to_state"
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_duplicate_state_trigger_pairs() {
+        let first = CeremonyTransition::new(
+            state_id("drafting"),
+            state_id("done"),
+            trigger("finish"),
+            Vec::new(),
+        )
+        .unwrap();
+        let duplicate = CeremonyTransition::new(
+            state_id("drafting"),
+            state_id("done"),
+            trigger("finish"),
+            Vec::new(),
+        )
+        .unwrap();
+
+        let err = definition(
+            vec![
+                CeremonyState::initial(state_id("drafting")),
+                CeremonyState::terminal(state_id("done")),
+            ],
+            vec![first, duplicate],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DomainError::AlreadyExists {
+                what: "ceremony_transition.state_trigger"
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_transition_referencing_unknown_guard() {
+        let transition = CeremonyTransition::new(
+            state_id("drafting"),
+            state_id("done"),
+            trigger("finish"),
+            vec![guard_name("absent")],
+        )
+        .unwrap();
+
+        let err = definition(
+            vec![
+                CeremonyState::initial(state_id("drafting")),
+                CeremonyState::terminal(state_id("done")),
+            ],
+            vec![transition],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DomainError::NotFound {
+                what: "ceremony_transition.guard"
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_step_referencing_unknown_state() {
+        let err = definition(
+            vec![
+                CeremonyState::initial(state_id("drafting")),
+                CeremonyState::terminal(state_id("done")),
+            ],
+            Vec::new(),
+            vec![step("plan", "ghost")],
+            Vec::new(),
+            Vec::new(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DomainError::NotFound {
+                what: "ceremony_step.state"
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_role_that_references_unknown_transition_trigger() {
+        let role = role(vec![RoleAction::transition(trigger("ghost"))]);
+
+        let err = definition(
+            vec![
+                CeremonyState::initial(state_id("drafting")),
+                CeremonyState::terminal(state_id("done")),
+            ],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            vec![role],
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DomainError::NotFound {
+                what: "ceremony_role.transition_action"
+            }
+        ));
+    }
+
+    #[test]
     fn resolves_role_authorised_for_a_step() {
         let definition = valid_definition();
 


### PR DESCRIPTION
## Quality slice 5/7 — use-case failure coverage (audit: unit-coverage)

`RunCeremonyUseCase::execute` was only tested on the happy path and duplicate-instance rejection. This adds the two missing failure-path tests (audit findings F20, F21):

- **step failure aborts the run** → `InvariantViolated { "ceremony step did not complete successfully" }`, instance left non-terminal.
- **no satisfiable transition** (the human-approval ceremony with no approval in context) → `InvariantViolated { "no satisfied ceremony transition is available" }`, handler never invoked.

Both reuse existing `ceremony_test_support` fixtures (`StepHandlerFake::failing`, `approval_definition`). Pure test additions — no production changes.

### Validation
- `cargo fmt --all -- --check` ✅
- `cargo clippy -p choreo-app --all-targets -- -D warnings` ✅
- `cargo test -p choreo-app` ✅ (47 passed, +2 new)

> **Stacked on #77 → #76.** Merge those first; GitHub retargets this PR automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)