### PR TITLE
feat(ceremony): add technical debate, sprint planning, and speaker Q&A ceremonies

### DIFF
--- a/crates/choreo-e2e-runner/src/main.rs
+++ b/crates/choreo-e2e-runner/src/main.rs
@@ -22,7 +22,9 @@ use scenarios::{
     verify_external_context_bundle_round_trips, verify_multi_agent_council_against_real_vllm,
     verify_orchestrate_invokes_runtime_executor,
     verify_orchestrate_rejects_proposal_violating_json_schema, verify_seeded_council_visible,
+    verify_speaker_talk_qa_ceremony, verify_sprint_planning_ceremony,
     verify_structured_output_against_stub_llm, verify_structured_output_against_vllm_kind,
+    verify_technical_debate_ceremony,
 };
 use tonic::transport::Channel;
 use tracing::info;
@@ -144,6 +146,17 @@ async fn run_selected_scenarios(
             .context("scenario 10 failed")?;
     }
 
+    run_ceremony_scenarios(client, selected_scenarios).await?;
+
+    Ok(())
+}
+
+/// Run the selected ceremony scenarios — declarative meeting ceremonies
+/// driven through the RunCeremony RPC.
+async fn run_ceremony_scenarios(
+    client: &mut ChoreographerServiceClient<Channel>,
+    selected_scenarios: &BTreeSet<E2eScenario>,
+) -> Result<()> {
     if selected_scenarios.contains(&E2eScenario::CeremonyDiagram) {
         info!("scenario 11: four-role ceremony YAML renders a Mermaid conversation diagram");
         verify_editorial_meeting_ceremony_diagram(client)
@@ -163,6 +176,27 @@ async fn run_selected_scenarios(
         verify_daily_standup_ceremony(client)
             .await
             .context("scenario 13 failed")?;
+    }
+
+    if selected_scenarios.contains(&E2eScenario::TechnicalDebate) {
+        info!("scenario 14: four-role technical debate argues, rebuts across rounds, and decides");
+        verify_technical_debate_ceremony(client)
+            .await
+            .context("scenario 14 failed")?;
+    }
+
+    if selected_scenarios.contains(&E2eScenario::SprintPlanning) {
+        info!("scenario 15: four-role sprint planning threads priorities into a committed scope");
+        verify_sprint_planning_ceremony(client)
+            .await
+            .context("scenario 15 failed")?;
+    }
+
+    if selected_scenarios.contains(&E2eScenario::SpeakerTalkQa) {
+        info!("scenario 16: speaker talk + Q&A grounds questions and answers in the talk");
+        verify_speaker_talk_qa_ceremony(client)
+            .await
+            .context("scenario 16 failed")?;
     }
 
     Ok(())

--- a/crates/choreo-e2e-runner/src/scenario_selection.rs
+++ b/crates/choreo-e2e-runner/src/scenario_selection.rs
@@ -19,6 +19,9 @@ pub(crate) enum E2eScenario {
     CeremonyDiagram,
     CeremonyVllm,
     DailyStandup,
+    TechnicalDebate,
+    SprintPlanning,
+    SpeakerTalkQa,
 }
 
 impl E2eScenario {
@@ -43,6 +46,12 @@ impl E2eScenario {
     const CEREMONY_VLLM: [Self; 1] = [Self::CeremonyVllm];
 
     const DAILY_STANDUP: [Self; 1] = [Self::DailyStandup];
+
+    const TECHNICAL_DEBATE: [Self; 1] = [Self::TechnicalDebate];
+
+    const SPRINT_PLANNING: [Self; 1] = [Self::SprintPlanning];
+
+    const SPEAKER_TALK_QA: [Self; 1] = [Self::SpeakerTalkQa];
 
     const CLUSTER_CONNECTIVITY: [Self; 4] = [
         Self::SeededCouncil,
@@ -75,6 +84,9 @@ impl E2eScenario {
             Self::CeremonyDiagram => 11,
             Self::CeremonyVllm => 12,
             Self::DailyStandup => 13,
+            Self::TechnicalDebate => 14,
+            Self::SprintPlanning => 15,
+            Self::SpeakerTalkQa => 16,
         }
     }
 }
@@ -132,6 +144,18 @@ fn add_scenario_token(token: &str, selected: &mut BTreeSet<E2eScenario>) -> Resu
             selected.extend(E2eScenario::DAILY_STANDUP);
             return Ok(());
         }
+        "technical-debate" | "debate" | "tech-debate" => {
+            selected.extend(E2eScenario::TECHNICAL_DEBATE);
+            return Ok(());
+        }
+        "sprint-planning" | "sprint-plan" | "planning" => {
+            selected.extend(E2eScenario::SPRINT_PLANNING);
+            return Ok(());
+        }
+        "speaker-talk-qa" | "talk-qa" | "speaker-qa" => {
+            selected.extend(E2eScenario::SPEAKER_TALK_QA);
+            return Ok(());
+        }
         _ => {}
     }
 
@@ -157,7 +181,7 @@ fn add_scenario_token(token: &str, selected: &mut BTreeSet<E2eScenario>) -> Resu
     }
 
     bail!(
-        "unknown scenario selector `{token}`; expected compose, cluster-connectivity, runtime-stub, structured-output, vllm-real-multi-agent, ceremony-vllm, daily-standup, 1-13, or a range like 1-4"
+        "unknown scenario selector `{token}`; expected compose, cluster-connectivity, runtime-stub, structured-output, vllm-real-multi-agent, ceremony-vllm, daily-standup, technical-debate, sprint-planning, speaker-talk-qa, 1-16, or a range like 1-4"
     )
 }
 
