### PR TITLE
fix(security): validate provider endpoint scheme (gap H1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "url",
  "uuid",
  "wiremock",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 
+# net
+url = "2.5"
+
 # time / ids
 time = { version = "0.3", features = ["serde", "serde-human-readable", "macros", "formatting", "parsing"] }
 uuid = { version = "1.10", features = ["v4", "serde"] }

--- a/crates/choreo-adapters/Cargo.toml
+++ b/crates/choreo-adapters/Cargo.toml
@@ -44,7 +44,7 @@ agent-anthropic = ["_http"]
 agent-openai = ["_http"]
 
 # Internal helper feature: shared HTTP client wiring for any provider adapter.
-_http = ["dep:reqwest"]
+_http = ["dep:reqwest", "dep:url"]
 
 [dependencies]
 choreo-core = { workspace = true }
@@ -70,6 +70,7 @@ jsonschema = { workspace = true }
 prost-types = { workspace = true, optional = true }
 async-nats = { workspace = true, optional = true }
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false, optional = true }
+url = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }
 opentelemetry = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }

--- a/crates/choreo-adapters/src/agents/anthropic.rs
+++ b/crates/choreo-adapters/src/agents/anthropic.rs
@@ -103,13 +103,8 @@ impl AnthropicConfig {
     }
 
     pub fn with_endpoint(mut self, endpoint: impl Into<String>) -> Result<Self, DomainError> {
-        let value = endpoint.into().trim().to_owned();
-        if value.is_empty() {
-            return Err(DomainError::EmptyField {
-                field: "anthropic.endpoint",
-            });
-        }
-        self.endpoint = value;
+        self.endpoint =
+            super::endpoint::validate_provider_endpoint("anthropic.endpoint", endpoint)?;
         Ok(self)
     }
 

