### PR TITLE
feat(ceremony): add the daily standup ceremony

### DIFF
--- a/crates/choreo-e2e-runner/src/main.rs
+++ b/crates/choreo-e2e-runner/src/main.rs
@@ -7,14 +7,16 @@
 //!
 //! Exits 0 on success, non-zero on the first failed assertion.
 
+use std::collections::BTreeSet;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
 use scenario_selection::{
     parse_scenario_selection, scenario_selection_summary, E2eScenario, SCENARIO_SELECTION_ENV,
 };
 use scenarios::{
-    connect_with_retry, verify_causal_metadata_propagates_over_nats,
+    connect_with_retry, verify_causal_metadata_propagates_over_nats, verify_daily_standup_ceremony,
     verify_delete_missing_council_returns_false, verify_deliberate_returns_winner,
     verify_editorial_meeting_ceremony_against_vllm_kind, verify_editorial_meeting_ceremony_diagram,
     verify_external_context_bundle_round_trips, verify_multi_agent_council_against_real_vllm,
@@ -22,6 +24,7 @@ use scenarios::{
     verify_orchestrate_rejects_proposal_violating_json_schema, verify_seeded_council_visible,
     verify_structured_output_against_stub_llm, verify_structured_output_against_vllm_kind,
 };
+use tonic::transport::Channel;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 
@@ -52,44 +55,57 @@ async fn main() -> Result<()> {
 
     let mut client = connect_with_retry(&endpoint, Duration::from_secs(30)).await?;
 
+    run_selected_scenarios(&mut client, &selected_scenarios, &seed_specialty).await?;
+
+    info!("E2E scenarios passed");
+    Ok(())
+}
+
+/// Run each selected scenario in order, failing on the first assertion
+/// that does not hold.
+async fn run_selected_scenarios(
+    client: &mut ChoreographerServiceClient<Channel>,
+    selected_scenarios: &BTreeSet<E2eScenario>,
+    seed_specialty: &str,
+) -> Result<()> {
     if selected_scenarios.contains(&E2eScenario::SeededCouncil) {
         info!("scenario 1: seeded council is visible");
-        verify_seeded_council_visible(&mut client, &seed_specialty)
+        verify_seeded_council_visible(client, seed_specialty)
             .await
             .context("scenario 1 failed")?;
     }
 
     if selected_scenarios.contains(&E2eScenario::Deliberate) {
         info!("scenario 2: Deliberate on the seeded specialty returns a winner");
-        verify_deliberate_returns_winner(&mut client, &seed_specialty)
+        verify_deliberate_returns_winner(client, seed_specialty)
             .await
             .context("scenario 2 failed")?;
     }
 
     if selected_scenarios.contains(&E2eScenario::DeleteMissingCouncil) {
         info!("scenario 3: DeleteCouncil on a missing specialty returns deleted=false");
-        verify_delete_missing_council_returns_false(&mut client)
+        verify_delete_missing_council_returns_false(client)
             .await
             .context("scenario 3 failed")?;
     }
 
     if selected_scenarios.contains(&E2eScenario::CausalMetadata) {
         info!("scenario 4: causal metadata propagates from inbound trigger to outbound bus event");
-        verify_causal_metadata_propagates_over_nats(&seed_specialty)
+        verify_causal_metadata_propagates_over_nats(seed_specialty)
             .await
             .context("scenario 4 failed")?;
     }
 
     if selected_scenarios.contains(&E2eScenario::RuntimeExecutor) {
         info!("scenario 5: Orchestrate routes the winner through the configured Runtime executor");
-        verify_orchestrate_invokes_runtime_executor(&mut client, &seed_specialty)
+        verify_orchestrate_invokes_runtime_executor(client, seed_specialty)
             .await
             .context("scenario 5 failed")?;
     }
 
     if selected_scenarios.contains(&E2eScenario::StrictSchemaRejection) {
         info!("scenario 6: Orchestrate with a strict JSON Schema output contract rejects free-form proposals");
-        verify_orchestrate_rejects_proposal_violating_json_schema(&mut client, &seed_specialty)
+        verify_orchestrate_rejects_proposal_violating_json_schema(client, seed_specialty)
             .await
             .context("scenario 6 failed")?;
     }
@@ -98,7 +114,7 @@ async fn main() -> Result<()> {
         info!(
             "scenario 7: ExternalContextBundle round-trips to the outbound DeliberationCompleted envelope"
         );
-        verify_external_context_bundle_round_trips(&mut client, &seed_specialty)
+        verify_external_context_bundle_round_trips(client, seed_specialty)
             .await
             .context("scenario 7 failed")?;
     }
@@ -107,7 +123,7 @@ async fn main() -> Result<()> {
         info!(
             "scenario 8: structured-output Report contract passes against a stub OpenAI-shaped agent"
         );
-        verify_structured_output_against_stub_llm(&mut client)
+        verify_structured_output_against_stub_llm(client)
             .await
             .context("scenario 8 failed")?;
     }
@@ -116,32 +132,38 @@ async fn main() -> Result<()> {
         info!(
             "scenario 9: structured-output Report contract passes against the stub-llm via the vllm adapter"
         );
-        verify_structured_output_against_vllm_kind(&mut client)
+        verify_structured_output_against_vllm_kind(client)
             .await
             .context("scenario 9 failed")?;
     }
 
     if selected_scenarios.contains(&E2eScenario::VllmRealMultiAgent) {
         info!("scenario 10: real vLLM multi-agent council returns a schema-valid Report winner");
-        verify_multi_agent_council_against_real_vllm(&mut client)
+        verify_multi_agent_council_against_real_vllm(client)
             .await
             .context("scenario 10 failed")?;
     }
 
     if selected_scenarios.contains(&E2eScenario::CeremonyDiagram) {
         info!("scenario 11: four-role ceremony YAML renders a Mermaid conversation diagram");
-        verify_editorial_meeting_ceremony_diagram(&mut client)
+        verify_editorial_meeting_ceremony_diagram(client)
             .await
             .context("scenario 11 failed")?;
     }
 
     if selected_scenarios.contains(&E2eScenario::CeremonyVllm) {
         info!("scenario 12: four-agent ceremony YAML executes through the vLLM adapter");
-        verify_editorial_meeting_ceremony_against_vllm_kind(&mut client)
+        verify_editorial_meeting_ceremony_against_vllm_kind(client)
             .await
             .context("scenario 12 failed")?;
     }
 
-    info!("E2E scenarios passed");
+    if selected_scenarios.contains(&E2eScenario::DailyStandup) {
+        info!("scenario 13: four-role daily standup threads each turn through the transcript");
+        verify_daily_standup_ceremony(client)
+            .await
+            .context("scenario 13 failed")?;
+    }
+
     Ok(())
 }

--- a/crates/choreo-e2e-runner/src/scenario_selection.rs
+++ b/crates/choreo-e2e-runner/src/scenario_selection.rs
@@ -18,6 +18,7 @@ pub(crate) enum E2eScenario {
     VllmRealMultiAgent,
     CeremonyDiagram,
     CeremonyVllm,
+    DailyStandup,
 }
 
 impl E2eScenario {
@@ -40,6 +41,8 @@ impl E2eScenario {
     const CEREMONY: [Self; 1] = [Self::CeremonyDiagram];
 
     const CEREMONY_VLLM: [Self; 1] = [Self::CeremonyVllm];
+
+    const DAILY_STANDUP: [Self; 1] = [Self::DailyStandup];
 
     const CLUSTER_CONNECTIVITY: [Self; 4] = [
         Self::SeededCouncil,
@@ -71,6 +74,7 @@ impl E2eScenario {
             Self::VllmRealMultiAgent => 10,
             Self::CeremonyDiagram => 11,
             Self::CeremonyVllm => 12,
+            Self::DailyStandup => 13,
         }
     }
 }
@@ -124,6 +128,10 @@ fn add_scenario_token(token: &str, selected: &mut BTreeSet<E2eScenario>) -> Resu
             selected.extend(E2eScenario::CEREMONY_VLLM);
             return Ok(());
         }
+        "daily-standup" | "daily" | "standup" => {
+            selected.extend(E2eScenario::DAILY_STANDUP);
+            return Ok(());
+        }
         _ => {}
     }
 