@@ -176,7 +200,10 @@ fn scenario_from_number(number: u8) -> Result<E2eScenario> {
         11 => Ok(E2eScenario::CeremonyDiagram),
         12 => Ok(E2eScenario::CeremonyVllm),
         13 => Ok(E2eScenario::DailyStandup),
-        _ => bail!("scenario number {number} is out of range; expected 1-13"),
+        14 => Ok(E2eScenario::TechnicalDebate),
+        15 => Ok(E2eScenario::SprintPlanning),
+        16 => Ok(E2eScenario::SpeakerTalkQa),
+        _ => bail!("scenario number {number} is out of range; expected 1-16"),
     }
 }
 
@@ -224,6 +251,12 @@ mod tests {
         assert_eq!(numbers(Some("daily-standup")), vec![13]);
         assert_eq!(numbers(Some("daily")), vec![13]);
         assert_eq!(numbers(Some("standup")), vec![13]);
+        assert_eq!(numbers(Some("technical-debate")), vec![14]);
+        assert_eq!(numbers(Some("debate")), vec![14]);
+        assert_eq!(numbers(Some("sprint-planning")), vec![15]);
+        assert_eq!(numbers(Some("planning")), vec![15]);
+        assert_eq!(numbers(Some("speaker-talk-qa")), vec![16]);
+        assert_eq!(numbers(Some("speaker-qa")), vec![16]);
     }
 
     #[test]
@@ -237,11 +270,12 @@ mod tests {
         assert_eq!(numbers(Some("s11")), vec![11]);
         assert_eq!(numbers(Some("s12")), vec![12]);
         assert_eq!(numbers(Some("s13")), vec![13]);
+        assert_eq!(numbers(Some("s16")), vec![16]);
     }
 
     #[test]
     fn invalid_selection_is_rejected() {
-        assert!(parse_scenario_selection(Some("14")).is_err());
+        assert!(parse_scenario_selection(Some("17")).is_err());
         assert!(parse_scenario_selection(Some("4-1")).is_err());
         assert!(parse_scenario_selection(Some("unknown")).is_err());
     }

--- a/crates/choreo-e2e-runner/src/scenarios/mod.rs
+++ b/crates/choreo-e2e-runner/src/scenarios/mod.rs
@@ -5,7 +5,10 @@ mod ceremony_vllm_provider_config;
 mod connectivity;
 mod daily_standup;
 mod runtime;
+mod speaker_talk_qa;
+mod sprint_planning;
 mod structured_output;
+mod technical_debate;
 
 use std::time::Duration;
 
@@ -23,11 +26,14 @@ pub(crate) use connectivity::{
 };
 pub(crate) use daily_standup::verify_daily_standup_ceremony;
 pub(crate) use runtime::verify_orchestrate_invokes_runtime_executor;
+pub(crate) use speaker_talk_qa::verify_speaker_talk_qa_ceremony;
+pub(crate) use sprint_planning::verify_sprint_planning_ceremony;
 pub(crate) use structured_output::{
     verify_external_context_bundle_round_trips, verify_multi_agent_council_against_real_vllm,
     verify_orchestrate_rejects_proposal_violating_json_schema,
     verify_structured_output_against_stub_llm, verify_structured_output_against_vllm_kind,
 };
