### PR TITLE
docs: reconcile status/tracking surface with shipped ceremonies + judge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,23 @@ operator command.
 
 ### Added
 
+- LLM-as-judge scoring: an optional `JudgeAwareScoring` strategy fed by an
+  `LlmJudgeValidator` that ranks deliberation proposals by intrinsic
+  quality instead of validator pass-fraction. Opt-in via
+  `CHOREO_JUDGE_ENABLED` (with `CHOREO_JUDGE_THRESHOLD`), reusing the vLLM
+  endpoint/model; fail-fast wiring and a Helm chart guard refuse a
+  judge-on-without-vLLM configuration. Covered by unit tests and a
+  provider-backed E2E.
+- Ceremony engine: `RunCeremony` executes YAML-defined ceremonies as
+  finite-state machines (states, steps with pluggable handlers, guarded
+  transitions, roles), with multi-agent panels, a run-time context brief
+  injected into each agent's task, and a Mermaid sequence diagram in the
+  response. Catalog ceremonies (daily standup, technical debate, sprint
+  planning, speaker + Q&A) run end-to-end in CI, driven by the
+  `choreo-run-ceremony` operator tool.
+- Helm persistence for the judge + vLLM provider env in the
+  `underpass-runtime` overlay, guarded by a CI marker and a chart `fail`
+  assertion enforcing the judge↔vLLM coupling.
 - Product usability and publication planning:
   `docs/product-usability-publication-plan.md` and
   `docs/product-publication-checklist.md`.
@@ -27,7 +44,7 @@ operator command.
 - MCP fixture and live-gRPC quickstarts, plus examples for
   `CreateCouncil`, `RegisterAgent`, `RegisterContract`,
   `RunCouncilDecision`, and `Orchestrate`.
-- Repo-owned compose E2E guide covering the nine scenarios, stubs,
+- Repo-owned compose E2E guide covering the compose scenarios, stubs,
   Report schema, and provider-shaped OpenAI/vLLM paths.
 - E2E runner scenario selection through `CHOREO_E2E_SCENARIOS`, with
   groups for `compose`, `cluster-connectivity`, `runtime-stub`, and

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ CHOREO_MCP_GRPC_ENDPOINT=http://127.0.0.1:50055 choreo-mcp
 | `choreo-mcp-proto` | Vendored `underpass.choreo.v1` proto crate used to publish `choreo-mcp` independently. |
 | `choreo` | Binary: wires adapters, runs gRPC + NATS. |
 | `choreo-mcp` | Stdio MCP adapter that exposes every gRPC RPC as an MCP tool. |
+| `choreo-e2e-runner` | Operator + E2E driver binaries (incl. `choreo-run-ceremony`) that exercise the service over its public gRPC surface. |
+| `choreo-tests-integration` | Integration tests backed by testcontainers-managed services. Not shipped. |
+| `choreo-consumer-smoke` | Standalone NATS consumer smoke check. Not shipped. |
 
 ## Principles
 
@@ -174,8 +177,8 @@ gate in this repository):
   `GetDeliberationResult`, `Orchestrate`, `CreateCouncil`,
   `ListCouncils`, `DeleteCouncil`, `RegisterAgent`,
   `UnregisterAgent`, `ProcessTriggerEvent`, `RunCouncilDecision`,
-  `RegisterContract`, `ListContracts`, `DeleteContract`, `GetStatus`,
-  and `GetMetrics`. No RPC returns `UNIMPLEMENTED`. Caveats:
+  `RegisterContract`, `ListContracts`, `DeleteContract`, `RunCeremony`,
+  `GetStatus`, and `GetMetrics`. No RPC returns `UNIMPLEMENTED`. Caveats:
   (a) provider-backed `RegisterAgent` kinds require the matching Cargo
   feature and boot-time credentials; `noop` is always available.
   (b) `StreamDeliberation` emits phase transitions + a final
@@ -189,6 +192,20 @@ gate in this repository):
 - Optional seeding: `CHOREO_SEED_SPECIALTIES=triage,reviewer`
   registers one `NoopAgent` and one single-agent council per specialty
   so a fresh deployment is immediately exercisable end-to-end.
