### PR TITLE
feat(ceremony): thread the prior-step transcript into each step

### DIFF
--- a/crates/choreo-adapters/src/ceremony/ceremony_step_config.rs
+++ b/crates/choreo-adapters/src/ceremony/ceremony_step_config.rs
@@ -30,6 +30,8 @@ mod key {
     /// Legacy agent-kind key, still accepted for backwards compatibility.
     pub(super) const AGENT_KIND_LEGACY: &str = "agent.kind";
     pub(super) const PARTICIPANTS: &str = "participants";
+    /// Whether the step deliberates with the prior transcript in view.
+    pub(super) const SEE_PRIOR: &str = "see_prior";
 }
 
 /// Stable `DomainError` field names surfaced when a value is malformed.
@@ -38,6 +40,7 @@ mod field {
     pub(super) const ROUNDS: &str = "ceremony_step.config.rounds";
     pub(super) const NUM_AGENTS: &str = "ceremony_step.config.num_agents";
     pub(super) const PARTICIPANTS: &str = "ceremony_step.config.participants";
+    pub(super) const SEE_PRIOR: &str = "ceremony_step.config.see_prior";
 }
 
 /// A validated, typed view over one ceremony step's handler configuration.
@@ -124,6 +127,14 @@ impl<'a> CeremonyStepConfig<'a> {
             })
             .collect()
     }
+
+    /// Whether the step should deliberate with the prior transcript in
+    /// view. Defaults to `true`: a ceremony is a conversation, so a step
+    /// builds on what came before unless it is explicitly made blind
+    /// (for example, independent estimates before a reveal).
+    pub(crate) fn see_prior_steps(&self) -> Result<bool, DomainError> {
+        Ok(optional_bool(self.attributes.get(key::SEE_PRIOR), field::SEE_PRIOR)?.unwrap_or(true))
+    }
 }
 
 fn required_string(value: Option<&Value>, field: &'static str) -> Result<String, DomainError> {
@@ -144,6 +155,17 @@ fn optional_string(value: Option<&Value>) -> Option<&str> {
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|raw| !raw.is_empty())
+}
+
+fn optional_bool(value: Option<&Value>, field: &'static str) -> Result<Option<bool>, DomainError> {
+    match value {
+        None => Ok(None),
+        Some(value) if value.is_null() => Ok(None),
+        Some(value) => value
+            .as_bool()
+            .map(Some)
+            .ok_or(DomainError::InvalidCharacters { field }),
+    }
 }
 
 fn optional_u32(value: Option<&Value>, field: &'static str) -> Result<Option<u32>, DomainError> {
@@ -259,6 +281,37 @@ mod tests {
             step.participant_labels().unwrap_err(),
             DomainError::InvalidCharacters {
                 field: "ceremony_step.config.participants"
+            }
+        ));
+    }
+
+    #[test]
+    fn see_prior_defaults_to_true() {
+        let (attributes, handler_kind) = config(BTreeMap::new());
+        let step = CeremonyStepConfig::new(&attributes, &handler_kind);
+
+        assert!(step.see_prior_steps().unwrap());
+    }
+
+    #[test]
+    fn see_prior_can_be_disabled() {
+        let (attributes, handler_kind) =
+            config(BTreeMap::from([("see_prior".to_owned(), json!(false))]));
+        let step = CeremonyStepConfig::new(&attributes, &handler_kind);
+
+        assert!(!step.see_prior_steps().unwrap());
+    }
+
+    #[test]
+    fn non_bool_see_prior_is_rejected() {
+        let (attributes, handler_kind) =
+            config(BTreeMap::from([("see_prior".to_owned(), json!("yes"))]));
+        let step = CeremonyStepConfig::new(&attributes, &handler_kind);
+
+        assert!(matches!(
+            step.see_prior_steps().unwrap_err(),
+            DomainError::InvalidCharacters {
+                field: "ceremony_step.config.see_prior"
             }
         ));
     }

