### PR TITLE
refactor(ceremony): centralize step config behind a typed accessor

### DIFF
--- a/crates/choreo-adapters/src/ceremony/ceremony_participant_plan_adapter.rs
+++ b/crates/choreo-adapters/src/ceremony/ceremony_participant_plan_adapter.rs
@@ -3,12 +3,10 @@ use std::collections::BTreeMap;
 use choreo_app::usecases::{CeremonyParticipantDescriptor, PrepareCeremonyParticipantsInput};
 use choreo_core::entities::CeremonyDefinition;
 use choreo_core::error::DomainError;
-use choreo_core::value_objects::{
-    AgentId, AgentKind, Attributes, CeremonyStep, NumAgents, Specialty,
-};
+use choreo_core::value_objects::{AgentId, Attributes, CeremonyStep};
 use serde_json::{json, Value};
 
-const DEFAULT_AGENT_KIND: &str = "noop";
+use super::CeremonyStepConfig;
 
 #[derive(Debug, Clone, Copy)]
 pub struct CeremonyParticipantPlanAdapter;
@@ -35,17 +33,15 @@ fn participants_from_step(
     definition: &CeremonyDefinition,
     step: &CeremonyStep,
 ) -> Result<Vec<CeremonyParticipantDescriptor>, DomainError> {
-    let config = step.handler_config().attributes();
-    let specialty = Specialty::new(
-        optional_string(config.get("specialty")).unwrap_or(step.handler_kind().as_str()),
-    )?;
-    let kind = AgentKind::new(
-        optional_string(config.get("agent_kind"))
-            .or_else(|| optional_string(config.get("agent.kind")))
-            .unwrap_or(DEFAULT_AGENT_KIND),
-    )?;
-    let labels = participant_labels(config.get("participants"))?;
-    let count = participant_count(config.get("num_agents"), labels.len())?;
+    let config = CeremonyStepConfig::new(step.handler_config().attributes(), step.handler_kind());
+    let specialty = config.specialty()?;
+    let kind = config.agent_kind()?;
+    let labels = config.participant_labels()?;
+    let count = if labels.is_empty() {
+        config.num_agents()?.map_or(1, |num| num.get() as usize)
+    } else {
+        labels.len()
+    };
 
     (0..count)
         .map(|index| {
@@ -58,66 +54,6 @@ fn participants_from_step(
             ))
         })
         .collect()
