### PR TITLE
feat(ceremony): run each step as a 3-agent panel so peer-review engages

### DIFF
--- a/tests/e2e/ceremonies/daily-standup.yaml
+++ b/tests/e2e/ceremonies/daily-standup.yaml
@@ -44,8 +44,7 @@ steps:
     handler: facilitation_prompt
     config:
       see_prior: false
-      participants:
-        - scrum_master
+      num_agents: 3
       prompt: "Open the standup. Restate the sprint goal and what 'done' means for today."
   - id: progress_round
     state: SHARING
@@ -53,24 +52,21 @@ steps:
     config:
       see_prior: true
       rounds: 1
-      participants:
-        - engineer
+      num_agents: 3
       prompt: "Report yesterday's progress and today's plan. Build on what has already been shared; do not repeat it."
   - id: impediment_review
     state: IMPEDIMENTS
     handler: challenge_prompt
     config:
       see_prior: true
-      participants:
-        - qa_lead
+      num_agents: 3
       prompt: "Given the progress shared, name the blockers, risks, and cross-dependencies, and who owns each."
   - id: commitment_summary
     state: COMMITMENTS
     handler: synthesis_prompt
     config:
       see_prior: true
-      participants:
-        - delivery_lead
+      num_agents: 3
       prompt: "Summarize the standup into commitments for today: owner, outcome, and the single most important unblock."
 guards:
   open_standup_completed:

--- a/tests/e2e/ceremonies/speaker-talk-qa.yaml
+++ b/tests/e2e/ceremonies/speaker-talk-qa.yaml
@@ -44,8 +44,7 @@ steps:
     handler: facilitation_prompt
     config:
       see_prior: false
-      participants:
-        - speaker
+      num_agents: 3
       prompt: "You are the speaker. Deliver the core talk on the announced topic: state your central thesis in one sentence, then lay out the two or three claims that support it and the single most important piece of evidence behind each. Be concrete and stake out a clear position the audience can push back on — name the assumption you are most relying on. This is the opening; there is no prior transcript to build on."
   - id: audience_questions
     state: QUESTIONING
@@ -53,8 +52,7 @@ steps:
     config:
       see_prior: true
       rounds: 1
-      participants:
-        - audience
+      num_agents: 3
       prompt: "You are the audience. Read the talk the speaker just delivered and raise the sharpest, most specific questions and challenges about it. Quote or name the exact claims and the stated assumption you are probing — do not invent material the speaker did not say. Press hardest where the evidence was thin or the position was strongest-but-unproven. Rank your questions from most to least important and address them directly to the speaker."
   - id: speaker_answers
     state: ANSWERING
@@ -62,16 +60,14 @@ steps:
     config:
       see_prior: true
       rounds: 1
-      participants:
-        - speaker
+      num_agents: 3
       prompt: "You are the speaker, now responding. Answer the audience's questions one by one, in their order of importance, referring to each question explicitly before you answer it. Defend the claims you can with reasoning or evidence, and where a challenge lands, concede the point plainly and state what would change your mind or what remains unresolved. Do not dodge or repeat the talk verbatim — engage with exactly what was asked."
   - id: takeaway_synthesis
     state: WRAP_UP
     handler: synthesis_prompt
     config:
       see_prior: true
-      participants:
-        - moderator
+      num_agents: 3
       prompt: "You are the moderator closing the session. Using the full exchange above, synthesize three sections: (1) the key takeaways and the thesis as it now stands after Q&A; (2) the questions that were answered convincingly and the points the speaker conceded; (3) the questions that remain open or unresolved. Attribute fairly and add nothing that was not actually said in the talk or the Q&A."
 guards:
   deliver_talk_completed:

--- a/tests/e2e/ceremonies/sprint-planning.yaml
+++ b/tests/e2e/ceremonies/sprint-planning.yaml
@@ -44,8 +44,7 @@ steps:
     handler: facilitation_prompt
     config:
       see_prior: false
-      participants:
-        - product_owner
+      num_agents: 3
       prompt: "Open the sprint planning. Restate the sprint goal in one sentence, then present the ranked priorities for this sprint and the concrete business outcomes each must deliver. For each top item, state why it matters now and what 'done' looks like from a user's perspective. Be explicit about the ordering so the engineer knows exactly which items to break down first."
   - id: task_breakdown
     state: TASK_BREAKDOWN
@@ -53,24 +52,21 @@ steps:
     config:
       see_prior: true
       rounds: 1
-      participants:
-        - engineer
+      num_agents: 3
       prompt: "Take the ranked priorities and desired outcomes the product owner just presented and break the top items, in their stated order, into concrete engineering tasks. For each item give a rough estimate (S/M/L or points) and explicitly surface the unknowns, technical risks, and open questions that could change that estimate. In your second pass, refine the estimates against the unknowns you raised and flag any item that looks too large to finish this sprint. Do not re-list the priorities; react to them directly."
   - id: capacity_review
     state: CAPACITY_CHECK
     handler: challenge_prompt
     config:
       see_prior: true
