### PR TITLE
ci(ceremony): run the noop ceremony as a Kubernetes Job

### DIFF
--- a/tests/e2e/kubernetes/runner-job.yaml
+++ b/tests/e2e/kubernetes/runner-job.yaml
@@ -33,7 +33,7 @@ spec:
             - name: CHOREO_SEED_SPECIALTY
               value: triage
             - name: CHOREO_E2E_SCENARIOS
-              value: cluster-connectivity
+              value: cluster-connectivity,ceremony-diagram
             - name: RUST_LOG
               value: info
           resources:


### PR DESCRIPTION
## Quality slice 7/7 — ceremony e2e as a Kubernetes Job (audit: e2e-k8s-job)

The four-role **noop** ceremony (scenario 11, `ceremony-diagram`) exercises the full ceremony path — YAML parse → participant prep → council-backed step execution → Mermaid diagram — and needs **no external provider**, yet it ran as a Kubernetes Job nowhere (audit finding F14).

### Fix
Add `ceremony-diagram` to the cheap, vLLM-free `runner-job.yaml` (driven by `make e2e-kubernetes`), alongside the existing `cluster-connectivity` scenarios.

I placed it here rather than the audit's suggested `council-vllm-job.yaml` because that job requires a real vLLM endpoint (operator-only); `runner-job.yaml` runs the repo-owned noop path cheaply in CI.

### Validation
Ran scenario 11 against the **live deployed choreographer** (`e2e-0557aed`) via port-forward:

```
scenario 11: four-role ceremony YAML renders a Mermaid conversation diagram
... final_state=CLOSED steps=4 ...
E2E scenarios passed
```

The selector `cluster-connectivity,ceremony-diagram` is parsed by the existing scenario-selection logic (named set + single selector union).

**Breaking:** none (CI manifest only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)