-}
-
-fn optional_string(value: Option<&Value>) -> Option<&str> {
-    value
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|raw| !raw.is_empty())
-}
-
-fn participant_labels(value: Option<&Value>) -> Result<Vec<String>, DomainError> {
-    let Some(value) = value else {
-        return Ok(Vec::new());
-    };
-    if value.is_null() {
-        return Ok(Vec::new());
-    }
-    let Some(items) = value.as_array() else {
-        return Err(DomainError::InvalidCharacters {
-            field: "ceremony_step.config.participants",
-        });
-    };
-    items
-        .iter()
-        .map(|item| {
-            item.as_str()
-                .map(str::trim)
-                .filter(|label| !label.is_empty())
-                .map(str::to_owned)
-                .ok_or(DomainError::InvalidCharacters {
-                    field: "ceremony_step.config.participants",
-                })
-        })
-        .collect()
-}
-
-fn participant_count(value: Option<&Value>, label_count: usize) -> Result<usize, DomainError> {
-    if label_count > 0 {
-        return Ok(label_count);
-    }
-    let Some(value) = value else { return Ok(1) };
-    if value.is_null() {
-        return Ok(1);
-    }
-    let Some(raw) = value.as_u64() else {
-        return Err(DomainError::InvalidCharacters {
-            field: "ceremony_step.config.num_agents",
-        });
-    };
-    let count = u32::try_from(raw).map_err(|_| DomainError::OutOfRange {
-        field: "ceremony_step.config.num_agents",
-        value: raw as f64,
-        min: 1.0,
-        max: f64::from(u32::MAX),
-    })?;
-    usize::try_from(NumAgents::new(count)?.get()).map_err(|_| DomainError::OutOfRange {
-        field: "ceremony_step.config.num_agents",
-        value: f64::from(count),
-        min: 1.0,
-        max: f64::from(u32::MAX),
-    })
 }
 
 fn participant_attributes(

--- a/crates/choreo-adapters/src/ceremony/ceremony_step_config.rs
+++ b/crates/choreo-adapters/src/ceremony/ceremony_step_config.rs
@@ -1,0 +1,265 @@
+//! [`CeremonyStepConfig`] — typed accessor over a ceremony step's handler
+//! configuration.
+//!
+//! Ceremony step handlers are configured through the free-form
+//! [`Attributes`] bag carried by `StepHandlerConfig`. Reading that bag
+//! with scattered string literals is primitive-obsessed and error-prone,
+//! so this view owns the configuration key schema in exactly one place
+//! and exposes a validated, fail-fast typed value for each field. Both
+//! the deliberation step handler and the participant planner read the
+//! step configuration through it, which keeps the schema — including the
+//! canonical-vs-legacy agent-kind key — consistent across the adapter.
+
+use choreo_core::error::DomainError;
+use choreo_core::value_objects::{
+    AgentKind, Attributes, NumAgents, Rounds, Specialty, StepHandlerKind, TaskDescription,
+};
+use serde_json::Value;
+
+/// Agent kind assumed when a step does not declare one.
+const DEFAULT_AGENT_KIND: &str = "noop";
+
+/// Configuration keys recognised on a ceremony step's handler config.
+mod key {
+    pub(super) const PROMPT: &str = "prompt";
+    pub(super) const SPECIALTY: &str = "specialty";
+    pub(super) const ROUNDS: &str = "rounds";
+    pub(super) const NUM_AGENTS: &str = "num_agents";
+    /// Canonical agent-kind key.
+    pub(super) const AGENT_KIND: &str = "agent_kind";
+    /// Legacy agent-kind key, still accepted for backwards compatibility.
+    pub(super) const AGENT_KIND_LEGACY: &str = "agent.kind";
+    pub(super) const PARTICIPANTS: &str = "participants";
+}
+
+/// Stable `DomainError` field names surfaced when a value is malformed.
+mod field {
+    pub(super) const PROMPT: &str = "ceremony_step.config.prompt";
+    pub(super) const ROUNDS: &str = "ceremony_step.config.rounds";
+    pub(super) const NUM_AGENTS: &str = "ceremony_step.config.num_agents";
+    pub(super) const PARTICIPANTS: &str = "ceremony_step.config.participants";
+}
+
+/// A validated, typed view over one ceremony step's handler configuration.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CeremonyStepConfig<'a> {
+    attributes: &'a Attributes,
+    handler_kind: &'a StepHandlerKind,
+}
+
+impl<'a> CeremonyStepConfig<'a> {
+    /// Wrap a step's handler-config attributes together with the handler
+    /// kind that backs the specialty default.
+    pub(crate) fn new(attributes: &'a Attributes, handler_kind: &'a StepHandlerKind) -> Self {
+        Self {
+            attributes,
+            handler_kind,
+        }
+    }
+
+    /// Required free-text prompt the step deliberates over.
+    pub(crate) fn prompt(&self) -> Result<TaskDescription, DomainError> {
+        TaskDescription::new(required_string(
+            self.attributes.get(key::PROMPT),
+            field::PROMPT,
+        )?)
+    }
+
+    /// Specialty the step deliberates under, defaulting to the handler kind.
+    pub(crate) fn specialty(&self) -> Result<Specialty, DomainError> {
+        Specialty::new(
+            optional_string(self.attributes.get(key::SPECIALTY))
+                .unwrap_or_else(|| self.handler_kind.as_str()),
+        )
+    }
+
+    /// Number of deliberation rounds; the domain default when unset.
+    pub(crate) fn rounds(&self) -> Result<Rounds, DomainError> {
+        match optional_u32(self.attributes.get(key::ROUNDS), field::ROUNDS)? {
+            Some(value) => Rounds::new(value),
+            None => Ok(Rounds::default()),
+        }
+    }
+
+    /// Explicit agent count, if the step declares one.
+    pub(crate) fn num_agents(&self) -> Result<Option<NumAgents>, DomainError> {
+        optional_u32(self.attributes.get(key::NUM_AGENTS), field::NUM_AGENTS)?
+            .map(NumAgents::new)
+            .transpose()
+    }
+
+    /// Agent kind, resolving the canonical `agent_kind` first, then the
+    /// legacy `agent.kind`, and defaulting to noop.
+    pub(crate) fn agent_kind(&self) -> Result<AgentKind, DomainError> {
+        AgentKind::new(
+            optional_string(self.attributes.get(key::AGENT_KIND))
+                .or_else(|| optional_string(self.attributes.get(key::AGENT_KIND_LEGACY)))
+                .unwrap_or(DEFAULT_AGENT_KIND),
+        )
+    }
+
+    /// Participant labels declared on the step, in order (possibly empty).
+    pub(crate) fn participant_labels(&self) -> Result<Vec<String>, DomainError> {
+        let Some(value) = self.attributes.get(key::PARTICIPANTS) else {
+            return Ok(Vec::new());
+        };
+        if value.is_null() {
+            return Ok(Vec::new());
+        }
+        let Some(items) = value.as_array() else {
+            return Err(DomainError::InvalidCharacters {
+                field: field::PARTICIPANTS,
+            });
+        };
+        items
+            .iter()
+            .map(|item| {
+                item.as_str()
+                    .map(str::trim)
+                    .filter(|label| !label.is_empty())
+                    .map(str::to_owned)
+                    .ok_or(DomainError::InvalidCharacters {
+                        field: field::PARTICIPANTS,
+                    })
+            })
+            .collect()
+    }
+}
+
+fn required_string(value: Option<&Value>, field: &'static str) -> Result<String, DomainError> {
+    let Some(value) = value else {
+        return Err(DomainError::EmptyField { field });
+    };
+    let Some(raw) = value.as_str() else {
+        return Err(DomainError::InvalidCharacters { field });
+    };
+    if raw.trim().is_empty() {
+        return Err(DomainError::EmptyField { field });
+    }
+    Ok(raw.to_owned())
+}
+
+fn optional_string(value: Option<&Value>) -> Option<&str> {
+    value
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|raw| !raw.is_empty())
+}
+
+fn optional_u32(value: Option<&Value>, field: &'static str) -> Result<Option<u32>, DomainError> {
+    let Some(value) = value else { return Ok(None) };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let Some(raw) = value.as_u64() else {
+        return Err(DomainError::InvalidCharacters { field });
+    };
+    u32::try_from(raw)
+        .map(Some)
+        .map_err(|_| DomainError::OutOfRange {
+            field,
+            value: raw as f64,
+            min: 0.0,
+            max: f64::from(u32::MAX),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use serde_json::json;
+
+    use super::*;
+
+    fn config(map: BTreeMap<String, Value>) -> (Attributes, StepHandlerKind) {
+        (
+            Attributes::new(map).unwrap(),
+            StepHandlerKind::new("facilitation_prompt").unwrap(),
+        )
+    }
+
+    #[test]
+    fn specialty_defaults_to_handler_kind() {
+        let (attributes, handler_kind) = config(BTreeMap::new());
+        let step = CeremonyStepConfig::new(&attributes, &handler_kind);
+
+        assert_eq!(step.specialty().unwrap().as_str(), "facilitation_prompt");
+    }
+
+    #[test]
+    fn explicit_specialty_wins() {
+        let (attributes, handler_kind) = config(BTreeMap::from([(
+            "specialty".to_owned(),
+            json!("facilitator"),
+        )]));
+        let step = CeremonyStepConfig::new(&attributes, &handler_kind);
+
+        assert_eq!(step.specialty().unwrap().as_str(), "facilitator");
+    }
+
+    #[test]
+    fn rounds_default_is_one_when_unset() {
+        let (attributes, handler_kind) = config(BTreeMap::new());
+        let step = CeremonyStepConfig::new(&attributes, &handler_kind);
+
+        assert_eq!(step.rounds().unwrap().get(), 1);
+    }
+
+    #[test]
+    fn agent_kind_prefers_canonical_key() {
+        let (attributes, handler_kind) = config(BTreeMap::from([
+            ("agent_kind".to_owned(), json!("vllm")),
+            ("agent.kind".to_owned(), json!("openai")),
+        ]));
+        let step = CeremonyStepConfig::new(&attributes, &handler_kind);
+
+        assert_eq!(step.agent_kind().unwrap().as_str(), "vllm");
+    }
+
+    #[test]
+    fn agent_kind_falls_back_to_legacy_key() {
+        let (attributes, handler_kind) =
+            config(BTreeMap::from([("agent.kind".to_owned(), json!("openai"))]));
+        let step = CeremonyStepConfig::new(&attributes, &handler_kind);
+
+        assert_eq!(step.agent_kind().unwrap().as_str(), "openai");
+    }
+
+    #[test]
+    fn agent_kind_defaults_to_noop() {
+        let (attributes, handler_kind) = config(BTreeMap::new());
+        let step = CeremonyStepConfig::new(&attributes, &handler_kind);
+
+        assert_eq!(step.agent_kind().unwrap().as_str(), "noop");
+    }
+
+    #[test]
+    fn missing_prompt_is_rejected() {
+        let (attributes, handler_kind) = config(BTreeMap::new());
+        let step = CeremonyStepConfig::new(&attributes, &handler_kind);
+
+        assert!(matches!(
+            step.prompt().unwrap_err(),
+            DomainError::EmptyField {
+                field: "ceremony_step.config.prompt"
+            }
+        ));
+    }
+
+    #[test]
+    fn non_array_participants_are_rejected() {
+        let (attributes, handler_kind) = config(BTreeMap::from([(
+            "participants".to_owned(),
+            json!("facilitator"),
+        )]));
+        let step = CeremonyStepConfig::new(&attributes, &handler_kind);
+
+        assert!(matches!(
+            step.participant_labels().unwrap_err(),
+            DomainError::InvalidCharacters {
+                field: "ceremony_step.config.participants"
+            }
+        ));
+    }
+}

--- a/crates/choreo-adapters/src/ceremony/deliberation_step_config.rs
+++ b/crates/choreo-adapters/src/ceremony/deliberation_step_config.rs
@@ -1,7 +1,8 @@
 use choreo_core::error::DomainError;
 use choreo_core::ports::CeremonyStepHandlerRequest;
 use choreo_core::value_objects::{NumAgents, Rounds, Specialty, TaskDescription};
-use serde_json::Value;
+
+use super::CeremonyStepConfig;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeliberationStepConfig {
@@ -13,30 +14,16 @@ pub struct DeliberationStepConfig {
 
 impl DeliberationStepConfig {
     pub fn from_request(request: &CeremonyStepHandlerRequest) -> Result<Self, DomainError> {
-        let attributes = request.handler_config().attributes();
-        let task_description = TaskDescription::new(required_string(
-            attributes.get("prompt"),
-            "ceremony_step.config.prompt",
-        )?)?;
-        let specialty = Specialty::new(
-            optional_string(attributes.get("specialty")).unwrap_or(request.handler_kind().as_str()),
-        )?;
-        let rounds = optional_u32(attributes.get("rounds"), "ceremony_step.config.rounds")?
-            .map(Rounds::new)
-            .transpose()?
-            .unwrap_or_default();
-        let num_agents = optional_u32(
-            attributes.get("num_agents"),
-            "ceremony_step.config.num_agents",
-        )?
-        .map(NumAgents::new)
-        .transpose()?;
+        let config = CeremonyStepConfig::new(
+            request.handler_config().attributes(),
+            request.handler_kind(),
+        );
 
         Ok(Self {
-            specialty,
-            task_description,
-            rounds,
-            num_agents,
+            task_description: config.prompt()?,
+            specialty: config.specialty()?,
+            rounds: config.rounds()?,
+            num_agents: config.num_agents()?,
         })
     }
 
@@ -61,43 +48,6 @@ impl DeliberationStepConfig {
     }
 }
 
-fn required_string(value: Option<&Value>, field: &'static str) -> Result<String, DomainError> {
-    let Some(value) = value else {
-        return Err(DomainError::EmptyField { field });
-    };
-    let Some(raw) = value.as_str() else {
-        return Err(DomainError::InvalidCharacters { field });
-    };
-    if raw.trim().is_empty() {
-        return Err(DomainError::EmptyField { field });
-    }
-    Ok(raw.to_owned())
-}
-
-fn optional_string(value: Option<&Value>) -> Option<&str> {
-    value
-        .and_then(Value::as_str)
-        .filter(|raw| !raw.trim().is_empty())
-}
-
-fn optional_u32(value: Option<&Value>, field: &'static str) -> Result<Option<u32>, DomainError> {
-    let Some(value) = value else { return Ok(None) };
-    if value.is_null() {
-        return Ok(None);
-    }
-    let Some(raw) = value.as_u64() else {
-        return Err(DomainError::InvalidCharacters { field });
-    };
-    u32::try_from(raw)
-        .map(Some)
-        .map_err(|_| DomainError::OutOfRange {
-            field,
-            value: raw as f64,
-            min: 0.0,
-            max: f64::from(u32::MAX),
-        })
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
@@ -106,7 +56,7 @@ mod tests {
         Attributes, CeremonyContext, CeremonyId, CeremonyName, CeremonyVersion, StateId,
         StepAttempt, StepHandlerConfig, StepHandlerKind, StepId,
     };
-    use serde_json::json;
+    use serde_json::{json, Value};
 
     use super::*;
 

--- a/crates/choreo-adapters/src/ceremony/mod.rs
+++ b/crates/choreo-adapters/src/ceremony/mod.rs
@@ -1,7 +1,10 @@
 mod ceremony_participant_plan_adapter;
+mod ceremony_step_config;
 mod deliberating_ceremony_step_handler;
 mod deliberation_step_config;
 
 pub use ceremony_participant_plan_adapter::CeremonyParticipantPlanAdapter;
 pub use deliberating_ceremony_step_handler::DeliberatingCeremonyStepHandler;
 pub use deliberation_step_config::DeliberationStepConfig;
+
+pub(crate) use ceremony_step_config::CeremonyStepConfig;


### PR DESCRIPTION
## Quality slice 3/7 — kill primitive obsession in step config (audit: primitive-obsession)

The deliberation step handler and the participant planner both read a ceremony step's handler-config `Attributes` with **scattered string literals** and each carried its **own copy** of the `required_string` / `optional_string` / `optional_u32` parsing helpers (audit findings F3, F4). The config-key schema — including the `agent_kind` vs `agent.kind` ambiguity — could drift between the two.

### Fix
New `CeremonyStepConfig` value object: a typed view over the step's attributes that owns the key schema in one place and exposes fail-fast typed accessors:

| accessor | behaviour |
|---|---|
| `prompt()` | required → `TaskDescription` |
| `specialty()` | defaults to the handler kind |
| `rounds()` | domain default (1) when unset |
| `num_agents()` | `Option<NumAgents>` |
| `agent_kind()` | canonical `agent_kind`, then legacy `agent.kind`, then `noop` |
| `participant_labels()` | ordered labels, possibly empty |

Both consumers now read through it and their duplicated helpers are deleted. The `agent.kind` legacy key is **kept** (non-breaking) and documented as backwards-compat; `agent_kind` is canonical.

### Tests
+8 unit tests on `CeremonyStepConfig` (specialty defaulting, rounds default, agent-kind canonical/legacy/default, required-prompt error, non-array participants error). Existing adapter tests pass unchanged — **no behaviour change**.

### Validation
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets` + provider features `-- -D warnings` ✅
- `cargo test --workspace` + provider features ✅

**Breaking:** none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)