+- Ceremony orchestration: `RunCeremony` executes a YAML-defined ceremony
+  as a finite-state machine — states, steps with pluggable handlers,
+  guarded transitions, and roles. A step can drive a full council
+  deliberation; prior turns thread into later steps' briefs; the
+  response carries a Mermaid sequence diagram of the conversation.
+  Catalog ceremonies (daily standup, technical debate, sprint planning,
+  speaker + Q&A) run end-to-end in CI.
+- Scoring: the winner of a deliberation is chosen by a pluggable
+  `ScoringPort`. The default ranks by validator pass-fraction; an
+  optional LLM-as-judge (`CHOREO_JUDGE_ENABLED`, with
+  `CHOREO_JUDGE_THRESHOLD`) instead rates each proposal's intrinsic
+  quality and makes that the score. Disabled by default, and fail-fast:
+  enabling it without a vLLM endpoint/model refuses to start rather than
+  silently degrading.
 
 **Persistence**:
 

--- a/crates/choreo-mcp/README.md
+++ b/crates/choreo-mcp/README.md
@@ -71,6 +71,11 @@ without an extra round trip.
 | `choreo_register_agent`           | `RegisterAgent`                   | control plane |
 | `choreo_unregister_agent`         | `UnregisterAgent`                 | control plane |
 | `choreo_process_trigger_event`    | `ProcessTriggerEvent`             | event ingest |
+| `choreo_run_council_decision`     | `RunCouncilDecision`              | sync; structured-output decision |
+| `choreo_register_contract`        | `RegisterContract`                | control plane |
+| `choreo_list_contracts`           | `ListContracts`                   | read |
+| `choreo_delete_contract`          | `DeleteContract`                  | idempotent control plane |
+| `choreo_run_ceremony`             | `RunCeremony`                     | sync; runs a YAML ceremony to a terminal state |
 | `choreo_get_status`               | `GetStatus`                       | observability |
 | `choreo_get_metrics`              | `GetMetrics`                      | observability |
 
@@ -133,7 +138,7 @@ cargo test -p choreo-mcp --locked
 A separate `tests/real_kernel.rs` boots the published
 `ghcr.io/underpass-ai/underpass-choreographer:latest` image via
 testcontainers, spawns this crate's binary against its mapped gRPC
-port, and exercises `initialize`, `tools/list` (asserts the full 16-
+port, and exercises `initialize`, `tools/list` (asserts the full 17-
 tool catalog), and `tools/call` on the four simplest read-only RPCs.
 The test is gated by the `container-tests` Cargo feature so the
 default workspace `cargo test --workspace` stays fast + network-free.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -3,7 +3,8 @@
 Snapshot date: 2026-04-25; honest re-audit 2026-05-11; PIR framing
 dropped 2026-05-12 (PIR is owned by a separate project — this backlog
 tracks Choreographer's own stack-readiness, not any one downstream
-consumer).
+consumer); ceremony engine + LLM-as-judge scorer landed 2026-06-06→09
+(Milestone F, below).
 
 Choreographer is agnostic and independent. References to PIR, KMP,
 Runtime, or other repositories in this backlog are historical context,
@@ -59,6 +60,34 @@ finish the release-candidate publication gates.
 Milestones A, B, C, D, and E are all complete as of 2026-05-14. The
 `choreo-mcp` Git-install UX and fixture/live smoke path are present;
 crates.io publication remains release-candidate work tracked in