--- a/crates/choreo-adapters/src/ceremony/deliberating_ceremony_step_handler.rs
+++ b/crates/choreo-adapters/src/ceremony/deliberating_ceremony_step_handler.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use choreo_app::usecases::DeliberateUseCase;
-use choreo_core::entities::{Task, TaskConstraints};
+use choreo_core::entities::{
+    ContextItem, ContextSummary, ExternalContextBundle, Task, TaskConstraints,
+};
 use choreo_core::error::DomainError;
 use choreo_core::ports::{CeremonyStepHandlerPort, CeremonyStepHandlerRequest};
 use choreo_core::value_objects::{Attributes, StepOutput, StepResult, TaskId};
@@ -11,6 +13,11 @@ use serde_json::{json, Value};
 use tracing::info;
 
 use super::DeliberationStepConfig;
+
+/// `ContextItem.kind` used for prior ceremony interventions.
+const CONTRIBUTION_KIND: &str = "ceremony.contribution";
+/// Attribute key under which a deliberation winner's content is stored.
+const WINNER_CONTENT_KEY: &str = "winner_content";
 
 #[derive(Debug, Clone)]
 pub struct DeliberatingCeremonyStepHandler {
@@ -31,7 +38,12 @@ impl CeremonyStepHandlerPort for DeliberatingCeremonyStepHandler {
         request: CeremonyStepHandlerRequest,
     ) -> Result<StepResult, DomainError> {
         let config = DeliberationStepConfig::from_request(&request)?;
-        let task = task_from(&request, &config)?;
+        let external_context = if config.see_prior() {
+            external_context_from_transcript(&request)?
+        } else {
+            None
+        };
+        let task = task_from(&request, &config, external_context)?;
         let output = self.deliberate.execute(task).await?;
         let ranked = output.deliberation.ranked_outcomes()?;
         let winner = ranked
@@ -61,8 +73,9 @@ impl CeremonyStepHandlerPort for DeliberatingCeremonyStepHandler {
 fn task_from(
     request: &CeremonyStepHandlerRequest,
     config: &DeliberationStepConfig,
+    external_context: Option<ExternalContextBundle>,
 ) -> Result<Task, DomainError> {
-    Ok(Task::new(
+    Ok(Task::new_with_context(
         task_id_from(request)?,
         config.specialty().clone(),
         config.task_description().clone(),
@@ -73,7 +86,64 @@ fn task_from(
             None,
         ),
         Attributes::new(task_attributes(request, config))?,
+        external_context,
     ))
+}
+
+/// Render the prior-step transcript into an [`ExternalContextBundle`] so
+/// the deliberating agents see what earlier steps decided. Returns `None`
+/// when the transcript is empty.
+fn external_context_from_transcript(
+    request: &CeremonyStepHandlerRequest,
+) -> Result<Option<ExternalContextBundle>, DomainError> {
+    let transcript = request.transcript();
+    if transcript.is_empty() {
+        return Ok(None);
+    }
+
+    let items = transcript
+        .contributions()
+        .iter()
+        .enumerate()
+        .map(|(index, contribution)| {
+            let narrative = contribution
+                .output()
+                .attributes()
+                .get(WINNER_CONTENT_KEY)
+                .and_then(Value::as_str)
+                .map(str::to_owned);
+            ContextItem::new(
+                format!("contribution-{index}"),
+                CONTRIBUTION_KIND,
+                format!(
+                    "{} · {}",
+                    contribution.role_id().as_str(),
+                    contribution.step_id().as_str()
+                ),
+                narrative,
+                Attributes::empty(),
+                Vec::new(),
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let summary = ContextSummary::new(
+        format!(
+            "Prior interventions in this ceremony ({} so far).",
+            transcript.len()
+        ),
+        Attributes::empty(),
+    )?;
+
+    ExternalContextBundle::new(
+        "ceremony-transcript",
+        "ceremony.transcript.v1",
+        Some(summary),
+        items,
+        Vec::new(),
+        Attributes::empty(),
+    )
+    .map(Some)
 }
 
 fn task_id_from(request: &CeremonyStepHandlerRequest) -> Result<TaskId, DomainError> {
@@ -162,8 +232,9 @@ mod tests {
     use choreo_core::entities::Council;
     use choreo_core::ports::{ClockPort, CouncilRegistryPort, StatisticsPort};
     use choreo_core::value_objects::{
-        AgentId, Attributes, CeremonyContext, CeremonyId, CeremonyName, CeremonyVersion, CouncilId,
-        Specialty, StateId, StepAttempt, StepHandlerConfig, StepHandlerKind, StepId, StepStatus,
+        AgentId, Attributes, CeremonyContext, CeremonyId, CeremonyName, CeremonyStepContribution,
+        CeremonyTranscript, CeremonyVersion, CouncilId, RoleId, Specialty, StateId, StepAttempt,
+        StepHandlerConfig, StepHandlerKind, StepId, StepOutput, StepStatus,
     };
     use serde_json::json;
 
@@ -250,6 +321,44 @@ mod tests {
                 .get(&specialty)
                 .copied(),
             Some(1)
+        );
+    }
+
+    #[test]
+    fn empty_transcript_yields_no_external_context() {
+        let request = request_with_prompt();
+
+        assert!(external_context_from_transcript(&request)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn transcript_renders_each_contribution_as_a_context_item() {
+        let contribution = CeremonyStepContribution::new(
+            StepId::new("open_room").unwrap(),
+            RoleId::new("FACILITATOR").unwrap(),
+            StepOutput::new(
+                Attributes::new(BTreeMap::from([(
+                    "winner_content".to_owned(),
+                    json!("Restating the brief and inviting perspectives."),
+                )]))
+                .unwrap(),
+            ),
+        );
+        let request = request_with_prompt()
+            .with_transcript(CeremonyTranscript::empty().appended(contribution));
+
+        let bundle = external_context_from_transcript(&request)
+            .unwrap()
+            .expect("a non-empty transcript renders a bundle");
+
+        assert_eq!(bundle.items().len(), 1);
+        assert_eq!(bundle.items()[0].kind(), "ceremony.contribution");
+        assert!(bundle.items()[0].title().contains("FACILITATOR"));
+        assert_eq!(
+            bundle.items()[0].narrative(),
+            Some("Restating the brief and inviting perspectives.")
         );
     }
 

--- a/crates/choreo-adapters/src/ceremony/deliberation_step_config.rs
+++ b/crates/choreo-adapters/src/ceremony/deliberation_step_config.rs
@@ -10,6 +10,7 @@ pub struct DeliberationStepConfig {
     task_description: TaskDescription,
     rounds: Rounds,
     num_agents: Option<NumAgents>,
+    see_prior: bool,
 }
 
 impl DeliberationStepConfig {
@@ -24,6 +25,7 @@ impl DeliberationStepConfig {
             specialty: config.specialty()?,
             rounds: config.rounds()?,
             num_agents: config.num_agents()?,
+            see_prior: config.see_prior_steps()?,
         })
     }
 
@@ -45,6 +47,13 @@ impl DeliberationStepConfig {
     #[must_use]
     pub fn num_agents(&self) -> Option<NumAgents> {
         self.num_agents
+    }
+
+    /// Whether the step deliberates with the prior ceremony transcript in
+    /// view (defaults to `true`).
+    #[must_use]
+    pub fn see_prior(&self) -> bool {
+        self.see_prior
     }
 }
 

--- a/crates/choreo-app/src/usecases/ceremony_test_support.rs
+++ b/crates/choreo-app/src/usecases/ceremony_test_support.rs
@@ -4,14 +4,15 @@ use async_trait::async_trait;
 use choreo_core::entities::{CeremonyDefinition, CeremonyInstance};
 use choreo_core::error::DomainError;
 use choreo_core::ports::{
-    CeremonyDefinitionRepositoryPort, CeremonyInstanceRepositoryPort, CeremonyStepHandlerPort,
-    CeremonyStepHandlerRequest, ClockPort,
+    CeremonyContextStorePort, CeremonyDefinitionRepositoryPort, CeremonyInstanceRepositoryPort,
+    CeremonyStepHandlerPort, CeremonyStepHandlerRequest, ClockPort,
 };
 use choreo_core::value_objects::{
     CeremonyContext, CeremonyGuard, CeremonyId, CeremonyName, CeremonyRole, CeremonyState,
-    CeremonyStep, CeremonyTransition, CeremonyVersion, DurationMs, GuardCondition, GuardName,
-    IdempotencyKey, LeaseOwnerId, RetryPolicy, RoleAction, RoleId, StateId, StepAttempt,
-    StepHandlerConfig, StepHandlerKind, StepId, StepResult, StepStatus, TransitionTrigger,
+    CeremonyStep, CeremonyStepContribution, CeremonyTranscript, CeremonyTransition,
+    CeremonyVersion, DurationMs, GuardCondition, GuardName, IdempotencyKey, LeaseOwnerId,
+    RetryPolicy, RoleAction, RoleId, StateId, StepAttempt, StepHandlerConfig, StepHandlerKind,
+    StepId, StepResult, StepStatus, TransitionTrigger,
 };
 use time::macros::datetime;
 use time::OffsetDateTime;
@@ -156,6 +157,42 @@ impl CeremonyStepHandlerPort for StepHandlerFake {
     }
 }
 
+#[derive(Debug, Default)]
+pub(super) struct ContextStoreFake {
+    inner: RwLock<BTreeMap<CeremonyId, Vec<CeremonyStepContribution>>>,
+}
+
+#[async_trait]
+impl CeremonyContextStorePort for ContextStoreFake {
+    async fn append(
+        &self,
+        instance_id: &CeremonyId,
+        contribution: CeremonyStepContribution,
+    ) -> Result<(), DomainError> {
+        self.inner
+            .write()
+            .await
+            .entry(instance_id.clone())
+            .or_default()
+            .push(contribution);
+        Ok(())
+    }
+
+    async fn transcript(
+        &self,
+        instance_id: &CeremonyId,
+    ) -> Result<CeremonyTranscript, DomainError> {
+        Ok(CeremonyTranscript::new(
+            self.inner
+                .read()
+                .await
+                .get(instance_id)
+                .cloned()
+                .unwrap_or_default(),
+        ))
+    }
+}
+
 pub(super) fn now() -> OffsetDateTime {
     datetime!(2026-06-06 12:00:00 UTC)
 }
@@ -245,6 +282,84 @@ pub(super) fn definition() -> CeremonyDefinition {
         vec![transition],
         vec![step],
         vec![guard],
+        vec![role],
+    )
+    .unwrap()
+}
+
+/// A two-step linear ceremony (`open` in OPENING, `respond` in
+/// RESPONDING) used to prove that step outputs thread forward into the
+/// transcript the next step receives.
+pub(super) fn two_step_definition() -> CeremonyDefinition {
+    let open = CeremonyStep::new(
+        StepId::new("open").unwrap(),
+        StateId::new("OPENING").unwrap(),
+        StepHandlerKind::new("multiagent_round").unwrap(),
+        StepHandlerConfig::empty(),
+        RetryPolicy::single_attempt(),
+        None,
+    );
+    let respond = CeremonyStep::new(
+        StepId::new("respond").unwrap(),
+        StateId::new("RESPONDING").unwrap(),
+        StepHandlerKind::new("multiagent_round").unwrap(),
+        StepHandlerConfig::empty(),
+        RetryPolicy::single_attempt(),
+        None,
+    );
+    let open_done = CeremonyGuard::new(
+        GuardName::new("open_done").unwrap(),
+        GuardCondition::StepStatus {
+            step_id: open.id().clone(),
+            status: StepStatus::Completed,
+        },
+    );
+    let respond_done = CeremonyGuard::new(
+        GuardName::new("respond_done").unwrap(),
+        GuardCondition::StepStatus {
+            step_id: respond.id().clone(),
+            status: StepStatus::Completed,
+        },
+    );
+    let opened = CeremonyTransition::new(
+        StateId::new("OPENING").unwrap(),
+        StateId::new("RESPONDING").unwrap(),
+        TransitionTrigger::new("opened").unwrap(),
+        vec![open_done.name().clone()],
+    )
+    .unwrap();
+    let responded = CeremonyTransition::new(
+        StateId::new("RESPONDING").unwrap(),
+        StateId::new("CLOSED").unwrap(),
+        TransitionTrigger::new("responded").unwrap(),
+        vec![respond_done.name().clone()],
+    )
+    .unwrap();
+    let role = CeremonyRole::new(
+        role_id(),
+        vec![
+            RoleAction::step(open.id().clone()),
+            RoleAction::step(respond.id().clone()),
+            RoleAction::transition(opened.trigger().clone()),
+            RoleAction::transition(responded.trigger().clone()),
+        ],
+    )
+    .unwrap();
+
+    CeremonyDefinition::new(
+        CeremonyName::new("two_step_meeting").unwrap(),
+        version(),
+        None,
+        Vec::new(),
+        Vec::new(),
+        vec![
+            CeremonyState::initial(StateId::new("OPENING").unwrap()),
+            CeremonyState::intermediate(StateId::new("RESPONDING").unwrap()),
+            CeremonyState::terminal(StateId::new("CLOSED").unwrap()),
+        ],
+        vec![opened, responded],
+        vec![open, respond],
+        vec![open_done, respond_done],
         vec![role],
     )
     .unwrap()

--- a/crates/choreo-app/src/usecases/run_ceremony_use_case.rs
+++ b/crates/choreo-app/src/usecases/run_ceremony_use_case.rs
@@ -5,12 +5,12 @@ use std::sync::Arc;
 use choreo_core::entities::{CeremonyDefinition, CeremonyInstance};
 use choreo_core::error::DomainError;
 use choreo_core::ports::{
-    CeremonyDefinitionRepositoryPort, CeremonyInstanceRepositoryPort, CeremonyStepHandlerPort,
-    CeremonyStepHandlerRequest, ClockPort,
+    CeremonyContextStorePort, CeremonyDefinitionRepositoryPort, CeremonyInstanceRepositoryPort,
+    CeremonyStepHandlerPort, CeremonyStepHandlerRequest, ClockPort,
 };
 use choreo_core::value_objects::{
-    DurationMs, IdempotencyKey, LeaseOwnerId, RoleId, StepAttempt, StepErrorMessage, StepId,
-    StepLease, StepResult,
+    CeremonyStepContribution, CeremonyTranscript, DurationMs, IdempotencyKey, LeaseOwnerId, RoleId,
+    StepAttempt, StepErrorMessage, StepId, StepLease, StepResult,
 };
 
 use super::ceremony_step_trace::CeremonyStepTrace;
@@ -21,6 +21,7 @@ pub struct RunCeremonyUseCase {
     definitions: Arc<dyn CeremonyDefinitionRepositoryPort>,
     instances: Arc<dyn CeremonyInstanceRepositoryPort>,
     handler: Arc<dyn CeremonyStepHandlerPort>,
+    context_store: Arc<dyn CeremonyContextStorePort>,
     clock: Arc<dyn ClockPort>,
 }
 
@@ -36,12 +37,14 @@ impl RunCeremonyUseCase {
         definitions: Arc<dyn CeremonyDefinitionRepositoryPort>,
         instances: Arc<dyn CeremonyInstanceRepositoryPort>,
         handler: Arc<dyn CeremonyStepHandlerPort>,
+        context_store: Arc<dyn CeremonyContextStorePort>,
         clock: Arc<dyn ClockPort>,
     ) -> Self {
         Self {
             definitions,
             instances,
             handler,
+            context_store,
             clock,
         }
     }
@@ -88,6 +91,7 @@ impl RunCeremonyUseCase {
                     continue;
                 }
                 let role_id = definition.role_id_for_step(&step_id)?;
+                let transcript = self.context_store.transcript(&id).await?;
                 let (attempt, step_result) = self
                     .run_step(
                         &definition,
@@ -97,8 +101,21 @@ impl RunCeremonyUseCase {
                         &lease_owner_id,
                         lease_ttl,
                         step_traces.len(),
+                        transcript,
                     )
                     .await?;
+                if step_result.is_success() {
+                    self.context_store
+                        .append(
+                            &id,
+                            CeremonyStepContribution::new(
+                                step_id.clone(),
+                                role_id.clone(),
+                                step_result.output().clone(),
+                            ),
+                        )
+                        .await?;
+                }
                 step_traces.push(CeremonyStepTrace::new(
                     state_id.clone(),
                     step_id,
@@ -145,6 +162,7 @@ impl RunCeremonyUseCase {
         lease_owner_id: &LeaseOwnerId,
         lease_ttl: DurationMs,
         trace_index: usize,
+        transcript: CeremonyTranscript,
     ) -> Result<(StepAttempt, StepResult), DomainError> {
         let step = definition
             .step(step_id)
@@ -177,7 +195,8 @@ impl RunCeremonyUseCase {
             step.handler_config().clone(),
             instance.context().clone(),
             attempt,
-        );
+        )
+        .with_transcript(transcript);
         let step_result = self.execute_handler(request).await?;
 
         let mut refreshed = self.instances.get(instance.id()).await?;
@@ -213,8 +232,8 @@ mod tests {
     use super::*;
     use crate::usecases::ceremony_test_support::{
         approval_definition, ceremony_id, definition, lease_owner, lease_ttl, now,
-        started_instance, step_id, DefinitionRepositoryFake, FixedClock, InstanceRepositoryFake,
-        StepHandlerFake,
+        started_instance, step_id, two_step_definition, ContextStoreFake, DefinitionRepositoryFake,
+        FixedClock, InstanceRepositoryFake, StepHandlerFake,
     };
 
     #[tokio::test]
@@ -229,6 +248,7 @@ mod tests {
             definitions,
             instances.clone(),
             handler.clone(),
+            Arc::new(ContextStoreFake::default()),
             Arc::new(FixedClock::new(now())),
         );
 
@@ -266,6 +286,7 @@ mod tests {
             definitions,
             instances.clone(),
             handler,
+            Arc::new(ContextStoreFake::default()),
             Arc::new(FixedClock::new(now())),
         );
 
@@ -309,6 +330,7 @@ mod tests {
             definitions,
             instances,
             handler.clone(),
+            Arc::new(ContextStoreFake::default()),
             Arc::new(FixedClock::new(now())),
         );
 
@@ -346,6 +368,7 @@ mod tests {
             definitions,
             instances,
             handler,
+            Arc::new(ContextStoreFake::default()),
             Arc::new(FixedClock::new(now())),
         );
         let input = || {
@@ -385,6 +408,7 @@ mod tests {
             definitions.clone(),
             instances,
             handler.clone(),
+            Arc::new(ContextStoreFake::default()),
             Arc::new(FixedClock::new(now())),
         );
 
@@ -407,5 +431,46 @@ mod tests {
         ));
         assert!(definitions.list().await.unwrap().is_empty());
         assert!(handler.requests().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn threads_prior_step_output_into_the_next_step() {
+        let definition = two_step_definition();
+        let definitions = Arc::new(DefinitionRepositoryFake::default());
+        let instances = Arc::new(InstanceRepositoryFake::default());
+        let handler = Arc::new(StepHandlerFake::succeeding(
+            StepResult::completed(StepOutput::empty()).unwrap(),
+        ));
+        let usecase = RunCeremonyUseCase::new(
+            definitions,
+            instances,
+            handler.clone(),
+            Arc::new(ContextStoreFake::default()),
+            Arc::new(FixedClock::new(now())),
+        );
+
+        usecase
+            .execute(RunCeremonyInput::new(
+                ceremony_id(),
+                definition,
+                CeremonyContext::empty(),
+                lease_owner(),
+                lease_ttl(),
+            ))
+            .await
+            .unwrap();
+
+        let requests = handler.requests().await;
+        assert_eq!(requests.len(), 2);
+        // The first step opens the meeting with an empty transcript.
+        assert!(requests[0].transcript().is_empty());
+        // The second step receives the first step's contribution.
+        let transcript = requests[1].transcript();
+        assert_eq!(transcript.len(), 1);
+        assert_eq!(transcript.contributions()[0].step_id().as_str(), "open");
+        assert_eq!(
+            transcript.contributions()[0].role_id().as_str(),
+            "FACILITATOR"
+        );
     }
 }

--- a/crates/choreo-core/src/ports/ceremony_step_handler_request.rs
+++ b/crates/choreo-core/src/ports/ceremony_step_handler_request.rs
@@ -1,8 +1,8 @@
 //! Request passed to ceremony step handler adapters.
 
 use crate::value_objects::{
-    CeremonyContext, CeremonyId, CeremonyName, CeremonyVersion, StateId, StepAttempt,
-    StepHandlerConfig, StepHandlerKind, StepId,
+    CeremonyContext, CeremonyId, CeremonyName, CeremonyTranscript, CeremonyVersion, StateId,
+    StepAttempt, StepHandlerConfig, StepHandlerKind, StepId,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -16,6 +16,7 @@ pub struct CeremonyStepHandlerRequest {
     handler_config: StepHandlerConfig,
     context: CeremonyContext,
     attempt: StepAttempt,
+    transcript: CeremonyTranscript,
 }
 
 impl CeremonyStepHandlerRequest {
@@ -41,7 +42,17 @@ impl CeremonyStepHandlerRequest {
             handler_config,
             context,
             attempt,
+            transcript: CeremonyTranscript::empty(),
         }
+    }
+
+    /// Attach the prior-step transcript the engine accumulated for this
+    /// ceremony, so the handler can deliberate with earlier interventions
+    /// in view. Defaults to an empty transcript when not set.
+    #[must_use]
+    pub fn with_transcript(mut self, transcript: CeremonyTranscript) -> Self {
+        self.transcript = transcript;
+        self
     }
 
     #[must_use]
@@ -87,5 +98,12 @@ impl CeremonyStepHandlerRequest {
     #[must_use]
     pub fn attempt(&self) -> StepAttempt {
         self.attempt
+    }
+
+    /// The transcript of interventions produced by earlier steps of this
+    /// ceremony.
+    #[must_use]
+    pub fn transcript(&self) -> &CeremonyTranscript {
+        &self.transcript
     }
 }

--- a/crates/choreo-tests-integration/src/grpc_fixture.rs
+++ b/crates/choreo-tests-integration/src/grpc_fixture.rs
@@ -24,7 +24,7 @@ use choreo_adapters::ceremony::DeliberatingCeremonyStepHandler;
 use choreo_adapters::clock::SystemClock;
 use choreo_adapters::grpc::ChoreographerGrpcService;
 use choreo_adapters::memory::{
-    InMemoryAgentRegistry, InMemoryCeremonyDefinitionRepository,
+    InMemoryAgentRegistry, InMemoryCeremonyContextStore, InMemoryCeremonyDefinitionRepository,
     InMemoryCeremonyInstanceRepository, InMemoryContractRegistry, InMemoryCouncilRegistry,
     InMemoryDeliberationRepository, InMemoryStatistics,
 };
@@ -145,6 +145,7 @@ impl GrpcFixture {
             ceremony_definitions,
             ceremony_instances,
             ceremony_step_handler,
+            Arc::new(InMemoryCeremonyContextStore::new()),
             clock.clone(),
         ));
         let create_council = Arc::new(CreateCouncilUseCase::new(
@@ -302,6 +303,7 @@ impl GrpcFixture {
             ceremony_definitions,
             ceremony_instances,
             ceremony_step_handler,
+            Arc::new(InMemoryCeremonyContextStore::new()),
             clock.clone(),
         ));
         let create_council = Arc::new(CreateCouncilUseCase::new(

--- a/crates/choreo/src/compose.rs
+++ b/crates/choreo/src/compose.rs
@@ -7,7 +7,7 @@ use choreo_adapters::ceremony::DeliberatingCeremonyStepHandler;
 use choreo_adapters::clock::SystemClock;
 use choreo_adapters::config::EnvConfiguration;
 use choreo_adapters::memory::{
-    InMemoryAgentRegistry, InMemoryCeremonyDefinitionRepository,
+    InMemoryAgentRegistry, InMemoryCeremonyContextStore, InMemoryCeremonyDefinitionRepository,
     InMemoryCeremonyInstanceRepository, InMemoryContractRegistry, InMemoryCouncilRegistry,
     InMemoryDeliberationRepository, InMemoryStatistics,
 };
@@ -33,10 +33,10 @@ use choreo_app::usecases::{
 };
 use choreo_core::error::DomainError;
 use choreo_core::ports::{
-    AgentFactoryPort, AgentRegistryPort, AgentResolverPort, CeremonyDefinitionRepositoryPort,
-    CeremonyInstanceRepositoryPort, CeremonyStepHandlerPort, ConfigurationPort,
-    ContractRegistryPort, CouncilRegistryPort, DeliberationRepositoryPort, ExecutorPort,
-    MessagingPort, ScoringPort, ServiceConfig, StatisticsPort, ValidatorPort,
+    AgentFactoryPort, AgentRegistryPort, AgentResolverPort, CeremonyContextStorePort,
+    CeremonyDefinitionRepositoryPort, CeremonyInstanceRepositoryPort, CeremonyStepHandlerPort,
+    ConfigurationPort, ContractRegistryPort, CouncilRegistryPort, DeliberationRepositoryPort,
+    ExecutorPort, MessagingPort, ScoringPort, ServiceConfig, StatisticsPort, ValidatorPort,
 };
 use thiserror::Error;
 use tracing::info;
@@ -142,6 +142,8 @@ pub async fn compose() -> Result<Application, ComposeError> {
         Arc::new(InMemoryCeremonyDefinitionRepository::new());
     let ceremony_instances: Arc<dyn CeremonyInstanceRepositoryPort> =
         Arc::new(InMemoryCeremonyInstanceRepository::new());
+    let ceremony_context_store: Arc<dyn CeremonyContextStorePort> =
+        Arc::new(InMemoryCeremonyContextStore::new());
 
     let MessagingWiring {
         port: messaging,
@@ -183,6 +185,7 @@ pub async fn compose() -> Result<Application, ComposeError> {
         ceremony_definitions,
         ceremony_instances,
         ceremony_step_handler,
+        ceremony_context_store,
         clock.clone(),
     ));
 


### PR DESCRIPTION
## Engine richness — M1b: make ceremonies a conversation

Wires the context-store port (#81) into the engine so each step deliberates with **what earlier steps decided** in view. This is what turns the 4-step editorial meeting from "4 monologues" into an actual conversation.

### Flow
1. `RunCeremonyUseCase` records each completed step's output into `CeremonyContextStorePort` (`append`).
2. Before running the next step, it reads the accumulated `CeremonyTranscript` (`transcript`) and attaches it to the step request (`with_transcript`).
3. `DeliberatingCeremonyStepHandler` renders the transcript into an `ExternalContextBundle` (one `ContextItem` per prior intervention, carrying the winner's content) — which the agent prompt **already embeds** (`prompts.rs`), so the council sees the meeting-so-far.

### YAML knob (per step)
| `config.see_prior` | effect |
|---|---|
| `true` (default) | step builds on the prior transcript |
| `false` | step is **blind** — independent contribution (e.g. estimates before a reveal) |

Parsed by the typed `CeremonyStepConfig`, surfaced via `DeliberationStepConfig::see_prior`.

### Agnostic
The store stays behind the port: the binary wires the generic `InMemoryCeremonyContextStore`; a **KMP / knowledge-plane** adapter can replace it later without touching the engine.

### Tests
- use case threads a 2-step ceremony → step 2's request carries step 1's contribution;
- handler renders a transcript into context items (none when empty);
- `see_prior` default / disable / non-bool reject;
- compose + `GrpcFixture` wire the store; the in-process `run_ceremony_rpc` integration test exercises the full threaded 4-step path.

### Validation
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets` + provider features `-- -D warnings` ✅
- `cargo test --workspace` + provider features ✅

**Breaking:** none — `with_transcript` is an additive builder; `see_prior` defaults to today's behaviour for steps with no prior transcript.

> Depends on #80 + #81 (already in `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)