-      participants:
-        - scrum_master
+      num_agents: 3
       prompt: "Using the engineer's task breakdown and estimates, check the proposed work against real team capacity for this sprint. Sum the estimates against available capacity, then name the cross-task dependencies and sequencing constraints, the delivery risks, and any item whose unknowns make it unsafe to commit. Directly challenge any priority that no longer fits, and propose what should be deferred or split so the plan is achievable. Tie every concern back to a specific item the product owner or engineer named."
   - id: scope_commitment
     state: COMMITMENT
     handler: synthesis_prompt
     config:
       see_prior: true
-      participants:
-        - delivery_lead
+      num_agents: 3
       prompt: "Synthesize the whole discussion into the final committed sprint scope. List the items the team commits to, each with an owner and the outcome it delivers, honoring the priority order and respecting the capacity, dependency, and risk findings raised. Then state the explicit out-of-scope: the items deferred or split, and the one-line reason for each, drawn from the concerns already surfaced. End with the single biggest risk to this commitment and who watches it."
 guards:
   present_priorities_completed:

--- a/tests/e2e/ceremonies/technical-debate.yaml
+++ b/tests/e2e/ceremonies/technical-debate.yaml
@@ -44,8 +44,7 @@ steps:
     handler: facilitation_prompt
     config:
       see_prior: false
-      participants:
-        - proponent
+      num_agents: 3
       prompt: "You are the PROPONENT. State the proposal as a clear thesis, then make the strongest possible case for adopting it. Lead with the single most important benefit, then give the supporting evidence, the concrete mechanism by which it works, and the cost of NOT doing it. Be specific and falsifiable: name the assumptions your case depends on so they can be tested later. Do not hedge — argue to win."
   - id: raise_objections
     state: ARGUING
@@ -53,8 +52,7 @@ steps:
     config:
       see_prior: true
       rounds: 1
-      participants:
-        - opponent
+      num_agents: 3
       prompt: "You are the OPPONENT. You have just heard the proponent's thesis and case in the transcript above. Rebut it directly: quote or paraphrase each of their specific claims and dismantle it. Attack the weakest assumption first, then surface the risks, failure modes, hidden costs, and viable alternatives they ignored. Do not raise generic concerns — answer THEIR argument point by point and explain why each pillar of their case does not hold."
   - id: answer_objections
     state: REBUTTING
@@ -62,16 +60,14 @@ steps:
     config:
       see_prior: true
       rounds: 2
-      participants:
-        - rebutter
+      num_agents: 3
       prompt: "You are the REBUTTER arguing for the proposal. The opponent's objections are in the transcript above. Take their objections one at a time, in their own words, and answer each: concede what is genuinely true, then show why the remaining objections are mitigable, mispriced, or outweighed. Where you concede, propose the concrete condition or safeguard that neutralizes the risk. Across both rounds, sharpen the strongest surviving version of the proposal and make clear what, if anything, would have to be true for the objection to be fatal."
   - id: render_decision
     state: DECIDING
     handler: synthesis_prompt
     config:
       see_prior: true
-      participants:
-        - arbiter
+      num_agents: 3
       prompt: "You are the ARBITER. Read the full debate transcript above — thesis, objections, and rebuttal rounds. Render one decision: ADOPT, REJECT, or ADOPT WITH CONDITIONS. Justify it by citing the single strongest point from the proponent/rebutter side AND the single strongest point from the opponent side, and explain why one outweighs the other. If you adopt with conditions, list the specific conditions (drawn from the rebuttal's concessions) that must hold. State the one assumption that, if proven wrong, would reverse your decision."
 guards:
   state_thesis_completed:


### PR DESCRIPTION
## Engage intra-step rounds — 3-agent panels per step

The catalog ceremonies (#83/#84) declared **one** participant per step, so each turn's council had a single agent and the intra-step `rounds` (critique/revise) **never fired** — `run_peer_review_rounds` no-ops below two agents. Richness came only from cross-step transcript threading; the `rounds` knobs were inert.

### Change
Raise every step to `num_agents: 3`. Each role's turn is now produced by a **three-agent panel**: generate diverse drafts → critique peers → revise → best wins. `rounds` default to 1 (the technical debate's rebuttal keeps `rounds: 2`). Combined with `see_prior`, a step now both **builds on the prior transcript** and is **internally deliberated**.

### Unchanged
Step count, roles, and terminal states are the same → the four `run_<name>_rpc` integration tests still pass.

### Verified against real gemma
Re-ran the daily standup against the deployed M1b choreographer talking to `google/gemma-4-31B-it`: CLOSED, with per-step `deliberation completed rounds:1` spans taking seconds of real inference (e.g. `impediment_review` 13.4s) — confirming the three-agent panel + peer-review actually engages.

### Validation
- `cargo test -p choreo-tests-integration` (the 4 ceremony tests) ✅
- gemma e2e (daily standup, multi-agent) ✅

**Breaking:** none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)