+`docs/product-publication-checklist.md`.
+
+## Milestone F — ceremony engine + judge scoring (landed 2026-06-06 → 2026-06-09)
+
+Two stack capabilities beyond the original eight areas shipped to `main`:
+
+- **Ceremony engine.** `RunCeremony` (RPC #17 of `underpass.choreo.v1`)
+  executes a YAML-defined ceremony as a finite-state machine —
+  states/steps/transitions/guards/roles — with pluggable step handlers,
+  multi-agent panels, a run-time context brief injected into each agent's
+  task, and a Mermaid sequence diagram in the response. Catalog ceremonies
+  (daily standup, technical debate, sprint planning, speaker + Q&A) run
+  end-to-end in CI, driven by the `choreo-run-ceremony` operator tool
+  (`crates/choreo-e2e-runner`). Domain in
+  `crates/choreo-core/src/entities/ceremony_definition.rs` +
+  `ceremony_instance.rs`; use case in
+  `crates/choreo-app/src/usecases/run_ceremony_use_case.rs`.
+- **LLM-as-judge scoring.** Winner selection is a pluggable `ScoringPort`.
+  The default ranks by validator pass-fraction (which ties valid proposals
+  and picks an arbitrary winner); the opt-in `JudgeAwareScoring`
+  (`CHOREO_JUDGE_ENABLED`, `CHOREO_JUDGE_THRESHOLD`) is fed by an
+  `LlmJudgeValidator` that rates intrinsic quality and makes that the
+  score. Fail-fast: enabling it without a vLLM endpoint/model refuses to
+  start. Persisted durably in the `underpass-runtime` Helm overlay and
+  proven live against an in-cluster vLLM/Gemma endpoint.
+
+Remaining release-candidate work (crates.io publication, real external
+vLLM gates) is unchanged and tracked in
 `docs/product-publication-checklist.md`.
 
 The recommended remaining execution order is:

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,13 +18,19 @@ does not require KMP, PIR, or any downstream product to run:
   the sibling repo `underpass-runtime`; the choreographer talks to
   it through `RuntimeExecutor` (Epic 1).
 
+## Architecture — how it works and how it differs
+
+| Doc | Purpose |
+|---|---|
+| [`choreographer-architecture-and-differentiation.md`](./choreographer-architecture-and-differentiation.md) | Code-grounded walkthrough of the hexagonal core, council deliberation pipeline, the declarative ceremony engine, and the LLM-as-judge scorer — and where the design diverges from common agent-orchestration patterns. |
+
 ## Operations — how to run, install, and configure
 
 | Doc | Purpose |
 |---|---|
 | [`dev-loop.md`](./dev-loop.md) | Local iteration loop, including `CHOREO_NATS_ENABLED=false just run` for no-external-service startup. |
 | [`release.md`](./release.md) | Versioning + cut-a-release checklist. |
-| [`operations/compose-e2e.md`](./operations/compose-e2e.md) | Repo-owned compose E2E: stack shape, nine scenarios, stubs, Report schema, and provider-shaped paths. |
+| [`operations/compose-e2e.md`](./operations/compose-e2e.md) | Repo-owned compose E2E: stack shape, scenarios (incl. YAML ceremony execution), stubs, Report schema, and provider-shaped paths. |
 | [`operations/deploy-kubernetes.md`](./operations/deploy-kubernetes.md) | Helm install guide, including minimal standalone install, embedded NATS, TLS/mTLS, Postgres secret, provider env secrets, Runtime executor, and the Underpass Runtime profile. |
 | [`operations/mcp-stdio.md`](./operations/mcp-stdio.md) | **MCP entry point.** Installable stdio adapter exposing every gRPC RPC as an MCP tool, including fixture-mode quickstart. |
 | [`operations/mcp/codex.md`](./operations/mcp/codex.md) | Codex CLI specifics: `codex mcp add`, dev-from-checkout, mTLS, fixture. |

--- a/docs/product-publication-checklist.md
+++ b/docs/product-publication-checklist.md
@@ -368,6 +368,41 @@ de interacción (`revision_count`) en la respuesta.
 - [ ] Evitar claim "real-time deliberation streaming" para turnos
   internos.
 
+## Fase 7 - Validación Juez Y Motor De Ceremonias
+
+Cubre las dos capacidades que llegaron a `main` el 2026-06-06 → 2026-06-09:
+el motor de ceremonias declarativo (YAML FSM) y el scorer LLM-as-judge.
+
+- [x] Motor de ceremonias declarativo: `RunCeremony` ejecuta una FSM YAML
+  (states/steps/transitions/guards/roles) con handlers enchufables.
+  Referencia: `crates/choreo-app/src/usecases/run_ceremony_use_case.rs`,
+  `crates/choreo-core/src/entities/ceremony_definition.rs`.
+- [x] Paneles multiagente por paso (`num_agents`) y brief de contexto
+  inyectado en la tarea de cada agente. Referencia:
+  `crates/choreo-adapters/src/ceremony/deliberating_ceremony_step_handler.rs`.
+- [x] Ceremonias del catálogo ejecutan E2E (daily standup, debate técnico,
+  sprint planning, speaker + Q&A). Referencia:
+  `tests/e2e/ceremonies/*.yaml`, `docs/operations/compose-e2e.md`
+  (escenarios 11-16), bin `choreo-run-ceremony`.
+- [x] Diagrama Mermaid de la conversación en la respuesta de `RunCeremony`.
+- [x] Scorer LLM-as-judge: `JudgeAwareScoring` rankea por calidad
+  intrínseca en vez de fracción de validadores que pasan. Referencia:
+  `crates/choreo-adapters/src/scoring.rs`,
+  `crates/choreo-adapters/src/agents/judge.rs`.
+- [x] Juez opt-in y fail-fast (`CHOREO_JUDGE_ENABLED`,
+  `CHOREO_JUDGE_THRESHOLD`): si se activa sin endpoint/modelo vLLM, no
+  arranca. Referencia: `crates/choreo/src/compose.rs`,
+  `crates/choreo-adapters/src/agents/mod.rs`.
+- [x] Juez persistido en el overlay Helm de `underpass-runtime` con guard
+  de chart y marker de CI. Referencia:
+  `charts/choreographer/values.underpass-runtime.yaml`,
+  `charts/choreographer/templates/deployment.yaml`,
+  `scripts/ci/helm-lint.sh`.
+- [x] Exponer `RunCeremony` como tool MCP `choreo_run_ceremony`.
+  Referencia: `crates/choreo-mcp/src/grpc/tools.rs`.
+- [ ] Validar el juez contra un vLLM real en un deploy de producto (modelo,
+  credenciales, presupuesto de latencia, network policy).
+
 ## Definición De Usable
 
 - [ ] Se puede instalar localmente.

--- a/docs/product-usability-publication-plan.md
+++ b/docs/product-usability-publication-plan.md
@@ -38,7 +38,11 @@ ejecutar sin leer el código fuente.
 ### Se Puede Prometer
 
 - Coordina councils de agentes especializados.
-- Expone la API gRPC completa `underpass.choreo.v1`.
+- Orquesta ceremonias multiagentes declarativas en YAML (daily standup,
+  debate técnico, sprint planning, speaker + Q&A) vía `RunCeremony`.
+- Rankea propuestas mediante un juez LLM opcional (`CHOREO_JUDGE_ENABLED`)
+  en vez de fracción de validadores; fail-fast sin endpoint vLLM.
+- Expone la API gRPC completa `underpass.choreo.v1` (17 RPCs).
 - Expone MCP stdio para agentes como Codex y Claude Desktop.
 - Acepta contexto externo mediante `ExternalContextBundle`.
 - Puede ejecutar winners mediante `RuntimeExecutor`.

--- a/docs/stack-gap-analysis.md
+++ b/docs/stack-gap-analysis.md
@@ -1,6 +1,7 @@
 # Stack Gap Analysis
 
-Snapshot date: 2026-05-18
+Snapshot date: 2026-05-18 (ceremony engine + LLM-as-judge scorer added
+2026-06-09)
 
 This document records the remaining gaps for Choreographer as an
 independent, domain-agnostic coordination product. The following repos
@@ -27,7 +28,8 @@ current implementation state of sibling repositories.
 - The gRPC service exposes and implements the full
   `underpass.choreo.v1` surface: the generic deliberation/orchestration
   RPCs, council and agent registry RPCs, trigger ingest, status/metrics,
-  `RunCouncilDecision`, and contract CRUD.
+  `RunCouncilDecision`, contract CRUD, and `RunCeremony` ceremony
+  execution.
 - Runtime execution is configurable: `CHOREO_EXECUTOR_KIND=noop|runtime`
   selects either `NoopExecutor` or the gRPC `RuntimeExecutor`.
 - The context boundary is caller-materialized and agnostic.
@@ -47,14 +49,24 @@ current implementation state of sibling repositories.
   replay semantics.
 - Server TLS/mTLS and Runtime client TLS are wired and covered by
   handshake-level integration tests.
-- The compose E2E runner covers nine scenarios: seeded council,
+- The compose E2E runner covers the core scenarios: seeded council,
   deliberation, missing-council delete, causal metadata over NATS,
   `Orchestrate -> RuntimeExecutor -> stub-runtime`, strict schema
   rejection, `ExternalContextBundle` round-trip, positive structured
   output through a stub OpenAI-compatible agent, and the same Report
-  contract through the vLLM adapter shape. The operator-facing map
-  lives in [`operations/compose-e2e.md`](./operations/compose-e2e.md).
-- The stdio MCP adapter exposes all 16 gRPC RPCs as `choreo_*` tools
+  contract through the vLLM adapter shape — plus YAML ceremony execution
+  (a council deliberation per step) and the catalog ceremonies (daily
+  standup, technical debate, sprint planning, speaker + Q&A). The
+  operator-facing map lives in
+  [`operations/compose-e2e.md`](./operations/compose-e2e.md).
+- Ceremony orchestration is wired: `RunCeremony` executes a YAML
+  finite-state machine (states/steps/transitions/guards/roles) with
+  pluggable handlers, multi-agent panels, context threading between
+  steps, and a Mermaid diagram in the response.
+- Winner scoring is a pluggable `ScoringPort`: uniform pass-fraction by
+  default, or an opt-in LLM-as-judge (`CHOREO_JUDGE_ENABLED`) that ranks
+  by intrinsic quality and fails fast without a vLLM endpoint/model.
+- The stdio MCP adapter exposes all 17 gRPC RPCs as `choreo_*` tools
   and has fixture + live gRPC backends.
 
 ## Remaining Gaps


### PR DESCRIPTION
Audit remediation, batch 1/3 (the 9 major findings — all staleness, 0 blockers).

The ceremony engine and the LLM-as-judge scorer shipped to main (2026-06-06 →
2026-06-09) but were missing from the "what runs today" surface. A grep for
`ceremon|judge` across CHANGELOG / backlog / stack-gap returned **zero** hits;
status docs still said **16** RPCs while the proto declares **17**
(`RunCeremony`).

## Fixes (findings 1–9)

- **README** — add `RunCeremony` to the implemented-RPC list (it claimed the
  list was exhaustive but omitted the shipped, tested RPC); add *Ceremony
  orchestration* + *Scoring* bullets; add the 3 missing workspace crates.
- **CHANGELOG** — Added entries for the judge, ceremony engine +
  brief-from-context, and Helm judge-persistence; drop the stale "nine
  scenarios".
- **docs/index.md** — new *Architecture* section linking the architecture
  article; note ceremony execution in compose-e2e.
- **docs/backlog.md** — Milestone F (ceremony engine + judge) + refreshed
  snapshot.
- **docs/stack-gap-analysis.md** — ceremonies + judge in *What Is Wired
  Today*; "all 16 gRPC RPCs" → **17**.
- **docs/product-publication-checklist.md** — new *Fase 7* gates.
- **docs/product-usability-publication-plan.md** — judge + ceremonies in *Se
  Puede Prometer*.
- **crates/choreo-mcp/README.md** — the 5 missing tool rows (now **17**) +
  fix the "16-tool catalog" reference.

All numbers verified against the code (17 RPCs in `choreo.proto`, 17 tools in
`tool_catalog()`); every internal link resolves. Batches 2 (gated test +
AsyncAPI) and 3 (ops accuracy + cleanup) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)