### PR TITLE
fix(contract,test): DeliberationCompleted field names + gated tool-count assertion

### DIFF
--- a/crates/choreo-mcp/tests/real_kernel.rs
+++ b/crates/choreo-mcp/tests/real_kernel.rs
@@ -4,7 +4,7 @@
 //! spawns the locally-built `choreo-mcp` binary in gRPC mode pointing
 //! at the container's mapped port, and exercises the JSON-RPC surface:
 //!
-//!   1. `tools/list` — expect the full 16-tool catalog.
+//!   1. `tools/list` — expect the full 17-tool catalog.
 //!   2. `tools/call` — invoke the 4 simplest read-only tools and
 //!      assert the response is a well-formed JSON-RPC envelope with
 //!      a `result` object.
@@ -196,8 +196,8 @@ async fn mcp_lists_full_tool_catalog_and_calls_read_endpoints() {
         .unwrap_or_else(|| panic!("tools/list missing /result/tools array: {list:?}"));
     assert_eq!(
         tools.len(),
-        16,
-        "expected 16 tools, got {}: {:?}",
+        17,
+        "expected 17 tools, got {}: {:?}",
         tools.len(),
         tools.iter().map(|t| t.get("name")).collect::<Vec<_>>()
     );

--- a/specs/asyncapi/choreographer.asyncapi.yaml
+++ b/specs/asyncapi/choreographer.asyncapi.yaml
@@ -190,14 +190,14 @@ components:
       allOf:
         - $ref: '#/components/schemas/EventEnvelope'
         - type: object
-          required: [task_id, specialty, winner_proposal_id, duration_ms]
+          required: [task_id, specialty, winner_proposal_id, duration]
           properties:
             task_id: { type: string }
             specialty: { type: string }
             winner_proposal_id: { type: string }
-            duration_ms: { type: integer, minimum: 0 }
+            duration: { type: integer, minimum: 0 }
             num_candidates: { type: integer, minimum: 0 }
-            score: { type: number }
+            winner_score: { type: number }
 
     TaskDispatched:
       allOf:


### PR DESCRIPTION
Audit remediation, batch 2/3 — the code/spec drifts (the rest of the audit is doc-only).

## AsyncAPI `DeliberationCompleted`
The schema declared `score` and `duration_ms`, but the published event
serializes **`winner_score`** and **`duration`** (`DurationMs` is
`#[serde(transparent)]`, the field has no `#[serde(rename)]`). The spec
describes the wire, so it is corrected to match. The wire never emitted the
old names, so no real consumer could have depended on them. `asyncapi
validate` passes with 0 errors.

_(The audit flagged `score`; `duration_ms` is a sibling mismatch found while
verifying the fix.)_

## Gated MCP tool-count assertion
`crates/choreo-mcp/tests/real_kernel.rs` (gated by `container-tests`)
asserted **16** tools, but `tool_catalog()` builds **17** (one per RPC; the
proto declares 17 incl. `RunCeremony`). The default-feature unit test in
`src/server.rs` already asserts 17 — this one was stale and would fail under
the gate. Bumped the assertion + the module-doc comment to 17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)