@@ -149,7 +157,7 @@ fn add_scenario_token(token: &str, selected: &mut BTreeSet<E2eScenario>) -> Resu
     }
 
     bail!(
-        "unknown scenario selector `{token}`; expected compose, cluster-connectivity, runtime-stub, structured-output, vllm-real-multi-agent, ceremony-vllm, 1-12, or a range like 1-4"
+        "unknown scenario selector `{token}`; expected compose, cluster-connectivity, runtime-stub, structured-output, vllm-real-multi-agent, ceremony-vllm, daily-standup, 1-13, or a range like 1-4"
     )
 }
 
@@ -167,7 +175,8 @@ fn scenario_from_number(number: u8) -> Result<E2eScenario> {
         10 => Ok(E2eScenario::VllmRealMultiAgent),
         11 => Ok(E2eScenario::CeremonyDiagram),
         12 => Ok(E2eScenario::CeremonyVllm),
-        _ => bail!("scenario number {number} is out of range; expected 1-12"),
+        13 => Ok(E2eScenario::DailyStandup),
+        _ => bail!("scenario number {number} is out of range; expected 1-13"),
     }
 }
 
@@ -212,6 +221,9 @@ mod tests {
         assert_eq!(numbers(Some("ceremony-diagram")), vec![11]);
         assert_eq!(numbers(Some("ceremony-vllm")), vec![12]);
         assert_eq!(numbers(Some("gemma-ceremony")), vec![12]);
+        assert_eq!(numbers(Some("daily-standup")), vec![13]);
+        assert_eq!(numbers(Some("daily")), vec![13]);
+        assert_eq!(numbers(Some("standup")), vec![13]);
     }
 
     #[test]
