### PR TITLE
feat(chart): persist the LLM judge + vLLM provider env in the runtime overlay

### DIFF
--- a/charts/choreographer/templates/deployment.yaml
+++ b/charts/choreographer/templates/deployment.yaml
@@ -39,6 +39,24 @@ spec:
       {{- fail "executor.runtime.tls.mode != disabled but executor.runtime.tls.existingSecret is empty; provide a secret with ca.crt (plus tls.crt + tls.key for mutual)" }}
       {{- end }}
       {{- $runtimeTlsMounted := and (eq $executorKind "runtime") (ne $runtimeTlsMode "disabled") }}
+      {{- /*
+        LLM-judge fail-fast guard. The judge (CHOREO_JUDGE_ENABLED) reuses the
+        vLLM endpoint/model and the binary fails fast — crash-looping the pod —
+        when enabled without them. Refuse to render a judge-on-without-vLLM
+        config, mirroring the binary's truthiness ("1"/"true"/"yes"). Skipped
+        when providerEnvFrom is set, since a Secret/ConfigMap may carry the
+        vLLM vars and the template cannot introspect it.
+      */}}
+      {{- $penv := dict }}
+      {{- range (.Values.providerEnv | default list) }}
+      {{- $penv = set $penv .name ((.value | default "") | toString) }}
+      {{- end }}
+      {{- $judgeOn := has (lower (trim (get $penv "CHOREO_JUDGE_ENABLED"))) (list "1" "true" "yes") }}
+      {{- if and $judgeOn (not .Values.providerEnvFrom) }}
+      {{- if or (eq (get $penv "CHOREO_VLLM_ENDPOINT") "") (eq (get $penv "CHOREO_VLLM_MODEL") "") }}
+      {{- fail "CHOREO_JUDGE_ENABLED is set but providerEnv lacks CHOREO_VLLM_ENDPOINT/CHOREO_VLLM_MODEL; the judge fails fast without them. Add both to providerEnv, or supply them via providerEnvFrom." }}
+      {{- end }}
+      {{- end }}
       {{- if or .Values.tmpVolume.enabled (ne $tlsMode "none") $runtimeTlsMounted }}
       volumes:
         {{- if .Values.tmpVolume.enabled }}

--- a/charts/choreographer/values.underpass-runtime.yaml
+++ b/charts/choreographer/values.underpass-runtime.yaml
@@ -63,6 +63,30 @@ config:
   seedSpecialties: triage
   logLevel: info
 
+# Provider + scoring configuration for the in-namespace vLLM (gemma).
+# Captured here so `helm upgrade` reproduces the working pod instead of
+# depending on imperative `kubectl set env` drift. The endpoint/model are
+# the in-cluster gemma Service (not secrets), so they live in plain
+# values; a bearer token, if ever needed, belongs in a Secret wired via
+# `providerEnvFrom`.
+providerEnv:
+  - name: CHOREO_VLLM_ENDPOINT
+    value: "http://underpass-llm-gemma-4-31b-structured:8000"
+  - name: CHOREO_VLLM_MODEL
+    value: "google/gemma-4-31B-it"
+  - name: CHOREO_VLLM_MAX_TOKENS
+    value: "512"
+  - name: CHOREO_VLLM_TIMEOUT_SECS
+    value: "300"
+  # LLM-as-judge scoring (PR #89): ranks deliberation proposals by quality
+  # instead of uniform pass-fraction. It reuses the vLLM endpoint/model
+  # above and fails fast when they are absent, which is why both blocks
+  # are kept together — never enable the judge without the vLLM config.
+  - name: CHOREO_JUDGE_ENABLED
+    value: "true"
+  - name: CHOREO_JUDGE_THRESHOLD
+    value: "0.5"
+
 # Persistence stays off in this first rollout; the deliberation
 # registries default to in-memory adapters, which is fine for the
 # smoke + E2E pass. Flip on when a Postgres CR exists in-namespace.

