### PR TITLE
fix(robustness): bound CreateCouncil num_agents + Runtime gRPC timeouts (M2, M3)

### DIFF
--- a/crates/choreo-adapters/src/grpc/service.rs
+++ b/crates/choreo-adapters/src/grpc/service.rs
@@ -355,10 +355,12 @@ impl ChoreographerService for ChoreographerGrpcService {
     ) -> GrpcResult<pb::CreateCouncilResponse> {
         link_span_to_metadata(&request);
         let req = request.into_inner();
-        let n = usize::try_from(req.num_agents).unwrap_or(0);
-        if n == 0 {
-            return Err(Status::invalid_argument("num_agents must be > 0"));
-        }
+        // Bound the council size through the domain value object: rejects
+        // zero and caps at MAX_NUM_AGENTS, so a hostile `num_agents` can't
+        // request a multi-billion-id allocation.
+        let num_agents = choreo_core::value_objects::NumAgents::new(req.num_agents)
+            .map_err(domain_error_to_status)?;
+        let n = num_agents.get() as usize;
         // The create-council RPC does not carry pre-minted agent ids;
         // we mint one id per slot and expect the caller to have
         // previously registered matching agents through the (future)

--- a/crates/choreo-adapters/src/runtime.rs
+++ b/crates/choreo-adapters/src/runtime.rs
@@ -7,6 +7,8 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
+use std::time::Duration;
+
 use async_trait::async_trait;
 use choreo_core::entities::Proposal;
 use choreo_core::error::DomainError;
@@ -18,6 +20,13 @@ use serde_json::{Map as JsonMap, Number as JsonNumber, Value as JsonValue};
 use thiserror::Error;
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Endpoint, Identity};
 use tracing::{debug, warn};
+
+/// Max time to establish the TCP+TLS connection to the runtime.
+const RUNTIME_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+/// Per-RPC deadline applied to every call on the runtime channel. Generous
+/// because governed tool invocations can legitimately run for minutes; it
+/// is a safety net against an indefinitely-stuck runtime, not a tight SLA.
+const RUNTIME_REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
 
 const DEFAULT_RUNTIME_GRPC_ENDPOINT: &str = "http://underpass-runtime:50053";
 const DEFAULT_RUNTIME_TENANT_ID: &str = "choreographer";
@@ -331,8 +340,14 @@ impl RuntimeExecutor {
         config: RuntimeExecutorConfig,
     ) -> Result<Self, RuntimeExecutorConnectError> {
         let endpoint_uri = endpoint_uri_for_tls_mode(&config.grpc_endpoint, config.tls.mode);
+        // Bound both connection establishment and every RPC on this channel
+        // so a stuck runtime can never hang a deliberation indefinitely.
+        // The request bound is generous (long-running governed tools are
+        // legitimate); the connect bound is tight.
         let mut endpoint = Endpoint::from_shared(endpoint_uri)
-            .map_err(|_| RuntimeExecutorConnectError::InvalidEndpoint)?;
+            .map_err(|_| RuntimeExecutorConnectError::InvalidEndpoint)?
+            .connect_timeout(RUNTIME_CONNECT_TIMEOUT)
+            .timeout(RUNTIME_REQUEST_TIMEOUT);
 
         if config.tls.mode != RuntimeClientTlsMode::Disabled {
             let tls_config = build_runtime_client_tls(&config.tls).await?;


### PR DESCRIPTION
Gap-analysis remediation — two medium robustness gaps.

**M2 — unbounded `num_agents` (allocation DoS).** `CreateCouncil` did `usize::try_from(req.num_agents).unwrap_or(0)` guarded only by `== 0`, then minted one `AgentId` per slot — up to ~4.29B. Now routed through the domain `NumAgents` VO (rejects 0, caps at 64), the same VO used on every other path.

**M3 — no timeout on Runtime gRPC calls.** The runtime channel set neither connect nor per-request timeout (the only outbound adapter without one); a stuck runtime hung deliberations forever. Added `connect_timeout` (10s) + a generous per-request `timeout` (300s) so long governed-tool runs still work but an indefinite hang can't.

Validated under the 1.90 toolchain with all provider features + `-D warnings`; tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)