@@ -224,11 +236,12 @@ mod tests {
         assert_eq!(numbers(Some("s10")), vec![10]);
         assert_eq!(numbers(Some("s11")), vec![11]);
         assert_eq!(numbers(Some("s12")), vec![12]);
+        assert_eq!(numbers(Some("s13")), vec![13]);
     }
 
     #[test]
     fn invalid_selection_is_rejected() {
-        assert!(parse_scenario_selection(Some("13")).is_err());
+        assert!(parse_scenario_selection(Some("14")).is_err());
         assert!(parse_scenario_selection(Some("4-1")).is_err());
         assert!(parse_scenario_selection(Some("unknown")).is_err());
     }

--- a/crates/choreo-e2e-runner/src/scenarios/daily_standup.rs
+++ b/crates/choreo-e2e-runner/src/scenarios/daily_standup.rs
@@ -1,0 +1,72 @@
+use anyhow::{bail, Context, Result};
+use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
+use choreo_proto::v1::RunCeremonyRequest;
+use tonic::transport::Channel;
+use tracing::info;
+
+const DAILY_STANDUP_CEREMONY: &str =
+    include_str!("../../../../tests/e2e/ceremonies/daily-standup.yaml");
+
+pub(crate) async fn verify_daily_standup_ceremony(
+    client: &mut ChoreographerServiceClient<Channel>,
+) -> Result<()> {
+    let response = client
+        .run_ceremony(RunCeremonyRequest {
+            ceremony_id: "e2e-daily-standup".to_owned(),
+            definition_yaml: DAILY_STANDUP_CEREMONY.to_owned(),
+            context: None,
+            lease_owner_id: "e2e-runner".to_owned(),
+            lease_ttl_ms: 60_000,
+        })
+        .await
+        .context("RunCeremony failed for daily standup ceremony")?
+        .into_inner();
+
+    if !response.completed {
+        bail!(
+            "expected daily standup to complete; final_state={}",
+            response.final_state
+        );
+    }
+    if response.final_state != "CLOSED" {
+        bail!("expected final_state CLOSED, got {}", response.final_state);
+    }
+    if response.steps.len() != 4 {
+        bail!(
+            "expected 4 executed standup steps, got {}",
+            response.steps.len()
+        );
+    }
+    for role in ["SCRUM_MASTER", "ENGINEER", "QA_LEAD", "DELIVERY_LEAD"] {
+        if !response
+            .steps
+            .iter()
+            .any(|step| step.role_id == role && step.status == "COMPLETED")
+        {
+            bail!("daily standup response is missing completed role {role}");
+        }
+    }
+
+    let diagram = &response.mermaid_sequence;
+    for expected in [
+        "sequenceDiagram",
+        "open_standup [facilitation_prompt]",
+        "progress_round [progress_prompt]",
+        "impediment_review [challenge_prompt]",
+        "commitment_summary [synthesis_prompt]",
+        "commitments_made -> CLOSED",
+    ] {
+        if !diagram.contains(expected) {
+            bail!("daily standup diagram does not contain expected fragment `{expected}`");
+        }
+    }
+
+    info!(
+        ceremony_id = response.ceremony_id,
+        final_state = response.final_state,
+        steps = response.steps.len(),
+        diagram = %diagram,
+        "daily standup ceremony executed and rendered"
+    );
+    Ok(())
+}

