### PR TITLE
feat(ceremony): inject the run-time context brief into each agent's task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,6 +634,7 @@ dependencies = [
  "choreo-core",
  "choreo-proto",
  "futures",
+ "prost-types",
  "rcgen",
  "serde_json",
  "testcontainers",

--- a/crates/choreo-adapters/src/ceremony/deliberating_ceremony_step_handler.rs
+++ b/crates/choreo-adapters/src/ceremony/deliberating_ceremony_step_handler.rs
@@ -113,6 +113,12 @@ fn build_description(
         }
     }
 
+    let brief = render_brief(request.context().attributes());
+    if !brief.is_empty() {
+        text.push_str("\nMission brief:\n");
+        text.push_str(&brief);
+    }
+
     if config.see_prior() && !request.transcript().is_empty() {
         text.push_str("\nThe meeting so far:\n");
         for contribution in request.transcript().contributions() {
@@ -139,6 +145,28 @@ fn build_description(
     );
 
     TaskDescription::new(text)
+}
+
+/// Render the ceremony context as the mission brief shown to every
+/// agent. Boolean entries (such as human-approval guard flags) are
+/// skipped — only the caller-supplied inputs make it into the brief.
+fn render_brief(attributes: &Attributes) -> String {
+    let mut out = String::new();
+    for (key, value) in attributes.as_map() {
+        if value.is_boolean() {
+            continue;
+        }
+        let rendered = match value.as_str() {
+            Some(text) => text.to_owned(),
+            None => value.to_string(),
+        };
+        let _ = writeln!(
+            out,
+            "- {key}: {}",
+            truncate(&rendered, MAX_RENDERED_CONTRIBUTION_LEN)
+        );
+    }
+    out
 }
 
 /// Cap a rendered prior turn so a single runaway contribution cannot
@@ -369,6 +397,25 @@ mod tests {
         assert!(text
             .contains("FACILITATOR (open_room): Restating the brief and inviting perspectives."));
         assert!(text.contains("Your task now: Open the meeting"));
+    }
+
+    #[test]
+    fn render_brief_lists_inputs_and_skips_boolean_flags() {
+        let attributes = Attributes::new(BTreeMap::from([
+            (
+                "mission_brief".to_owned(),
+                json!("Photograph trees that show signs of disease."),
+            ),
+            ("audience_notes".to_owned(), json!("Field foresters")),
+            ("human_approved".to_owned(), json!(true)),
+        ]))
+        .unwrap();
+
+        let brief = render_brief(&attributes);
+
+        assert!(brief.contains("- mission_brief: Photograph trees that show signs of disease."));
+        assert!(brief.contains("- audience_notes: Field foresters"));
+        assert!(!brief.contains("human_approved"));
     }
 
     fn request_with_prompt() -> CeremonyStepHandlerRequest {

--- a/crates/choreo-e2e-runner/src/bin/run_ceremony_file.rs
+++ b/crates/choreo-e2e-runner/src/bin/run_ceremony_file.rs
@@ -11,10 +11,15 @@
 //! - `CHOREOGRAPHER_ENDPOINT` (default `http://localhost:50055`).
 //! - `CEREMONY_ID` (default `operator-ceremony`).
 //! - `CEREMONY_LEASE_TTL_MS` (default `120000`).
+//! - `CEREMONY_CONTEXT_JSON` (optional) — a JSON object passed as the
+//!   ceremony context (its inputs, e.g. `{"mission_brief": "..."}`),
+//!   so a generic ceremony can be driven for any mission.
 
 use anyhow::{Context, Result};
 use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
 use choreo_proto::v1::RunCeremonyRequest;
+use prost_types::{value::Kind, ListValue, Struct, Value as PbValue};
+use serde_json::Value as JsonValue;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -30,6 +35,7 @@ async fn main() -> Result<()> {
 
     let definition_yaml =
         std::fs::read_to_string(&path).with_context(|| format!("reading ceremony YAML {path}"))?;
+    let context = context_from_env()?;
 
     let mut client = ChoreographerServiceClient::connect(endpoint.clone())
         .await
@@ -39,7 +45,7 @@ async fn main() -> Result<()> {
         .run_ceremony(RunCeremonyRequest {
             ceremony_id: ceremony_id.clone(),
             definition_yaml,
-            context: None,
+            context,
             lease_owner_id: "operator".to_owned(),
             lease_ttl_ms,
         })
@@ -73,4 +79,44 @@ async fn main() -> Result<()> {
         );
     }
     Ok(())
+}
+
+/// Read `CEREMONY_CONTEXT_JSON` (a JSON object) into the ceremony context
+/// Struct, or `None` when unset.
+fn context_from_env() -> Result<Option<Struct>> {
+    let Some(raw) = std::env::var("CEREMONY_CONTEXT_JSON")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    else {
+        return Ok(None);
+    };
+    let value: JsonValue =
+        serde_json::from_str(&raw).context("CEREMONY_CONTEXT_JSON must be valid JSON")?;
+    let object = value
+        .as_object()
+        .context("CEREMONY_CONTEXT_JSON must be a JSON object")?;
+    Ok(Some(json_object_to_struct(object)))
+}
+
+fn json_object_to_struct(object: &serde_json::Map<String, JsonValue>) -> Struct {
+    Struct {
+        fields: object
+            .iter()
+            .map(|(key, value)| (key.clone(), json_to_pb_value(value)))
+            .collect(),
+    }
+}
+
+fn json_to_pb_value(value: &JsonValue) -> PbValue {
+    let kind = match value {
+        JsonValue::Null => Kind::NullValue(0),
+        JsonValue::Bool(b) => Kind::BoolValue(*b),
+        JsonValue::Number(n) => Kind::NumberValue(n.as_f64().unwrap_or(0.0)),
+        JsonValue::String(s) => Kind::StringValue(s.clone()),
+        JsonValue::Array(items) => Kind::ListValue(ListValue {
+            values: items.iter().map(json_to_pb_value).collect(),
+        }),
+        JsonValue::Object(object) => Kind::StructValue(json_object_to_struct(object)),
+    };
+    PbValue { kind: Some(kind) }
 }

--- a/crates/choreo-tests-integration/Cargo.toml
+++ b/crates/choreo-tests-integration/Cargo.toml
@@ -49,4 +49,5 @@ uuid = { workspace = true }
 serde_json = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }
+prost-types = { workspace = true }
 testcontainers = "0.23"

--- a/crates/choreo-tests-integration/tests/run_engineering_planning_rpc.rs
+++ b/crates/choreo-tests-integration/tests/run_engineering_planning_rpc.rs
@@ -1,0 +1,67 @@
+use std::collections::BTreeMap;
+
+use choreo_proto::v1::choreographer_service_client::ChoreographerServiceClient;
+use choreo_proto::v1::RunCeremonyRequest;
+use choreo_tests_integration::grpc_fixture::GrpcFixture;
+use prost_types::{value::Kind, Struct, Value};
+
+const ENGINEERING_PLANNING_CEREMONY: &str =
+    include_str!("../../../tests/e2e/ceremonies/engineering-planning.yaml");
+
+fn brief_context(brief: &str) -> Struct {
+    Struct {
+        fields: BTreeMap::from([(
+            "mission_brief".to_owned(),
+            Value {
+                kind: Some(Kind::StringValue(brief.to_owned())),
+            },
+        )]),
+    }
+}
+
+/// Drives the generic engineering-planning ceremony end-to-end, supplying
+/// the mission only through the run-time `context` brief. Proves a
+/// product-agnostic ceremony can be steered onto any mission without a
+/// bespoke YAML — the handler renders the brief into each agent's task.
+#[tokio::test]
+async fn run_engineering_planning_executes_with_a_context_brief() {
+    let fixture = GrpcFixture::start().await;
+    let mut client = ChoreographerServiceClient::new(fixture.channel);
+
+    let response = client
+        .run_ceremony(RunCeremonyRequest {
+            ceremony_id: "integration-engineering-planning".to_owned(),
+            definition_yaml: ENGINEERING_PLANNING_CEREMONY.to_owned(),
+            context: Some(brief_context(
+                "Build an autonomous drone that photographs trees showing signs of disease.",
+            )),
+            lease_owner_id: "integration-test".to_owned(),
+            lease_ttl_ms: 60_000,
+        })
+        .await
+        .expect("RunCeremony should succeed")
+        .into_inner();
+
+    assert_eq!(response.definition_name, "engineering_planning");
+    assert_eq!(response.final_state, "CLOSED");
+    assert!(response.completed);
+    assert_eq!(response.steps.len(), 4);
+    assert!(response.steps.iter().all(|step| step.status == "COMPLETED"));
+
+    for role in [
+        "MISSION_OWNER",
+        "SYSTEMS_ARCHITECT",
+        "SAFETY_REVIEWER",
+        "PROGRAM_LEAD",
+    ] {
+        assert!(
+            response.steps.iter().any(|step| step.role_id == role),
+            "missing completed role {role}"
+        );
+    }
+
+    let diagram = &response.mermaid_sequence;
+    assert!(diagram.contains("sequenceDiagram"));
+    assert!(diagram.contains("frame_mission [facilitation_prompt]"));
+    assert!(diagram.contains("plan_committed -> CLOSED"));
+}

--- a/tests/e2e/ceremonies/engineering-planning.yaml
+++ b/tests/e2e/ceremonies/engineering-planning.yaml
@@ -1,0 +1,103 @@
+version: "1.0"
+name: "engineering_planning"
+description: "Generic four-role engineering planning; the mission is supplied at run time via the context brief"
+inputs:
+  required:
+    - mission_brief
+outputs:
+  build_plan:
+    type: object
+states:
+  - id: BRIEFING
+    initial: true
+  - id: DESIGN
+  - id: RISK_REVIEW
+  - id: BUILD_PLAN
+  - id: CLOSED
+    terminal: true
+transitions:
+  - from: BRIEFING
+    to: DESIGN
+    trigger: mission_framed
+    guards:
+      - frame_mission_completed
+  - from: DESIGN
+    to: RISK_REVIEW
+    trigger: approach_proposed
+    guards:
+      - design_approach_completed
+  - from: RISK_REVIEW
+    to: BUILD_PLAN
+    trigger: risks_reviewed
+    guards:
+      - review_risks_completed
+  - from: BUILD_PLAN
+    to: CLOSED
+    trigger: plan_committed
+    guards:
+      - build_plan_completed
+steps:
+  - id: frame_mission
+    state: BRIEFING
+    handler: facilitation_prompt
+    config:
+      see_prior: false
+      num_agents: 3
+      prompt: "Read the mission brief above and frame it for the engineering team. State the concrete objectives, the measurable success criteria, and the hard operating constraints implied by the mission. Keep it crisp so the architect can design against it."
+  - id: design_approach
+    state: DESIGN
+    handler: progress_prompt
+    config:
+      see_prior: true
+      num_agents: 3
+      prompt: "Given the framed mission, propose the end-to-end technical approach and system architecture. Be concrete about the major subsystems and the key component or technology choices, and justify each against the stated objectives and constraints."
+  - id: review_risks
+    state: RISK_REVIEW
+    handler: challenge_prompt
+    config:
+      see_prior: true
+      num_agents: 3
+      prompt: "Stress-test the proposed approach against the mission. Name the safety, regulatory, and technical risks and the failure modes it must survive. For every risk give a concrete mitigation and who owns it, and be specific about any design choice you would change."
+  - id: build_plan
+    state: BUILD_PLAN
+    handler: synthesis_prompt
+    config:
+      see_prior: true
+      num_agents: 3
+      prompt: "Synthesise the whole discussion into a phased build plan: milestones from a minimum-viable prototype to a mission-capable system, the single biggest technical risk to retire first, and the go/no-go criteria for each phase."
+guards:
+  frame_mission_completed:
+    type: automated
+    check: "step_status:frame_mission:COMPLETED"
+  design_approach_completed:
+    type: automated
+    check: "step_status:design_approach:COMPLETED"
+  review_risks_completed:
+    type: automated
+    check: "step_status:review_risks:COMPLETED"
+  build_plan_completed:
+    type: automated
+    check: "step_status:build_plan:COMPLETED"
+roles:
+  - id: MISSION_OWNER
+    allowed_actions:
+      - frame_mission
+      - mission_framed
+  - id: SYSTEMS_ARCHITECT
+    allowed_actions:
+      - design_approach
+      - approach_proposed
+  - id: SAFETY_REVIEWER
+    allowed_actions:
+      - review_risks
+      - risks_reviewed
+  - id: PROGRAM_LEAD
+    allowed_actions:
+      - build_plan
+      - plan_committed
+timeouts:
+  step_default: 300
+retry_policies:
+  default:
+    max_attempts: 2
+    backoff_seconds: 1


### PR DESCRIPTION
## Drive a generic ceremony onto any mission via the context brief

Closes the gap the captured prompts exposed: a ceremony's `inputs` (passed at run time in the request `context`) never reached the agents, so a ceremony's topic had to be **baked into its step prompts**.

- the handler renders the context as a **"Mission brief"** block in each agent's task (boolean entries — e.g. human-approval guard flags — are skipped; only caller-supplied inputs appear).
- **`choreo-run-ceremony`** accepts `CEREMONY_CONTEXT_JSON` and passes it as the ceremony context.
- a new product-agnostic **`engineering_planning`** ceremony (frame → design → risk-review → build-plan, three-agent panels) + an integration test that drives it **purely from a context brief** — proving a generic ceremony can plan any mission without a bespoke YAML.

### Verified
End-to-end against real gemma: the same generic ceremony plans a "tree-disease survey drone" supplied only via the context brief — each agent's prompt shows `Mission brief: - mission_brief: Build an autonomous … drone …`.

### Validation
- `cargo fmt/clippy --workspace -D warnings` (provider features) ✅
- `cargo test --workspace` ✅

**Breaking:** none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)