--- a/docs/operations/deploy-kubernetes.md
+++ b/docs/operations/deploy-kubernetes.md
@@ -791,6 +791,34 @@ curl -s localhost:8080/healthz
 curl -s localhost:8080/readyz   # {"checks":[{"name":"nats","healthy":true,...}]}
 ```
 
+### LLM-as-judge scoring
+
+This profile enables the **LLM-as-judge** scorer. By default a deliberation's
+winner is whichever proposal clears the most validators (uniform
+pass-fraction), so among several valid proposals the winner is effectively
+arbitrary. With the judge on, an LLM rates each proposal's intrinsic quality
+and that score picks the winner instead.
+
+It is configured through `providerEnv` in
+[`values.underpass-runtime.yaml`](../../charts/choreographer/values.underpass-runtime.yaml):
+
+| Var | Meaning |
+| --- | --- |
+| `CHOREO_JUDGE_ENABLED` | `true` turns the judge on (opt-in; default off). |
+| `CHOREO_JUDGE_THRESHOLD` | Pass/quality gate `0.0–1.0` (default `0.5`). The *score*, not the gate, drives ranking. |
+
+The judge **reuses the vLLM endpoint/model** (`CHOREO_VLLM_ENDPOINT`,
+`CHOREO_VLLM_MODEL`) and the binary fails fast when enabled without them —
+so the two blocks are kept together in `providerEnv`, and the chart refuses
+to render a judge-on-without-vLLM config — a `fail` guard in
+`templates/deployment.yaml` — unless the vLLM vars come from a Secret via
+`providerEnvFrom`.
+
+Cost: the judge adds **one extra vLLM call per proposal**, run serially
+against the single-stream in-cluster gemma — expect deliberations to take
+proportionally longer. Turn it off by removing the two `CHOREO_JUDGE_*`
+entries (the vLLM agents keep working without it).
+
 ## End-to-end against the deploy
 
 `tests/e2e/kubernetes/runner-job.yaml` runs the `choreo-e2e-runner`

--- a/scripts/ci/helm-lint.sh
+++ b/scripts/ci/helm-lint.sh
@@ -229,6 +229,19 @@ runtime_markers=(
   'name: runtime-tls'
   'secretName: "choreographer-runtime-client-tls"'
   'mountPath: /etc/choreographer/runtime-tls'
+  # vLLM provider + LLM-judge scoring (persisted in providerEnv so a
+  # `helm upgrade` reproduces the working pod). If a future edit drops
+  # this block, these markers fail CI before the drift reaches a cluster.
+  # `toYaml` renders the URL/model scalars bare and the rest quoted.
+  'name: CHOREO_VLLM_ENDPOINT'
+  'value: http://underpass-llm-gemma-4-31b-structured:8000'
+  'name: CHOREO_VLLM_MODEL'
+  'value: google/gemma-4-31B-it'
+  'name: CHOREO_VLLM_MAX_TOKENS'
+  'name: CHOREO_VLLM_TIMEOUT_SECS'
+  'name: CHOREO_JUDGE_ENABLED'
+  'name: CHOREO_JUDGE_THRESHOLD'
+  'value: "0.5"'
 )
 for marker in "${runtime_markers[@]}"; do
   if ! grep -qF -- "${marker}" "${RUNTIME_OUT}"; then


### PR DESCRIPTION
## What

Persist the LLM judge (PR #89) and the in-namespace vLLM (gemma) provider
config into the `underpass-runtime` Helm overlay, so a `helm upgrade`
reproduces the working pod instead of depending on imperative
`kubectl set env` drift.

## Why

The live `choreographer` pod carried six env vars only as imperative drift —
the chart's `providerEnv` default is `[]` and the overlay didn't set it:

```
CHOREO_VLLM_ENDPOINT, CHOREO_VLLM_MODEL, CHOREO_VLLM_MAX_TOKENS,
CHOREO_VLLM_TIMEOUT_SECS, CHOREO_JUDGE_ENABLED, CHOREO_JUDGE_THRESHOLD
```

A `helm upgrade` would have wiped them. Worse, enabling the judge durably
**without** the vLLM config would crash-loop the pod: `judge_from_env()`
fails fast when `CHOREO_JUDGE_ENABLED=true` but the endpoint/model are
absent.

## Changes

- **`values.underpass-runtime.yaml`** — capture the six vars in `providerEnv`,
  vLLM + judge kept together with a comment on the coupling. Endpoint/model
  are the in-cluster gemma Service (not secrets), so plain values; a bearer
  token, if ever needed, belongs in a Secret via `providerEnvFrom`.
- **`templates/deployment.yaml`** — a `fail` guard makes the judge↔vLLM
  coupling structural (the chart already uses `fail` for analogous coupled
  invariants): rendering aborts if `CHOREO_JUDGE_ENABLED` is truthy
  (`1`/`true`/`yes`, mirroring the binary) while `CHOREO_VLLM_ENDPOINT`/
  `MODEL` are missing — unless `providerEnvFrom` is set (a Secret the
  template can't introspect).
- **`scripts/ci/helm-lint.sh`** — add the vLLM/judge env to `runtime_markers`
  so a future edit that drops the block fails CI before the drift reaches a
  cluster.
- **`docs/operations/deploy-kubernetes.md`** — an "LLM-as-judge scoring"
  subsection: the knobs, the hard vLLM dependency, and the per-proposal
  serial vLLM cost.

## Verification

- `helm lint` clean; `scripts/ci/helm-lint.sh` passes (all profiles + the new
  markers).
- `helm template … --set image.tag=e2e-098d633` renders all six vars; the
  rendered container env is **identical (name→value set, all 24 entries)** to
  the live pod — a pure drift-elimination. (The only difference vs the live
  pod is the *order* of two vLLM entries, a `kubectl set env` append artifact
  that self-heals on the next deploy.)
- Guard tested: judge-on-without-vLLM **aborts** with the expected message;
  judge-on with `providerEnvFrom` set **renders** (guard correctly skipped).
- Adversarially reviewed across five lenses (env/spec parity, judge fail-fast
  safety, deploy-path + image durability, YAML/K8s type correctness,
  completeness).

The image tag stays a deploy-time argument (`--set image.tag=…`, per the
chart's immutable-per-commit convention); this PR only persists config.

**After merge**, run `deploy-kubernetes.sh` (or `helm upgrade`) against the
`underpass-runtime` namespace to reconcile the running pod and drop the
imperative env override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