--- a/crates/choreo-adapters/src/agents/endpoint.rs
+++ b/crates/choreo-adapters/src/agents/endpoint.rs
@@ -1,0 +1,107 @@
+//! Shared validation for provider HTTP endpoints.
+//!
+//! A provider `endpoint` can be supplied by an untrusted caller through a
+//! `RegisterAgent` descriptor attribute (`provider.endpoint`), and the
+//! adapter then POSTs proposal/task content — and, for keyed providers, a
+//! bearer credential — to it. Validating the endpoint at construction
+//! (fail-fast) rejects malformed and non-`http(s)` references with a clear
+//! [`DomainError`] instead of surfacing an opaque transport error at the
+//! first deliberation.
+//!
+//! Scheme allowlisting is defence-in-depth: it forbids `file:`, `gopher:`,
+//! `data:`, and similar schemes at registration time. It does **not** by
+//! itself stop exfiltration to an arbitrary `http(s)` host — restricting
+//! *who* may register an agent (authorization) and an operator host
+//! allowlist are the complementary layers tracked separately.
+
+use choreo_core::error::DomainError;
+use url::Url;
+
+/// Validate and normalise a provider endpoint.
+///
+/// Returns the trimmed endpoint on success. Errors when it is empty, not a
+/// valid absolute URL, or carries a scheme other than `http`/`https`.
+pub(crate) fn validate_provider_endpoint(
+    field: &'static str,
+    raw: impl Into<String>,
+) -> Result<String, DomainError> {
+    let value = raw.into().trim().to_owned();
+    if value.is_empty() {
+        return Err(DomainError::EmptyField { field });
+    }
+    let url = Url::parse(&value).map_err(|_| DomainError::InvariantViolated {
+        reason: "provider endpoint must be a valid absolute URL",
+    })?;
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err(DomainError::InvariantViolated {
+            reason: "provider endpoint scheme must be http or https",
+        });
+    }
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_https_and_http() {
+        assert_eq!(
+            validate_provider_endpoint("t", "https://api.example.com/v1").unwrap(),
+            "https://api.example.com/v1"
+        );
+        assert_eq!(
+            validate_provider_endpoint("t", "http://gemma.svc:8000").unwrap(),
+            "http://gemma.svc:8000"
+        );
+    }
+
+    #[test]
+    fn trims_surrounding_whitespace() {
+        assert_eq!(
+            validate_provider_endpoint("t", "  https://x.test  ").unwrap(),
+            "https://x.test"
+        );
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(matches!(
+            validate_provider_endpoint("openai.endpoint", "   ").unwrap_err(),
+            DomainError::EmptyField {
+                field: "openai.endpoint"
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_non_http_schemes() {
+        for bad in [
+            "file:///etc/passwd",
+            "gopher://evil.test/x",
+            "data:text/plain,hi",
+            "ftp://host/x",
+        ] {
+            assert!(
+                matches!(
+                    validate_provider_endpoint("t", bad).unwrap_err(),
+                    DomainError::InvariantViolated { .. }
+                ),
+                "expected {bad} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_relative_or_garbage() {
+        for bad in ["example.com:8000", "not a url", "/v1/chat"] {
+            assert!(
+                matches!(
+                    validate_provider_endpoint("t", bad).unwrap_err(),
+                    DomainError::InvariantViolated { .. }
+                ),
+                "expected {bad} to be rejected"
+            );
+        }
+    }
+}

--- a/crates/choreo-adapters/src/agents/judge.rs
+++ b/crates/choreo-adapters/src/agents/judge.rs
@@ -79,12 +79,7 @@ impl LlmJudgeValidator {
         model: impl Into<String>,
         threshold: f64,
     ) -> Result<Self, DomainError> {
-        let endpoint = endpoint.into().trim().to_owned();
-        if endpoint.is_empty() {
-            return Err(DomainError::EmptyField {
-                field: "judge.endpoint",
-            });
-        }
+        let endpoint = super::endpoint::validate_provider_endpoint("judge.endpoint", endpoint)?;
         let model = model.into().trim().to_owned();
         if model.is_empty() {
             return Err(DomainError::EmptyField {

--- a/crates/choreo-adapters/src/agents/mod.rs
+++ b/crates/choreo-adapters/src/agents/mod.rs
@@ -27,6 +27,11 @@ mod prompts;
 #[cfg(any(feature = "agent-openai", feature = "agent-vllm"))]
 mod openai_compat;
 
+// Shared provider-endpoint validation (scheme allowlist, fail-fast).
+// Available whenever any HTTP provider adapter is compiled in.
+#[cfg(feature = "_http")]
+mod endpoint;
+
 #[cfg(any(feature = "agent-openai", feature = "agent-vllm"))]
 pub mod judge;
 

--- a/crates/choreo-adapters/src/agents/openai.rs
+++ b/crates/choreo-adapters/src/agents/openai.rs
@@ -108,13 +108,7 @@ impl OpenAiConfig {
     }
 
     pub fn with_endpoint(mut self, endpoint: impl Into<String>) -> Result<Self, DomainError> {
-        let value = endpoint.into().trim().to_owned();
-        if value.is_empty() {
-            return Err(DomainError::EmptyField {
-                field: "openai.endpoint",
-            });
-        }
-        self.endpoint = value;
+        self.endpoint = super::endpoint::validate_provider_endpoint("openai.endpoint", endpoint)?;
         Ok(self)
     }
 

--- a/crates/choreo-adapters/src/agents/vllm.rs
+++ b/crates/choreo-adapters/src/agents/vllm.rs
@@ -170,13 +170,7 @@ impl VllmConfig {
     }
 
     pub fn with_endpoint(mut self, endpoint: impl Into<String>) -> Result<Self, DomainError> {
-        let value = endpoint.into().trim().to_owned();
-        if value.is_empty() {
-            return Err(DomainError::EmptyField {
-                field: "vllm.endpoint",
-            });
-        }
-        self.endpoint = value;
+        self.endpoint = super::endpoint::validate_provider_endpoint("vllm.endpoint", endpoint)?;
         Ok(self)
     }
 


### PR DESCRIPTION
Gap-analysis remediation — closes the only **High** finding (H1: SSRF / credential-exfiltration surface via an unvalidated provider `endpoint`).

A `RegisterAgent` descriptor attribute (`provider.endpoint`) flows unvalidated into the outbound HTTP client, which POSTs proposal/task content + a bearer credential to it. The four provider constructors checked only `is_empty()`.

**Fix:** a shared, pure `validate_provider_endpoint` (fail-fast) parses the endpoint as an absolute URL and rejects any scheme outside `{http, https}`, wired into openai/anthropic/vllm `with_endpoint` + the judge constructor. 5 unit tests; validated under the 1.90 toolchain with all provider features + `-D warnings`.

Scheme allowlisting is defence-in-depth; full closure (host allowlist + *who* may register an agent) pairs with the authz work (gap M6), which needs a design decision and ships separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)