--- a/crates/choreo-e2e-runner/src/scenarios/mod.rs
+++ b/crates/choreo-e2e-runner/src/scenarios/mod.rs
@@ -3,6 +3,7 @@ mod ceremony_vllm;
 mod ceremony_vllm_definition;
 mod ceremony_vllm_provider_config;
 mod connectivity;
+mod daily_standup;
 mod runtime;
 mod structured_output;
 
@@ -20,6 +21,7 @@ pub(crate) use connectivity::{
     verify_causal_metadata_propagates_over_nats, verify_delete_missing_council_returns_false,
     verify_deliberate_returns_winner, verify_seeded_council_visible,
 };
+pub(crate) use daily_standup::verify_daily_standup_ceremony;
 pub(crate) use runtime::verify_orchestrate_invokes_runtime_executor;
 pub(crate) use structured_output::{
     verify_external_context_bundle_round_trips, verify_multi_agent_council_against_real_vllm,

--- a/crates/choreo-tests-integration/tests/run_daily_standup_rpc.rs
+++ b/crates/choreo-tests-integration/tests/run_daily_standup_rpc.rs
@@ -1,0 +1,57 @@
+use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
+use choreo_proto::v1::RunCeremonyRequest;
+use choreo_tests_integration::grpc_fixture::GrpcFixture;
+
+const DAILY_STANDUP_CEREMONY: &str =
+    include_str!("../../../tests/e2e/ceremonies/daily-standup.yaml");
+
+/// Drives the four-role daily standup end-to-end through the RunCeremony
+/// RPC. The fixture wires the context store, so the run exercises the
+/// transcript-threading path (`see_prior: true` on every turn after the
+/// opening) while completing to the terminal state.
+#[tokio::test]
+async fn run_daily_standup_executes_threaded_ceremony() {
+    let fixture = GrpcFixture::start().await;
+    let mut client = ChoreographerServiceClient::new(fixture.channel);
+
+    let response = client
+        .run_ceremony(RunCeremonyRequest {
+            ceremony_id: "integration-daily-standup".to_owned(),
+            definition_yaml: DAILY_STANDUP_CEREMONY.to_owned(),
+            context: None,
+            lease_owner_id: "integration-test".to_owned(),
+            lease_ttl_ms: 60_000,
+        })
+        .await
+        .expect("RunCeremony should succeed")
+        .into_inner();
+
+    assert_eq!(response.ceremony_id, "integration-daily-standup");
+    assert_eq!(response.definition_name, "daily_standup");
+    assert_eq!(response.final_state, "CLOSED");
+    assert!(response.completed);
+    assert_eq!(response.steps.len(), 4);
+    assert!(response.steps.iter().all(|step| step.status == "COMPLETED"));
+
+    for role in ["SCRUM_MASTER", "ENGINEER", "QA_LEAD", "DELIVERY_LEAD"] {
+        assert!(
+            response.steps.iter().any(|step| step.role_id == role),
+            "missing completed role {role}"
+        );
+    }
+
+    let diagram = &response.mermaid_sequence;
+    assert!(diagram.contains("sequenceDiagram"));
+    for fragment in [
+        "open_standup [facilitation_prompt]",
+        "progress_round [progress_prompt]",
+        "impediment_review [challenge_prompt]",
+        "commitment_summary [synthesis_prompt]",
+        "commitments_made -> CLOSED",
+    ] {
+        assert!(
+            diagram.contains(fragment),
+            "diagram missing fragment `{fragment}`"
+        );
+    }
+}

--- a/tests/e2e/ceremonies/daily-standup.yaml
+++ b/tests/e2e/ceremonies/daily-standup.yaml
@@ -1,0 +1,110 @@
+version: "1.0"
+name: "daily_standup"
+description: "Four-role daily standup; each turn builds on the prior transcript"
+inputs:
+  required:
+    - sprint_goal
+  optional:
+    - board_url
+outputs:
+  standup_summary:
+    type: object
+states:
+  - id: STANDUP_OPEN
+    initial: true
+  - id: SHARING
+  - id: IMPEDIMENTS
+  - id: COMMITMENTS
+  - id: CLOSED
+    terminal: true
+transitions:
+  - from: STANDUP_OPEN
+    to: SHARING
+    trigger: standup_opened
+    guards:
+      - open_standup_completed
+  - from: SHARING
+    to: IMPEDIMENTS
+    trigger: progress_shared
+    guards:
+      - progress_round_completed
+  - from: IMPEDIMENTS
+    to: COMMITMENTS
+    trigger: impediments_reviewed
+    guards:
+      - impediment_review_completed
+  - from: COMMITMENTS
+    to: CLOSED
+    trigger: commitments_made
+    guards:
+      - commitment_summary_completed
+steps:
+  - id: open_standup
+    state: STANDUP_OPEN
+    handler: facilitation_prompt
+    config:
+      see_prior: false
+      participants:
+        - scrum_master
+      prompt: "Open the standup. Restate the sprint goal and what 'done' means for today."
+  - id: progress_round
+    state: SHARING
+    handler: progress_prompt
+    config:
+      see_prior: true
+      rounds: 1
+      participants:
+        - engineer
+      prompt: "Report yesterday's progress and today's plan. Build on what has already been shared; do not repeat it."
+  - id: impediment_review
+    state: IMPEDIMENTS
+    handler: challenge_prompt
+    config:
+      see_prior: true
+      participants:
+        - qa_lead
+      prompt: "Given the progress shared, name the blockers, risks, and cross-dependencies, and who owns each."
+  - id: commitment_summary
+    state: COMMITMENTS
+    handler: synthesis_prompt
+    config:
+      see_prior: true
+      participants:
+        - delivery_lead
+      prompt: "Summarize the standup into commitments for today: owner, outcome, and the single most important unblock."
+guards:
+  open_standup_completed:
+    type: automated
+    check: "step_status:open_standup:COMPLETED"
+  progress_round_completed:
+    type: automated
+    check: "step_status:progress_round:COMPLETED"
+  impediment_review_completed:
+    type: automated
+    check: "step_status:impediment_review:COMPLETED"
+  commitment_summary_completed:
+    type: automated
+    check: "step_status:commitment_summary:COMPLETED"
+roles:
+  - id: SCRUM_MASTER
+    allowed_actions:
+      - open_standup
+      - standup_opened
+  - id: ENGINEER
+    allowed_actions:
+      - progress_round
+      - progress_shared
+  - id: QA_LEAD
+    allowed_actions:
+      - impediment_review
+      - impediments_reviewed
+  - id: DELIVERY_LEAD
+    allowed_actions:
+      - commitment_summary
+      - commitments_made
+timeouts:
+  step_default: 120
+retry_policies:
+  default:
+    max_attempts: 2
+    backoff_seconds: 1

--- a/tests/e2e/kubernetes/runner-job.yaml
+++ b/tests/e2e/kubernetes/runner-job.yaml
@@ -33,7 +33,7 @@ spec:
             - name: CHOREO_SEED_SPECIALTY
               value: triage
             - name: CHOREO_E2E_SCENARIOS
-              value: cluster-connectivity,ceremony-diagram
+              value: cluster-connectivity,ceremony-diagram,daily-standup
             - name: RUST_LOG
               value: info
           resources:


### PR DESCRIPTION
## Ceremony catalog 1/4 — daily standup

First of the rich, multi-intervention ceremonies the transcript threading (#81/#82) unlocks.

A four-role **daily standup**:

| role | step | knobs |
|---|---|---|
| SCRUM_MASTER | `open_standup` | `see_prior: false` (opens) |
| ENGINEER | `progress_round` | `see_prior: true`, `rounds: 1` |
| QA_LEAD | `impediment_review` | `see_prior: true` |
| DELIVERY_LEAD | `commitment_summary` | `see_prior: true` |

Each turn after the opening builds on the running transcript instead of monologuing; the progress round adds a critique/revise pass via `rounds: 1`. **Pure YAML** — no engine change.

### Coverage
- **`run_daily_standup_rpc`** integration test drives it end-to-end through the RunCeremony RPC (the fixture wires the context store, so the threaded path runs) → asserts `CLOSED`, four completed roles, and the conversation diagram. Runs in `make test`.
- **`daily_standup`** e2e-runner scenario (`daily-standup`, scenario 13), added to the vLLM-free `runner-job.yaml` for the **Kubernetes Job** e2e.
- runner `main` dispatch extracted into `run_selected_scenarios` (keeps it under the clippy line budget).

### Validation
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets` + provider features `-- -D warnings` ✅
- `cargo test --workspace` + provider features ✅

**Breaking:** none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)