### PR TITLE
feat(e2e): add choreo-run-ceremony operator tool

### DIFF
--- a/crates/choreo-e2e-runner/Cargo.toml
+++ b/crates/choreo-e2e-runner/Cargo.toml
@@ -41,6 +41,13 @@ path = "src/bin/stub_runtime.rs"
 name = "choreo-stub-llm"
 path = "src/bin/stub_llm.rs"
 
+# Operator tool: run any ceremony YAML against a deployed Choreographer
+# over gRPC and print the resulting state, per-step roles, and the
+# rendered conversation diagram.
+[[bin]]
+name = "choreo-run-ceremony"
+path = "src/bin/run_ceremony_file.rs"
+
 [dependencies]
 choreo-proto = { workspace = true }
 choreo-core = { workspace = true }

--- a/crates/choreo-e2e-runner/src/bin/run_ceremony_file.rs
+++ b/crates/choreo-e2e-runner/src/bin/run_ceremony_file.rs
@@ -1,0 +1,76 @@
+//! Operator tool: run a ceremony YAML against a deployed Choreographer.
+//!
+//! Reads a ceremony definition from a file and drives it through the
+//! `RunCeremony` RPC, printing the terminal state, the per-step role and
+//! status, and the rendered Mermaid conversation diagram. Useful for
+//! exercising a ceremony (including provider-backed ones) against a live
+//! deployment.
+//!
+//! Env:
+//! - `CEREMONY_YAML_PATH` (required) — path to the ceremony YAML.
+//! - `CHOREOGRAPHER_ENDPOINT` (default `http://localhost:50055`).
+//! - `CEREMONY_ID` (default `operator-ceremony`).
+//! - `CEREMONY_LEASE_TTL_MS` (default `120000`).
+
+use anyhow::{Context, Result};
+use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
+use choreo_proto::v1::RunCeremonyRequest;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let endpoint = std::env::var("CHOREOGRAPHER_ENDPOINT")
+        .unwrap_or_else(|_| "http://localhost:50055".to_owned());
+    let path = std::env::var("CEREMONY_YAML_PATH").context("CEREMONY_YAML_PATH is required")?;
+    let ceremony_id =
+        std::env::var("CEREMONY_ID").unwrap_or_else(|_| "operator-ceremony".to_owned());
+    let lease_ttl_ms = std::env::var("CEREMONY_LEASE_TTL_MS")
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .unwrap_or(120_000);
+
+    let definition_yaml =
+        std::fs::read_to_string(&path).with_context(|| format!("reading ceremony YAML {path}"))?;
+
+    let mut client = ChoreographerServiceClient::connect(endpoint.clone())
+        .await
+        .with_context(|| format!("connecting to {endpoint}"))?;
+
+    let response = client
+        .run_ceremony(RunCeremonyRequest {
+            ceremony_id: ceremony_id.clone(),
+            definition_yaml,
+            context: None,
+            lease_owner_id: "operator".to_owned(),
+            lease_ttl_ms,
+        })
+        .await
+        .context("RunCeremony RPC failed")?
+        .into_inner();
+
+    println!(
+        "ceremony={} name={} final_state={} completed={} steps={}",
+        response.ceremony_id,
+        response.definition_name,
+        response.final_state,
+        response.completed,
+        response.steps.len()
+    );
+    for step in &response.steps {
+        println!(
+            "  step={:<22} role={:<20} status={:<10} attempt={}",
+            step.step_id, step.role_id, step.status, step.attempt
+        );
+    }
+    println!(
+        "--- conversation diagram ---\n{}",
+        response.mermaid_sequence
+    );
+
+    if !response.completed {
+        anyhow::bail!(
+            "ceremony did not complete; final_state={}",
+            response.final_state
+        );
+    }
+    Ok(())
+}


### PR DESCRIPTION
## `choreo-run-ceremony` — run any ceremony YAML against a live deployment

A small operator binary in `choreo-e2e-runner`: reads a ceremony YAML from a file and drives it through the `RunCeremony` RPC, printing the terminal state, per-step role/status, and the conversation diagram. Env-driven (`CEREMONY_YAML_PATH`, `CHOREOGRAPHER_ENDPOINT`, `CEREMONY_ID`, `CEREMONY_LEASE_TTL_MS`).

### Why
Lets an operator exercise any ceremony — including provider-backed (vLLM) ones — against a live deployment without a bespoke client.

### Used for
Validated the four catalog ceremonies running **end-to-end against real gemma** on the transcript-threading (M1b) build: each completed to its terminal state with four gemma-backed step deliberations (the choreographer logs confirm real per-step inference + transcript threading).

### Validation
- `cargo fmt --all -- --check` ✅
- `cargo clippy -p choreo-e2e-runner --all-targets -- -D warnings` ✅

**Breaking:** none (new bin only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)