+pub(crate) use technical_debate::verify_technical_debate_ceremony;
 
 pub(crate) async fn connect_with_retry(
     endpoint: &str,

--- a/crates/choreo-e2e-runner/src/scenarios/speaker_talk_qa.rs
+++ b/crates/choreo-e2e-runner/src/scenarios/speaker_talk_qa.rs
@@ -1,0 +1,72 @@
+use anyhow::{bail, Context, Result};
+use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
+use choreo_proto::v1::RunCeremonyRequest;
+use tonic::transport::Channel;
+use tracing::info;
+
+const SPEAKER_TALK_QA_CEREMONY: &str =
+    include_str!("../../../../tests/e2e/ceremonies/speaker-talk-qa.yaml");
+
+pub(crate) async fn verify_speaker_talk_qa_ceremony(
+    client: &mut ChoreographerServiceClient<Channel>,
+) -> Result<()> {
+    let response = client
+        .run_ceremony(RunCeremonyRequest {
+            ceremony_id: "e2e-speaker-talk-qa".to_owned(),
+            definition_yaml: SPEAKER_TALK_QA_CEREMONY.to_owned(),
+            context: None,
+            lease_owner_id: "e2e-runner".to_owned(),
+            lease_ttl_ms: 60_000,
+        })
+        .await
+        .context("RunCeremony failed for speaker talk + Q&A ceremony")?
+        .into_inner();
+
+    if !response.completed {
+        bail!(
+            "expected speaker talk + Q&A to complete; final_state={}",
+            response.final_state
+        );
+    }
+    if response.final_state != "CLOSED" {
+        bail!("expected final_state CLOSED, got {}", response.final_state);
+    }
+    if response.steps.len() != 4 {
+        bail!(
+            "expected 4 executed talk steps, got {}",
+            response.steps.len()
+        );
+    }
+    for role in ["SPEAKER", "AUDIENCE", "SPEAKER_RESPONDENT", "MODERATOR"] {
+        if !response
+            .steps
+            .iter()
+            .any(|step| step.role_id == role && step.status == "COMPLETED")
+        {
+            bail!("speaker talk + Q&A response is missing completed role {role}");
+        }
+    }
+
+    let diagram = &response.mermaid_sequence;
+    for expected in [
+        "sequenceDiagram",
+        "deliver_talk [facilitation_prompt]",
+        "audience_questions [challenge_prompt]",
+        "speaker_answers [progress_prompt]",
+        "takeaway_synthesis [synthesis_prompt]",
+        "takeaways_captured -> CLOSED",
+    ] {
+        if !diagram.contains(expected) {
+            bail!("speaker talk + Q&A diagram does not contain expected fragment `{expected}`");
+        }
+    }
+
+    info!(
+        ceremony_id = response.ceremony_id,
+        final_state = response.final_state,
+        steps = response.steps.len(),
+        diagram = %diagram,
+        "speaker talk + Q&A ceremony executed and rendered"
+    );
+    Ok(())
+}

--- a/crates/choreo-e2e-runner/src/scenarios/sprint_planning.rs
+++ b/crates/choreo-e2e-runner/src/scenarios/sprint_planning.rs
@@ -1,0 +1,72 @@
+use anyhow::{bail, Context, Result};
+use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
+use choreo_proto::v1::RunCeremonyRequest;
+use tonic::transport::Channel;
+use tracing::info;
+
+const SPRINT_PLANNING_CEREMONY: &str =
+    include_str!("../../../../tests/e2e/ceremonies/sprint-planning.yaml");
+
+pub(crate) async fn verify_sprint_planning_ceremony(
+    client: &mut ChoreographerServiceClient<Channel>,
+) -> Result<()> {
+    let response = client
+        .run_ceremony(RunCeremonyRequest {
+            ceremony_id: "e2e-sprint-planning".to_owned(),
+            definition_yaml: SPRINT_PLANNING_CEREMONY.to_owned(),
+            context: None,
+            lease_owner_id: "e2e-runner".to_owned(),
+            lease_ttl_ms: 60_000,
+        })
+        .await
+        .context("RunCeremony failed for sprint planning ceremony")?
+        .into_inner();
+
+    if !response.completed {
+        bail!(
+            "expected sprint planning to complete; final_state={}",
+            response.final_state
+        );
+    }
+    if response.final_state != "CLOSED" {
+        bail!("expected final_state CLOSED, got {}", response.final_state);
+    }
+    if response.steps.len() != 4 {
+        bail!(
+            "expected 4 executed planning steps, got {}",
+            response.steps.len()
+        );
+    }
+    for role in ["PRODUCT_OWNER", "ENGINEER", "SCRUM_MASTER", "DELIVERY_LEAD"] {
+        if !response
+            .steps
+            .iter()
+            .any(|step| step.role_id == role && step.status == "COMPLETED")
+        {
+            bail!("sprint planning response is missing completed role {role}");
+        }
+    }
+
+    let diagram = &response.mermaid_sequence;
+    for expected in [
+        "sequenceDiagram",
+        "present_priorities [facilitation_prompt]",
+        "task_breakdown [progress_prompt]",
+        "capacity_review [challenge_prompt]",
+        "scope_commitment [synthesis_prompt]",
+        "scope_committed -> CLOSED",
+    ] {
+        if !diagram.contains(expected) {
+            bail!("sprint planning diagram does not contain expected fragment `{expected}`");
+        }
+    }
+
+    info!(
+        ceremony_id = response.ceremony_id,
+        final_state = response.final_state,
+        steps = response.steps.len(),
+        diagram = %diagram,
+        "sprint planning ceremony executed and rendered"
+    );
+    Ok(())
+}

--- a/crates/choreo-e2e-runner/src/scenarios/technical_debate.rs
+++ b/crates/choreo-e2e-runner/src/scenarios/technical_debate.rs
@@ -1,0 +1,75 @@
+use anyhow::{bail, Context, Result};
+use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
+use choreo_proto::v1::RunCeremonyRequest;
+use tonic::transport::Channel;
+use tracing::info;
+
+const TECHNICAL_DEBATE_CEREMONY: &str =
+    include_str!("../../../../tests/e2e/ceremonies/technical-debate.yaml");
+
+pub(crate) async fn verify_technical_debate_ceremony(
+    client: &mut ChoreographerServiceClient<Channel>,
+) -> Result<()> {
+    let response = client
+        .run_ceremony(RunCeremonyRequest {
+            ceremony_id: "e2e-technical-debate".to_owned(),
+            definition_yaml: TECHNICAL_DEBATE_CEREMONY.to_owned(),
+            context: None,
+            lease_owner_id: "e2e-runner".to_owned(),
+            lease_ttl_ms: 60_000,
+        })
+        .await
+        .context("RunCeremony failed for technical debate ceremony")?
+        .into_inner();
+
+    if !response.completed {
+        bail!(
+            "expected technical debate to complete; final_state={}",
+            response.final_state
+        );
+    }
+    if response.final_state != "ADJOURNED" {
+        bail!(
+            "expected final_state ADJOURNED, got {}",
+            response.final_state
+        );
+    }
+    if response.steps.len() != 4 {
+        bail!(
+            "expected 4 executed debate steps, got {}",
+            response.steps.len()
+        );
+    }
+    for role in ["PROPONENT", "OPPONENT", "REBUTTER", "ARBITER"] {
+        if !response
+            .steps
+            .iter()
+            .any(|step| step.role_id == role && step.status == "COMPLETED")
+        {
+            bail!("technical debate response is missing completed role {role}");
+        }
+    }
+
+    let diagram = &response.mermaid_sequence;
+    for expected in [
+        "sequenceDiagram",
+        "state_thesis [facilitation_prompt]",
+        "raise_objections [challenge_prompt]",
+        "answer_objections [progress_prompt]",
+        "render_decision [synthesis_prompt]",
+        "decision_rendered -> ADJOURNED",
+    ] {
+        if !diagram.contains(expected) {
+            bail!("technical debate diagram does not contain expected fragment `{expected}`");
+        }
+    }
+
+    info!(
+        ceremony_id = response.ceremony_id,
+        final_state = response.final_state,
+        steps = response.steps.len(),
+        diagram = %diagram,
+        "technical debate ceremony executed and rendered"
+    );
+    Ok(())
+}

--- a/crates/choreo-tests-integration/tests/run_speaker_talk_qa_rpc.rs
+++ b/crates/choreo-tests-integration/tests/run_speaker_talk_qa_rpc.rs
@@ -1,0 +1,56 @@
+use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
+use choreo_proto::v1::RunCeremonyRequest;
+use choreo_tests_integration::grpc_fixture::GrpcFixture;
+
+const SPEAKER_TALK_QA_CEREMONY: &str =
+    include_str!("../../../tests/e2e/ceremonies/speaker-talk-qa.yaml");
+
+/// Drives the four-role speaker talk + Q&A end-to-end through RunCeremony.
+/// The audience questions and the speaker's answers set `see_prior: true`,
+/// so questions and answers are grounded in the actual talk while the run
+/// completes to the terminal state.
+#[tokio::test]
+async fn run_speaker_talk_qa_executes_threaded_ceremony() {
+    let fixture = GrpcFixture::start().await;
+    let mut client = ChoreographerServiceClient::new(fixture.channel);
+
+    let response = client
+        .run_ceremony(RunCeremonyRequest {
+            ceremony_id: "integration-speaker-talk-qa".to_owned(),
+            definition_yaml: SPEAKER_TALK_QA_CEREMONY.to_owned(),
+            context: None,
+            lease_owner_id: "integration-test".to_owned(),
+            lease_ttl_ms: 60_000,
+        })
+        .await
+        .expect("RunCeremony should succeed")
+        .into_inner();
+
+    assert_eq!(response.definition_name, "speaker_talk_qa");
+    assert_eq!(response.final_state, "CLOSED");
+    assert!(response.completed);
+    assert_eq!(response.steps.len(), 4);
+    assert!(response.steps.iter().all(|step| step.status == "COMPLETED"));
+
+    for role in ["SPEAKER", "AUDIENCE", "SPEAKER_RESPONDENT", "MODERATOR"] {
+        assert!(
+            response.steps.iter().any(|step| step.role_id == role),
+            "missing completed role {role}"
+        );
+    }
+
+    let diagram = &response.mermaid_sequence;
+    for fragment in [
+        "sequenceDiagram",
+        "deliver_talk [facilitation_prompt]",
+        "audience_questions [challenge_prompt]",
+        "speaker_answers [progress_prompt]",
+        "takeaway_synthesis [synthesis_prompt]",
+        "takeaways_captured -> CLOSED",
+    ] {
+        assert!(
+            diagram.contains(fragment),
+            "diagram missing fragment `{fragment}`"
+        );
+    }
+}

--- a/crates/choreo-tests-integration/tests/run_sprint_planning_rpc.rs
+++ b/crates/choreo-tests-integration/tests/run_sprint_planning_rpc.rs
@@ -1,0 +1,56 @@
+use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
+use choreo_proto::v1::RunCeremonyRequest;
+use choreo_tests_integration::grpc_fixture::GrpcFixture;
+
+const SPRINT_PLANNING_CEREMONY: &str =
+    include_str!("../../../tests/e2e/ceremonies/sprint-planning.yaml");
+
+/// Drives the four-role sprint planning end-to-end through RunCeremony.
+/// Every turn after the priorities opening sets `see_prior: true`, so the
+/// run threads priorities -> breakdown -> capacity -> commitment while
+/// completing to the terminal state.
+#[tokio::test]
+async fn run_sprint_planning_executes_threaded_ceremony() {
+    let fixture = GrpcFixture::start().await;
+    let mut client = ChoreographerServiceClient::new(fixture.channel);
+
+    let response = client
+        .run_ceremony(RunCeremonyRequest {
+            ceremony_id: "integration-sprint-planning".to_owned(),
+            definition_yaml: SPRINT_PLANNING_CEREMONY.to_owned(),
+            context: None,
+            lease_owner_id: "integration-test".to_owned(),
+            lease_ttl_ms: 60_000,
+        })
+        .await
+        .expect("RunCeremony should succeed")
+        .into_inner();
+
+    assert_eq!(response.definition_name, "sprint_planning");
+    assert_eq!(response.final_state, "CLOSED");
+    assert!(response.completed);
+    assert_eq!(response.steps.len(), 4);
+    assert!(response.steps.iter().all(|step| step.status == "COMPLETED"));
+
+    for role in ["PRODUCT_OWNER", "ENGINEER", "SCRUM_MASTER", "DELIVERY_LEAD"] {
+        assert!(
+            response.steps.iter().any(|step| step.role_id == role),
+            "missing completed role {role}"
+        );
+    }
+
+    let diagram = &response.mermaid_sequence;
+    for fragment in [
+        "sequenceDiagram",
+        "present_priorities [facilitation_prompt]",
+        "task_breakdown [progress_prompt]",
+        "capacity_review [challenge_prompt]",
+        "scope_commitment [synthesis_prompt]",
+        "scope_committed -> CLOSED",
+    ] {
+        assert!(
+            diagram.contains(fragment),
+            "diagram missing fragment `{fragment}`"
+        );
+    }
+}

--- a/crates/choreo-tests-integration/tests/run_technical_debate_rpc.rs
+++ b/crates/choreo-tests-integration/tests/run_technical_debate_rpc.rs
@@ -1,0 +1,56 @@
+use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
+use choreo_proto::v1::RunCeremonyRequest;
+use choreo_tests_integration::grpc_fixture::GrpcFixture;
+
+const TECHNICAL_DEBATE_CEREMONY: &str =
+    include_str!("../../../tests/e2e/ceremonies/technical-debate.yaml");
+
+/// Drives the four-role technical debate end-to-end through RunCeremony.
+/// The rebuttal runs `rounds: 2` and every turn after the thesis sets
+/// `see_prior: true`, so the run exercises the threaded, multi-round path
+/// while completing to the terminal state.
+#[tokio::test]
+async fn run_technical_debate_executes_threaded_ceremony() {
+    let fixture = GrpcFixture::start().await;
+    let mut client = ChoreographerServiceClient::new(fixture.channel);
+
+    let response = client
+        .run_ceremony(RunCeremonyRequest {
+            ceremony_id: "integration-technical-debate".to_owned(),
+            definition_yaml: TECHNICAL_DEBATE_CEREMONY.to_owned(),
+            context: None,
+            lease_owner_id: "integration-test".to_owned(),
+            lease_ttl_ms: 60_000,
+        })
+        .await
+        .expect("RunCeremony should succeed")
+        .into_inner();
+
+    assert_eq!(response.definition_name, "technical_debate");
+    assert_eq!(response.final_state, "ADJOURNED");
+    assert!(response.completed);
+    assert_eq!(response.steps.len(), 4);
+    assert!(response.steps.iter().all(|step| step.status == "COMPLETED"));
+
+    for role in ["PROPONENT", "OPPONENT", "REBUTTER", "ARBITER"] {
+        assert!(
+            response.steps.iter().any(|step| step.role_id == role),
+            "missing completed role {role}"
+        );
+    }
+
+    let diagram = &response.mermaid_sequence;
+    for fragment in [
+        "sequenceDiagram",
+        "state_thesis [facilitation_prompt]",
+        "raise_objections [challenge_prompt]",
+        "answer_objections [progress_prompt]",
+        "render_decision [synthesis_prompt]",
+        "decision_rendered -> ADJOURNED",
+    ] {
+        assert!(
+            diagram.contains(fragment),
+            "diagram missing fragment `{fragment}`"
+        );
+    }
+}

--- a/tests/e2e/ceremonies/speaker-talk-qa.yaml
+++ b/tests/e2e/ceremonies/speaker-talk-qa.yaml
@@ -1,0 +1,111 @@
+version: "1.0"
+name: "speaker_talk_qa"
+description: "Four-role speaker talk and Q&A; the speaker presents, the audience probes, the speaker answers, the moderator captures takeaways"
+inputs:
+  required:
+    - talk_title
+  optional:
+    - session_notes
+outputs:
+  session_takeaways:
+    type: object
+states:
+  - id: TALK_OPEN
+    initial: true
+  - id: QUESTIONING
+  - id: ANSWERING
+  - id: WRAP_UP
+  - id: CLOSED
+    terminal: true
+transitions:
+  - from: TALK_OPEN
+    to: QUESTIONING
+    trigger: talk_delivered
+    guards:
+      - deliver_talk_completed
+  - from: QUESTIONING
+    to: ANSWERING
+    trigger: questions_raised
+    guards:
+      - audience_questions_completed
+  - from: ANSWERING
+    to: WRAP_UP
+    trigger: questions_answered
+    guards:
+      - speaker_answers_completed
+  - from: WRAP_UP
+    to: CLOSED
+    trigger: takeaways_captured
+    guards:
+      - takeaway_synthesis_completed
+steps:
+  - id: deliver_talk
+    state: TALK_OPEN
+    handler: facilitation_prompt
+    config:
+      see_prior: false
+      participants:
+        - speaker
+      prompt: "You are the speaker. Deliver the core talk on the announced topic: state your central thesis in one sentence, then lay out the two or three claims that support it and the single most important piece of evidence behind each. Be concrete and stake out a clear position the audience can push back on — name the assumption you are most relying on. This is the opening; there is no prior transcript to build on."
+  - id: audience_questions
+    state: QUESTIONING
+    handler: challenge_prompt
+    config:
+      see_prior: true
+      rounds: 1
+      participants:
+        - audience
+      prompt: "You are the audience. Read the talk the speaker just delivered and raise the sharpest, most specific questions and challenges about it. Quote or name the exact claims and the stated assumption you are probing — do not invent material the speaker did not say. Press hardest where the evidence was thin or the position was strongest-but-unproven. Rank your questions from most to least important and address them directly to the speaker."
+  - id: speaker_answers
+    state: ANSWERING
+    handler: progress_prompt
+    config:
+      see_prior: true
+      rounds: 1
+      participants:
+        - speaker
+      prompt: "You are the speaker, now responding. Answer the audience's questions one by one, in their order of importance, referring to each question explicitly before you answer it. Defend the claims you can with reasoning or evidence, and where a challenge lands, concede the point plainly and state what would change your mind or what remains unresolved. Do not dodge or repeat the talk verbatim — engage with exactly what was asked."
+  - id: takeaway_synthesis
+    state: WRAP_UP
+    handler: synthesis_prompt
+    config:
+      see_prior: true
+      participants:
+        - moderator
+      prompt: "You are the moderator closing the session. Using the full exchange above, synthesize three sections: (1) the key takeaways and the thesis as it now stands after Q&A; (2) the questions that were answered convincingly and the points the speaker conceded; (3) the questions that remain open or unresolved. Attribute fairly and add nothing that was not actually said in the talk or the Q&A."
+guards:
+  deliver_talk_completed:
+    type: automated
+    check: "step_status:deliver_talk:COMPLETED"
+  audience_questions_completed:
+    type: automated
+    check: "step_status:audience_questions:COMPLETED"
+  speaker_answers_completed:
+    type: automated
+    check: "step_status:speaker_answers:COMPLETED"
+  takeaway_synthesis_completed:
+    type: automated
+    check: "step_status:takeaway_synthesis:COMPLETED"
+roles:
+  - id: SPEAKER
+    allowed_actions:
+      - deliver_talk
+      - talk_delivered
+  - id: AUDIENCE
+    allowed_actions:
+      - audience_questions
+      - questions_raised
+  - id: SPEAKER_RESPONDENT
+    allowed_actions:
+      - speaker_answers
+      - questions_answered
+  - id: MODERATOR
+    allowed_actions:
+      - takeaway_synthesis
+      - takeaways_captured
+timeouts:
+  step_default: 120
+retry_policies:
+  default:
+    max_attempts: 2
+    backoff_seconds: 1

--- a/tests/e2e/ceremonies/sprint-planning.yaml
+++ b/tests/e2e/ceremonies/sprint-planning.yaml
@@ -1,0 +1,110 @@
+version: "1.0"
+name: "sprint_planning"
+description: "Four-role sprint planning; each turn builds on the prior transcript to converge on a committed, achievable scope"
+inputs:
+  required:
+    - sprint_goal
+  optional:
+    - backlog_url
+outputs:
+  sprint_commitment:
+    type: object
+states:
+  - id: SPRINT_PLANNING_OPEN
+    initial: true
+  - id: TASK_BREAKDOWN
+  - id: CAPACITY_CHECK
+  - id: COMMITMENT
+  - id: CLOSED
+    terminal: true
+transitions:
+  - from: SPRINT_PLANNING_OPEN
+    to: TASK_BREAKDOWN
+    trigger: priorities_presented
+    guards:
+      - present_priorities_completed
+  - from: TASK_BREAKDOWN
+    to: CAPACITY_CHECK
+    trigger: tasks_estimated
+    guards:
+      - task_breakdown_completed
+  - from: CAPACITY_CHECK
+    to: COMMITMENT
+    trigger: capacity_checked
+    guards:
+      - capacity_review_completed
+  - from: COMMITMENT
+    to: CLOSED
+    trigger: scope_committed
+    guards:
+      - scope_commitment_completed
+steps:
+  - id: present_priorities
+    state: SPRINT_PLANNING_OPEN
+    handler: facilitation_prompt
+    config:
+      see_prior: false
+      participants:
+        - product_owner
+      prompt: "Open the sprint planning. Restate the sprint goal in one sentence, then present the ranked priorities for this sprint and the concrete business outcomes each must deliver. For each top item, state why it matters now and what 'done' looks like from a user's perspective. Be explicit about the ordering so the engineer knows exactly which items to break down first."
+  - id: task_breakdown
+    state: TASK_BREAKDOWN
+    handler: progress_prompt
+    config:
+      see_prior: true
+      rounds: 1
+      participants:
+        - engineer
+      prompt: "Take the ranked priorities and desired outcomes the product owner just presented and break the top items, in their stated order, into concrete engineering tasks. For each item give a rough estimate (S/M/L or points) and explicitly surface the unknowns, technical risks, and open questions that could change that estimate. In your second pass, refine the estimates against the unknowns you raised and flag any item that looks too large to finish this sprint. Do not re-list the priorities; react to them directly."
+  - id: capacity_review
+    state: CAPACITY_CHECK
+    handler: challenge_prompt
+    config:
+      see_prior: true
+      participants:
+        - scrum_master
+      prompt: "Using the engineer's task breakdown and estimates, check the proposed work against real team capacity for this sprint. Sum the estimates against available capacity, then name the cross-task dependencies and sequencing constraints, the delivery risks, and any item whose unknowns make it unsafe to commit. Directly challenge any priority that no longer fits, and propose what should be deferred or split so the plan is achievable. Tie every concern back to a specific item the product owner or engineer named."
+  - id: scope_commitment
+    state: COMMITMENT
+    handler: synthesis_prompt
+    config:
+      see_prior: true
+      participants:
+        - delivery_lead
+      prompt: "Synthesize the whole discussion into the final committed sprint scope. List the items the team commits to, each with an owner and the outcome it delivers, honoring the priority order and respecting the capacity, dependency, and risk findings raised. Then state the explicit out-of-scope: the items deferred or split, and the one-line reason for each, drawn from the concerns already surfaced. End with the single biggest risk to this commitment and who watches it."
+guards:
+  present_priorities_completed:
+    type: automated
+    check: "step_status:present_priorities:COMPLETED"
+  task_breakdown_completed:
+    type: automated
+    check: "step_status:task_breakdown:COMPLETED"
+  capacity_review_completed:
+    type: automated
+    check: "step_status:capacity_review:COMPLETED"
+  scope_commitment_completed:
+    type: automated
+    check: "step_status:scope_commitment:COMPLETED"
+roles:
+  - id: PRODUCT_OWNER
+    allowed_actions:
+      - present_priorities
+      - priorities_presented
+  - id: ENGINEER
+    allowed_actions:
+      - task_breakdown
+      - tasks_estimated
+  - id: SCRUM_MASTER
+    allowed_actions:
+      - capacity_review
+      - capacity_checked
+  - id: DELIVERY_LEAD
+    allowed_actions:
+      - scope_commitment
+      - scope_committed
+timeouts:
+  step_default: 120
+retry_policies:
+  default:
+    max_attempts: 2
+    backoff_seconds: 1

--- a/tests/e2e/ceremonies/technical-debate.yaml
+++ b/tests/e2e/ceremonies/technical-debate.yaml
@@ -1,0 +1,111 @@
+version: "1.0"
+name: "technical_debate"
+description: "Four-role adversarial technical debate; a proposal is argued for and against, rebutted across rounds, then decided by an arbiter on the full transcript"
+inputs:
+  required:
+    - proposal
+  optional:
+    - decision_context
+outputs:
+  decision_record:
+    type: object
+states:
+  - id: DEBATE_OPEN
+    initial: true
+  - id: ARGUING
+  - id: REBUTTING
+  - id: DECIDING
+  - id: ADJOURNED
+    terminal: true
+transitions:
+  - from: DEBATE_OPEN
+    to: ARGUING
+    trigger: thesis_stated
+    guards:
+      - state_thesis_completed
+  - from: ARGUING
+    to: REBUTTING
+    trigger: objections_raised
+    guards:
+      - raise_objections_completed
+  - from: REBUTTING
+    to: DECIDING
+    trigger: rebuttal_closed
+    guards:
+      - answer_objections_completed
+  - from: DECIDING
+    to: ADJOURNED
+    trigger: decision_rendered
+    guards:
+      - render_decision_completed
+steps:
+  - id: state_thesis
+    state: DEBATE_OPEN
+    handler: facilitation_prompt
+    config:
+      see_prior: false
+      participants:
+        - proponent
+      prompt: "You are the PROPONENT. State the proposal as a clear thesis, then make the strongest possible case for adopting it. Lead with the single most important benefit, then give the supporting evidence, the concrete mechanism by which it works, and the cost of NOT doing it. Be specific and falsifiable: name the assumptions your case depends on so they can be tested later. Do not hedge — argue to win."
+  - id: raise_objections
+    state: ARGUING
+    handler: challenge_prompt
+    config:
+      see_prior: true
+      rounds: 1
+      participants:
+        - opponent
+      prompt: "You are the OPPONENT. You have just heard the proponent's thesis and case in the transcript above. Rebut it directly: quote or paraphrase each of their specific claims and dismantle it. Attack the weakest assumption first, then surface the risks, failure modes, hidden costs, and viable alternatives they ignored. Do not raise generic concerns — answer THEIR argument point by point and explain why each pillar of their case does not hold."
+  - id: answer_objections
+    state: REBUTTING
+    handler: progress_prompt
+    config:
+      see_prior: true
+      rounds: 2
+      participants:
+        - rebutter
+      prompt: "You are the REBUTTER arguing for the proposal. The opponent's objections are in the transcript above. Take their objections one at a time, in their own words, and answer each: concede what is genuinely true, then show why the remaining objections are mitigable, mispriced, or outweighed. Where you concede, propose the concrete condition or safeguard that neutralizes the risk. Across both rounds, sharpen the strongest surviving version of the proposal and make clear what, if anything, would have to be true for the objection to be fatal."
+  - id: render_decision
+    state: DECIDING
+    handler: synthesis_prompt
+    config:
+      see_prior: true
+      participants:
+        - arbiter
+      prompt: "You are the ARBITER. Read the full debate transcript above — thesis, objections, and rebuttal rounds. Render one decision: ADOPT, REJECT, or ADOPT WITH CONDITIONS. Justify it by citing the single strongest point from the proponent/rebutter side AND the single strongest point from the opponent side, and explain why one outweighs the other. If you adopt with conditions, list the specific conditions (drawn from the rebuttal's concessions) that must hold. State the one assumption that, if proven wrong, would reverse your decision."
+guards:
+  state_thesis_completed:
+    type: automated
+    check: "step_status:state_thesis:COMPLETED"
+  raise_objections_completed:
+    type: automated
+    check: "step_status:raise_objections:COMPLETED"
+  answer_objections_completed:
+    type: automated
+    check: "step_status:answer_objections:COMPLETED"
+  render_decision_completed:
+    type: automated
+    check: "step_status:render_decision:COMPLETED"
+roles:
+  - id: PROPONENT
+    allowed_actions:
+      - state_thesis
+      - thesis_stated
+  - id: OPPONENT
+    allowed_actions:
+      - raise_objections
+      - objections_raised
+  - id: REBUTTER
+    allowed_actions:
+      - answer_objections
+      - rebuttal_closed
+  - id: ARBITER
+    allowed_actions:
+      - render_decision
+      - decision_rendered
+timeouts:
+  step_default: 120
+retry_policies:
+  default:
+    max_attempts: 2
+    backoff_seconds: 1

--- a/tests/e2e/kubernetes/runner-job.yaml
+++ b/tests/e2e/kubernetes/runner-job.yaml
@@ -33,7 +33,7 @@ spec:
             - name: CHOREO_SEED_SPECIALTY
               value: triage
             - name: CHOREO_E2E_SCENARIOS
-              value: cluster-connectivity,ceremony-diagram,daily-standup
+              value: cluster-connectivity,ceremony-diagram,daily-standup,technical-debate,sprint-planning,speaker-talk-qa
             - name: RUST_LOG
               value: info
           resources:


### PR DESCRIPTION
## Ceremony catalog 2/4–4/4 — debate, sprint planning, speaker Q&A

Completes the first ceremony catalog (with the daily standup #83). Three rich, multi-intervention meetings, **authored purely in YAML**, exploiting the transcript threading (#81/#82): every turn after the opening sets `see_prior: true` so it answers what came before, and adversarial / estimate turns add `rounds` for genuine back-and-forth.

| ceremony | flow | terminal |
|---|---|---|
| **technical_debate** | PROPONENT thesis → OPPONENT objections (`rounds:1`) → REBUTTER answers (`rounds:2`) → ARBITER decides | ADJOURNED |
| **sprint_planning** | PRODUCT_OWNER priorities → ENGINEER breakdown (`rounds:1`) → SCRUM_MASTER capacity/risk → DELIVERY_LEAD commits | CLOSED |
| **speaker_talk_qa** | SPEAKER talk → AUDIENCE questions → SPEAKER_RESPONDENT answers (`rounds:1`) → MODERATOR takeaways | CLOSED |

### Per ceremony
- **In-process integration test** `run_<name>_rpc` — drives RunCeremony through the `GrpcFixture` (which wires the context store, so the threaded path runs) → asserts terminal state + four completed roles + the conversation diagram. Runs in `make test`.
- **e2e-runner scenario** (14/15/16; selectors `technical-debate` / `sprint-planning` / `speaker-talk-qa`) added to the vLLM-free `runner-job.yaml` **Kubernetes Job**.

### Notes
- The three YAMLs were drafted from the validated daily-standup template (parallel design) and each **verified by parsing and running to its terminal state**.
- Runner ceremony dispatch split into `run_ceremony_scenarios` to keep functions within the clippy line budget.

### Validation
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets` + provider features `-- -D warnings` ✅
- `cargo test --workspace` + provider features ✅ (3 new ceremonies run to completion)

**Breaking:** none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)