### PR TITLE
feat(scoring): rank deliberations by an LLM judge instead of uniform scoring

### DIFF
--- a/crates/choreo-adapters/src/agents/judge.rs
+++ b/crates/choreo-adapters/src/agents/judge.rs
@@ -1,0 +1,357 @@
+//! LLM-judge validator.
+//!
+//! An LLM-backed [`ValidatorPort`] that rates a proposal's intrinsic
+//! quality, so a deliberation's winner is the *strongest* proposal — not
+//! an arbitrary one among those that merely pass the structural
+//! validators. The numeric verdict (0.0–1.0) is carried in the report's
+//! `details` under [`crate::scoring::JUDGE_SCORE_DETAIL_KEY`];
+//! [`crate::scoring::JudgeAwareScoring`] reads it to rank proposals.
+//!
+//! It speaks the same OpenAI/vLLM Chat Completions wire shape as the
+//! provider agents, reusing [`super::openai_compat`].
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use choreo_core::entities::{TaskConstraints, ValidatorReport};
+use choreo_core::error::DomainError;
+use choreo_core::ports::ValidatorPort;
+use choreo_core::value_objects::Attributes;
+use reqwest::Client;
+use serde_json::{json, Value};
+use tracing::warn;
+
+use super::openai_compat::{self as wire, ChatMessage, ChatRequest, ChatResponse, ErrorStrings};
+use crate::scoring::JUDGE_SCORE_DETAIL_KEY;
+
+const JUDGE_ERRORS: ErrorStrings = ErrorStrings {
+    unauthorized: "judge: unauthorized",
+    rate_limited: "judge: rate-limited",
+    bad_request: "judge: bad request",
+    upstream_error: "judge: upstream error",
+    malformed_body: "judge: malformed response body",
+    no_choices: "judge: no choices in response",
+    missing_content: "judge: choice has no message.content",
+    empty_content: "judge: empty text content",
+};
+
+/// `kind` of the report the judge emits.
+pub const JUDGE_KIND: &str = "llm_judge";
+
+const DEFAULT_MAX_TOKENS: u32 = 256;
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
+
+const SYSTEM_PROMPT: &str = "You are an impartial, rigorous judge of the proposals produced in a \
+multi-agent deliberation. You reward proposals that are specific, internally consistent (no \
+contradictions), complete, and actionable; you penalise vagueness, unfilled placeholders, and \
+self-contradiction. You never rewrite the proposal — you only rate it.";
+
+/// An LLM-backed quality judge, plugged into the deliberation as a
+/// validator.
+pub struct LlmJudgeValidator {
+    endpoint: String,
+    model: String,
+    max_tokens: u32,
+    threshold: f64,
+    http: Client,
+}
+
+impl fmt::Debug for LlmJudgeValidator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LlmJudgeValidator")
+            .field("endpoint", &self.endpoint)
+            .field("model", &self.model)
+            .field("threshold", &self.threshold)
+            .finish()
+    }
+}
+
+impl LlmJudgeValidator {
+    /// Build a judge against an OpenAI/vLLM-compatible `endpoint` serving
+    /// `model`, passing a proposal when its score reaches `threshold`
+    /// (0.0–1.0). The `passed` flag does not drive the ranking — the
+    /// numeric score does — but it lets the judge act as a quality gate
+    /// too.
+    pub fn new(
+        endpoint: impl Into<String>,
+        model: impl Into<String>,
+        threshold: f64,
+    ) -> Result<Self, DomainError> {
+        let endpoint = endpoint.into().trim().to_owned();
+        if endpoint.is_empty() {
+            return Err(DomainError::EmptyField {
+                field: "judge.endpoint",
+            });
+        }
+        let model = model.into().trim().to_owned();
+        if model.is_empty() {
+            return Err(DomainError::EmptyField {
+                field: "judge.model",
+            });
+        }
+        if !(0.0..=1.0).contains(&threshold) {
+            return Err(DomainError::OutOfRange {
+                field: "judge.threshold",
+                value: threshold,
+                min: 0.0,
+                max: 1.0,
+            });
+        }
+        let http = build_client(DEFAULT_TIMEOUT)?;
+        Ok(Self {
+            endpoint,
+            model,
+            max_tokens: DEFAULT_MAX_TOKENS,
+            threshold,
+            http,
+        })
+    }
+
+    pub fn with_max_tokens(mut self, max_tokens: u32) -> Result<Self, DomainError> {
+        if max_tokens == 0 {
+            return Err(DomainError::MustBeNonZero {
+                field: "judge.max_tokens",
+            });
+        }
+        self.max_tokens = max_tokens;
+        Ok(self)
+    }
+
+    pub fn with_timeout(mut self, timeout: Duration) -> Result<Self, DomainError> {
+        self.http = build_client(timeout)?;
+        Ok(self)
+    }
+
+    async fn rate(&self, content: &str) -> Result<f64, DomainError> {
+        let user = format!(
+            "Rate the following proposal on a 0–100 integer scale (100 = excellent). Respond with \
+             ONLY a JSON object: {{\"score\": <integer 0-100>, \"reason\": \"<one short sentence>\"}}. \
+             Do not wrap it in markdown.\n\nProposal:\n---\n{content}\n---"
+        );
+        let body = ChatRequest {
+            model: &self.model,
+            max_tokens: self.max_tokens,
+            messages: vec![
+                ChatMessage {
+                    role: "system",
+                    content: SYSTEM_PROMPT.to_owned(),
+                },
+                ChatMessage {
+                    role: "user",
+                    content: user,
+                },
+            ],
+        };
+        let url = format!(
+            "{}/v1/chat/completions",
+            self.endpoint.trim_end_matches('/')
+        );
+
+        let response = self
+            .http
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|err| {
+                warn!(error = %err, "judge: request failed");
+                DomainError::InvariantViolated {
+                    reason: "judge: request failed",
+                }
+            })?;
+
+        let status = response.status();
+        if !status.is_success() {
+            return Err(wire::classify_error(status, &JUDGE_ERRORS));
+        }
+
+        let parsed: ChatResponse = response.json().await.map_err(|err| {
+            warn!(error = %err, "judge: malformed response body");
+            DomainError::InvariantViolated {
+                reason: JUDGE_ERRORS.malformed_body,
+            }
+        })?;
+        let text = wire::extract_text(parsed, &JUDGE_ERRORS)?;
+        parse_score(&text)
+    }
+}
+
+#[async_trait]
+impl ValidatorPort for LlmJudgeValidator {
+    fn kind(&self) -> &str {
+        JUDGE_KIND
+    }
+
+    async fn validate(
+        &self,
+        proposal_content: &str,
+        _constraints: &TaskConstraints,
+    ) -> Result<ValidatorReport, DomainError> {
+        let score = self.rate(proposal_content).await?;
+        let details = Attributes::new(BTreeMap::from([(
+            JUDGE_SCORE_DETAIL_KEY.to_owned(),
+            json!(score),
+        )]))?;
+        ValidatorReport::new(
+            JUDGE_KIND,
+            score >= self.threshold,
+            format!("llm judge score {score:.2}"),
+            details,
+        )
+    }
+}
+
+fn build_client(timeout: Duration) -> Result<Client, DomainError> {
+    Client::builder().timeout(timeout).build().map_err(|err| {
+        warn!(error = %err, "judge: failed to build http client");
+        DomainError::InvariantViolated {
+            reason: "judge: failed to build http client",
+        }
+    })
+}
+
+/// Parse the judge's reply (a `{"score": 0-100, ...}` object, possibly
+/// surrounded by prose or markdown fences) into a 0.0–1.0 score.
+fn parse_score(text: &str) -> Result<f64, DomainError> {
+    let (Some(start), Some(end)) = (text.find('{'), text.rfind('}')) else {
+        return Err(DomainError::InvariantViolated {
+            reason: "judge: reply is not a JSON object",
+        });
+    };
+    if end <= start {
+        return Err(DomainError::InvariantViolated {
+            reason: "judge: reply is not a JSON object",
+        });
+    }
+    let value: Value =
+        serde_json::from_str(&text[start..=end]).map_err(|_| DomainError::InvariantViolated {
+            reason: "judge: reply JSON is malformed",
+        })?;
+    let score =
+        value
+            .get("score")
+            .and_then(Value::as_f64)
+            .ok_or(DomainError::InvariantViolated {
+                reason: "judge: reply has no numeric score",
+            })?;
+    Ok((score / 100.0).clamp(0.0, 1.0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn parse_score_handles_plain_json() {
+        assert!((parse_score(r#"{"score": 80, "reason": "ok"}"#).unwrap() - 0.8).abs() < 1e-9);
+    }
+
+    #[test]
+    fn parse_score_handles_markdown_fences_and_prose() {
+        let reply = "Sure!\n```json\n{\"score\": 95, \"reason\": \"specific\"}\n```";
+        assert!((parse_score(reply).unwrap() - 0.95).abs() < 1e-9);
+    }
+
+    #[test]
+    fn parse_score_clamps_above_range() {
+        assert_eq!(parse_score(r#"{"score": 130}"#).unwrap(), 1.0);
+    }
+
+    #[test]
+    fn parse_score_rejects_non_json() {
+        assert!(parse_score("no json here").is_err());
+    }
+
+    #[test]
+    fn parse_score_rejects_missing_score() {
+        assert!(parse_score(r#"{"reason": "x"}"#).is_err());
+    }
+
+    #[test]
+    fn threshold_out_of_range_is_rejected() {
+        assert!(matches!(
+            LlmJudgeValidator::new("http://x", "m", 1.5).unwrap_err(),
+            DomainError::OutOfRange {
+                field: "judge.threshold",
+                ..
+            }
+        ));
+    }
+
+    fn judge(server: &MockServer) -> LlmJudgeValidator {
+        LlmJudgeValidator::new(server.uri(), "test-model", 0.5)
+            .unwrap()
+            .with_timeout(Duration::from_secs(5))
+            .unwrap()
+    }
+
+    fn chat_response(text: &str) -> serde_json::Value {
+        json!({
+            "id": "cmpl-test",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": text},
+                "finish_reason": "stop"
+            }]
+        })
+    }
+
+    #[tokio::test]
+    async fn validate_carries_the_score_in_details_and_passes_above_threshold() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(chat_response(
+                r#"{"score": 88, "reason": "specific and consistent"}"#,
+            )))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let report = judge(&server)
+            .validate(
+                "a detailed, consistent proposal",
+                &TaskConstraints::default(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(report.kind(), "llm_judge");
+        assert!(report.passed());
+        assert!(
+            (report
+                .details()
+                .get(JUDGE_SCORE_DETAIL_KEY)
+                .and_then(Value::as_f64)
+                .unwrap()
+                - 0.88)
+                .abs()
+                < 1e-9
+        );
+    }
+
+    #[tokio::test]
+    async fn validate_marks_low_quality_as_not_passed() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(chat_response(
+                r#"{"score": 20, "reason": "vague placeholders"}"#,
+            )))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let report = judge(&server)
+            .validate("vague", &TaskConstraints::default())
+            .await
+            .unwrap();
+
+        assert!(!report.passed());
+    }
+}

--- a/crates/choreo-adapters/src/agents/mod.rs
+++ b/crates/choreo-adapters/src/agents/mod.rs
@@ -27,6 +27,9 @@ mod prompts;
 #[cfg(any(feature = "agent-openai", feature = "agent-vllm"))]
 mod openai_compat;
 
+#[cfg(any(feature = "agent-openai", feature = "agent-vllm"))]
+pub mod judge;
+
 #[cfg(feature = "agent-anthropic")]
 pub mod anthropic;
 
@@ -40,3 +43,76 @@ pub mod factory;
 pub use factory::{
     DispatchingAgentFactory, ANTHROPIC_AGENT_KIND, OPENAI_AGENT_KIND, VLLM_AGENT_KIND,
 };
+
+use std::sync::Arc;
+
+use choreo_core::error::DomainError;
+use choreo_core::ports::ValidatorPort;
+
+/// Build the LLM-judge validator from the environment, when enabled.
+///
+/// The judge is opt-in via `CHOREO_JUDGE_ENABLED` (`1`/`true`/`yes`). When
+/// enabled it reuses the vLLM endpoint and model (`CHOREO_VLLM_ENDPOINT`,
+/// `CHOREO_VLLM_MODEL`) and an optional `CHOREO_JUDGE_THRESHOLD` (default
+/// `0.5`). The feature-gating lives here, mirroring
+/// [`DispatchingAgentFactory::from_env`]: the composition root calls this
+/// unconditionally and stays free of provider `cfg`s.
+///
+/// Returns `Ok(None)` when the judge is disabled, or when the binary was
+/// built without a Chat-Completions provider feature (so the judge code is
+/// not compiled in). Returns `Err` — failing fast — when the judge is
+/// explicitly enabled but its endpoint/model/threshold are missing or
+/// invalid.
+pub fn judge_from_env() -> Result<Option<Arc<dyn ValidatorPort>>, DomainError> {
+    if !judge_enabled() {
+        return Ok(None);
+    }
+    #[cfg(any(feature = "agent-openai", feature = "agent-vllm"))]
+    {
+        build_env_judge().map(Some)
+    }
+    #[cfg(not(any(feature = "agent-openai", feature = "agent-vllm")))]
+    {
+        tracing::warn!(
+            "CHOREO_JUDGE_ENABLED is set but this build has no Chat-Completions \
+             provider feature; scoring stays uniform"
+        );
+        Ok(None)
+    }
+}
+
+/// Whether the operator opted the judge in via `CHOREO_JUDGE_ENABLED`.
+fn judge_enabled() -> bool {
+    std::env::var("CHOREO_JUDGE_ENABLED")
+        .map(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes"
+            )
+        })
+        .unwrap_or(false)
+}
+
+/// Construct the judge from the vLLM endpoint/model env, failing fast on a
+/// missing or invalid setting.
+#[cfg(any(feature = "agent-openai", feature = "agent-vllm"))]
+fn build_env_judge() -> Result<Arc<dyn ValidatorPort>, DomainError> {
+    let endpoint = std::env::var("CHOREO_VLLM_ENDPOINT").map_err(|_| DomainError::EmptyField {
+        field: "judge.endpoint",
+    })?;
+    let model = std::env::var("CHOREO_VLLM_MODEL").map_err(|_| DomainError::EmptyField {
+        field: "judge.model",
+    })?;
+    let threshold = std::env::var("CHOREO_JUDGE_THRESHOLD")
+        .ok()
+        .map_or(Ok(0.5), |value| {
+            value
+                .trim()
+                .parse::<f64>()
+                .map_err(|_| DomainError::EmptyField {
+                    field: "judge.threshold",
+                })
+        })?;
+    let judge = judge::LlmJudgeValidator::new(endpoint, model, threshold)?;
+    Ok(Arc::new(judge))
+}

--- a/crates/choreo-adapters/src/scoring.rs
+++ b/crates/choreo-adapters/src/scoring.rs
@@ -11,6 +11,12 @@ use choreo_core::entities::ValidatorReport;
 use choreo_core::error::DomainError;
 use choreo_core::ports::ScoringPort;
 use choreo_core::value_objects::Score;
+use serde_json::Value;
+
+/// Details key under which an LLM judge writes its 0.0–1.0 verdict. This
+/// is the contract between [`crate::agents::judge::LlmJudgeValidator`]
+/// (writer) and [`JudgeAwareScoring`] (reader).
+pub const JUDGE_SCORE_DETAIL_KEY: &str = "judge.score";
 
 /// Uniform scoring: the score is the fraction of reports that passed.
 ///
@@ -42,13 +48,95 @@ impl ScoringPort for UniformScoring {
     }
 }
 
+/// Scoring that lets an LLM judge decide the ranking.
+///
+/// If any report carries a numeric verdict under
+/// [`JUDGE_SCORE_DETAIL_KEY`] (written by `LlmJudgeValidator`), that
+/// value *is* the proposal's score — so the strongest proposal wins,
+/// not an arbitrary one among those that merely passed the structural
+/// validators. When no judge ran, it falls back to the same
+/// pass-fraction policy as [`UniformScoring`], so it is a safe default.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct JudgeAwareScoring;
+
+impl JudgeAwareScoring {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl ScoringPort for JudgeAwareScoring {
+    async fn score(&self, reports: &[ValidatorReport]) -> Result<Score, DomainError> {
+        if let Some(verdict) = reports
+            .iter()
+            .find_map(|report| report.details().get(JUDGE_SCORE_DETAIL_KEY))
+            .and_then(Value::as_f64)
+        {
+            return Score::new(verdict.clamp(0.0, 1.0));
+        }
+        if reports.is_empty() {
+            return Ok(Score::MIN);
+        }
+        let passed = reports.iter().filter(|report| report.passed()).count();
+        #[allow(clippy::cast_precision_loss)]
+        let value = passed as f64 / reports.len() as f64;
+        Score::new(value)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use choreo_core::value_objects::Attributes;
+    use serde_json::json;
+    use std::collections::BTreeMap;
 
     fn report(passed: bool) -> ValidatorReport {
         ValidatorReport::new("k", passed, "", Attributes::empty()).unwrap()
+    }
+
+    fn judged(score: f64) -> ValidatorReport {
+        let details = Attributes::new(BTreeMap::from([(
+            JUDGE_SCORE_DETAIL_KEY.to_owned(),
+            json!(score),
+        )]))
+        .unwrap();
+        ValidatorReport::new("llm_judge", score >= 0.5, "", details).unwrap()
+    }
+
+    #[tokio::test]
+    async fn judge_aware_uses_the_judge_verdict_when_present() {
+        let s = JudgeAwareScoring::new()
+            .score(&[report(true), judged(0.82)])
+            .await
+            .unwrap();
+        assert!((s.get() - 0.82).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn judge_aware_clamps_out_of_range_verdicts() {
+        let s = JudgeAwareScoring::new()
+            .score(&[judged(1.5)])
+            .await
+            .unwrap();
+        assert_eq!(s, Score::MAX);
+    }
+
+    #[tokio::test]
+    async fn judge_aware_falls_back_to_pass_fraction_without_a_judge() {
+        let s = JudgeAwareScoring::new()
+            .score(&[report(true), report(false)])
+            .await
+            .unwrap();
+        assert_eq!(s.get(), 0.5);
+    }
+
+    #[tokio::test]
+    async fn judge_aware_empty_reports_score_to_min() {
+        let s = JudgeAwareScoring::new().score(&[]).await.unwrap();
+        assert_eq!(s, Score::MIN);
     }
 
     #[tokio::test]

--- a/crates/choreo/src/compose.rs
+++ b/crates/choreo/src/compose.rs
@@ -20,7 +20,7 @@ use choreo_adapters::postgres::{
 use choreo_adapters::runtime::{
     ExecutorBackendConfig, RuntimeExecutor, RuntimeExecutorConnectError,
 };
-use choreo_adapters::scoring::UniformScoring;
+use choreo_adapters::scoring::{JudgeAwareScoring, UniformScoring};
 use choreo_adapters::validators::{
     AllowedStringValuesValidator, BoundedEventShapeValidator, ContentNonEmptyValidator,
     JsonObjectOutputValidator, JsonSchemaValidator, RequiredFieldsValidator,
@@ -84,6 +84,25 @@ pub enum ComposeError {
     RuntimeExecutor(#[from] RuntimeExecutorConnectError),
 }
 
+/// Pick the scoring policy and wire the optional LLM judge.
+///
+/// When `judge_from_env` yields a judge it is appended to `validators`,
+/// and `JudgeAwareScoring` makes its verdict rank proposals; otherwise
+/// scoring is uniform. Fails fast when the judge is enabled but
+/// misconfigured.
+fn wire_scoring(
+    validators: &mut Vec<Arc<dyn ValidatorPort>>,
+) -> Result<Arc<dyn ScoringPort>, DomainError> {
+    match choreo_adapters::agents::judge_from_env()? {
+        Some(judge) => {
+            validators.push(judge);
+            info!("scoring: LLM judge enabled; ranking by judge verdict");
+            Ok(Arc::new(JudgeAwareScoring::new()))
+        }
+        None => Ok(Arc::new(UniformScoring::new())),
+    }
+}
+
 /// Wire the full application.
 ///
 /// - Reads [`ServiceConfig`] from the environment.
@@ -101,7 +120,7 @@ pub async fn compose() -> Result<Application, ComposeError> {
     let service_config = EnvConfiguration::new().load().await?;
 
     let clock = Arc::new(SystemClock::new());
-    let validators: Vec<Arc<dyn ValidatorPort>> = vec![
+    let mut validators: Vec<Arc<dyn ValidatorPort>> = vec![
         Arc::new(ContentNonEmptyValidator::new()),
         Arc::new(JsonObjectOutputValidator::new()),
         Arc::new(RequiredFieldsValidator::new()),
@@ -114,7 +133,9 @@ pub async fn compose() -> Result<Application, ComposeError> {
         // needs different bounds.
         Arc::new(BoundedEventShapeValidator::new()),
     ];
-    let scoring: Arc<dyn ScoringPort> = Arc::new(UniformScoring::new());
+    // Choose scoring, and when an LLM judge is configured append it to
+    // the validator chain so its verdict drives the ranking.
+    let scoring: Arc<dyn ScoringPort> = wire_scoring(&mut validators)?;
     let executor = wire_executor().await?;
     let dispatching_factory = DispatchingAgentFactory::from_env()?;
     let supported_agent_kinds = dispatching_factory.supported_kinds().join(",");


### PR DESCRIPTION
## What

Replaces `UniformScoring` (where the winner of a deliberation is essentially
arbitrary among the proposals that pass the structural validators) with an
**LLM-as-judge** that rates each proposal's intrinsic quality, so the
*strongest* proposal wins.

## How it fits the hexagon

No core port signatures change. The judge plugs in as two adapters:

- **`LlmJudgeValidator`** (`choreo-adapters/src/agents/judge.rs`) — a
  `ValidatorPort` that POSTs the proposal to an OpenAI/vLLM Chat Completions
  endpoint, asks for a `{"score": 0-100, "reason": "..."}` verdict, and writes
  the normalised `0.0–1.0` score into the report's `details` under
  `JUDGE_SCORE_DETAIL_KEY` (`"judge.score"`). It speaks the same wire shape as
  the provider agents, reusing `openai_compat`. `parse_score` tolerates
  markdown fences / surrounding prose.
- **`JudgeAwareScoring`** (`choreo-adapters/src/scoring.rs`) — a `ScoringPort`
  that reads `judge.score` and makes it *the* proposal score. With no judge
  present it falls back to the same pass-fraction policy as `UniformScoring`,
  so it is a safe default.

The contract between the two is the single `JUDGE_SCORE_DETAIL_KEY` const.

## Composition root

`choreo_adapters::agents::judge_from_env()` is an always-compiled builder
(mirroring `DispatchingAgentFactory::from_env`) that keeps the provider
`cfg`s out of the composition root. `compose::wire_scoring` calls it: when a
judge is returned it is appended to the validator chain and `JudgeAwareScoring`
is used; otherwise scoring stays uniform.

Env (opt-in, fail-fast when enabled-but-misconfigured):

- `CHOREO_JUDGE_ENABLED=true` — turn the judge on.
- reuses `CHOREO_VLLM_ENDPOINT` / `CHOREO_VLLM_MODEL`.
- `CHOREO_JUDGE_THRESHOLD` (default `0.5`) — pass/quality gate; the *score*,
  not the gate, drives ranking.

Disabled by default, and a no-provider build compiles the judge out entirely
(returns `Ok(None)`), so behaviour is unchanged unless an operator opts in.

## Tests

- `judge.rs`: `parse_score` variants (plain JSON, markdown fences, clamping,
  rejects non-JSON / missing score), threshold validation, and two wiremock
  `validate` tests (carries score + passes above threshold; marks low-quality
  as not passed).
- `scoring.rs`: `JudgeAwareScoring` uses the verdict when present, clamps
  out-of-range verdicts, falls back to pass-fraction without a judge, scores
  empty reports to MIN.

Validated under the pinned 1.90 toolchain: `cargo clippy --workspace
--all-targets` with all three provider features and `-D warnings`, plus
`cargo test --workspace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
