### PR TITLE
feat(observability): judge health metrics — latency + score

### DIFF
--- a/crates/choreo-adapters/src/agents/judge.rs
+++ b/crates/choreo-adapters/src/agents/judge.rs
@@ -12,13 +12,14 @@
 
 use std::collections::BTreeMap;
 use std::fmt;
-use std::time::Duration;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use choreo_core::entities::{TaskConstraints, ValidatorReport};
 use choreo_core::error::DomainError;
-use choreo_core::ports::ValidatorPort;
-use choreo_core::value_objects::Attributes;
+use choreo_core::ports::{MetricsRecorderPort, ValidatorPort};
+use choreo_core::value_objects::{Attributes, DurationMs, Score};
 use reqwest::Client;
 use serde_json::{json, Value};
 use tracing::warn;
@@ -56,6 +57,7 @@ pub struct LlmJudgeValidator {
     max_tokens: u32,
     threshold: f64,
     http: Client,
+    metrics: Arc<dyn MetricsRecorderPort>,
 }
 
 impl fmt::Debug for LlmJudgeValidator {
@@ -78,6 +80,7 @@ impl LlmJudgeValidator {
         endpoint: impl Into<String>,
         model: impl Into<String>,
         threshold: f64,
+        metrics: Arc<dyn MetricsRecorderPort>,
     ) -> Result<Self, DomainError> {
         let endpoint = super::endpoint::validate_provider_endpoint("judge.endpoint", endpoint)?;
         let model = model.into().trim().to_owned();
@@ -101,6 +104,7 @@ impl LlmJudgeValidator {
             max_tokens: DEFAULT_MAX_TOKENS,
             threshold,
             http,
+            metrics,
         })
     }
 
@@ -119,7 +123,18 @@ impl LlmJudgeValidator {
         Ok(self)
     }
 
+    /// Time one rating call and record its latency, success or failure,
+    /// before propagating the result. Latency is the leading signal of
+    /// the judge approaching its timeout, so it is recorded on every path.
     async fn rate(&self, content: &str) -> Result<f64, DomainError> {
+        let started = Instant::now();
+        let outcome = self.rate_inner(content).await;
+        self.metrics
+            .observe_judge_latency(&self.model, elapsed_ms(started));
+        outcome
+    }
+
+    async fn rate_inner(&self, content: &str) -> Result<f64, DomainError> {
         let user = format!(
             "Rate the following proposal on a 0–100 integer scale (100 = excellent). Respond with \
              ONLY a JSON object: {{\"score\": <integer 0-100>, \"reason\": \"<one short sentence>\"}}. \
@@ -185,6 +200,9 @@ impl ValidatorPort for LlmJudgeValidator {
         _constraints: &TaskConstraints,
     ) -> Result<ValidatorReport, DomainError> {
         let score = self.rate(proposal_content).await?;
+        // `rate` already clamps to [0.0, 1.0], so this is always valid.
+        self.metrics
+            .observe_judge_score(&self.model, Score::new(score).unwrap_or(Score::MIN));
         let details = Attributes::new(BTreeMap::from([(
             JUDGE_SCORE_DETAIL_KEY.to_owned(),
             json!(score),
@@ -196,6 +214,11 @@ impl ValidatorPort for LlmJudgeValidator {
             details,
         )
     }
+}
+
+/// Whole-millisecond latency since `started`, as the domain duration type.
+fn elapsed_ms(started: Instant) -> DurationMs {
+    DurationMs::from_millis(started.elapsed().as_millis() as u64)
 }
 
 fn build_client(timeout: Duration) -> Result<Client, DomainError> {
@@ -237,9 +260,14 @@ fn parse_score(text: &str) -> Result<f64, DomainError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use choreo_core::ports::NoopMetricsRecorder;
     use serde_json::json;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn metrics() -> Arc<dyn MetricsRecorderPort> {
+        Arc::new(NoopMetricsRecorder)
+    }
 
     #[test]
     fn parse_score_handles_plain_json() {
@@ -270,7 +298,7 @@ mod tests {
     #[test]
     fn threshold_out_of_range_is_rejected() {
         assert!(matches!(
-            LlmJudgeValidator::new("http://x", "m", 1.5).unwrap_err(),
+            LlmJudgeValidator::new("http://x", "m", 1.5, metrics()).unwrap_err(),
             DomainError::OutOfRange {
                 field: "judge.threshold",
                 ..
@@ -279,7 +307,7 @@ mod tests {
     }
 
     fn judge(server: &MockServer) -> LlmJudgeValidator {
-        LlmJudgeValidator::new(server.uri(), "test-model", 0.5)
+        LlmJudgeValidator::new(server.uri(), "test-model", 0.5, metrics())
             .unwrap()
             .with_timeout(Duration::from_secs(5))
             .unwrap()

--- a/crates/choreo-adapters/src/agents/mod.rs
+++ b/crates/choreo-adapters/src/agents/mod.rs
@@ -52,7 +52,7 @@ pub use factory::{
 use std::sync::Arc;
 
 use choreo_core::error::DomainError;
-use choreo_core::ports::ValidatorPort;
+use choreo_core::ports::{MetricsRecorderPort, ValidatorPort};
 
 /// Build the LLM-judge validator from the environment, when enabled.
 ///
@@ -68,16 +68,19 @@ use choreo_core::ports::ValidatorPort;
 /// not compiled in). Returns `Err` — failing fast — when the judge is
 /// explicitly enabled but its endpoint/model/threshold are missing or
 /// invalid.
-pub fn judge_from_env() -> Result<Option<Arc<dyn ValidatorPort>>, DomainError> {
+pub fn judge_from_env(
+    metrics: Arc<dyn MetricsRecorderPort>,
+) -> Result<Option<Arc<dyn ValidatorPort>>, DomainError> {
     if !judge_enabled() {
         return Ok(None);
     }
     #[cfg(any(feature = "agent-openai", feature = "agent-vllm"))]
     {
-        build_env_judge().map(Some)
+        build_env_judge(metrics).map(Some)
     }
     #[cfg(not(any(feature = "agent-openai", feature = "agent-vllm")))]
     {
+        let _ = metrics;
         tracing::warn!(
             "CHOREO_JUDGE_ENABLED is set but this build has no Chat-Completions \
              provider feature; scoring stays uniform"
@@ -101,7 +104,9 @@ fn judge_enabled() -> bool {
 /// Construct the judge from the vLLM endpoint/model env, failing fast on a
 /// missing or invalid setting.
 #[cfg(any(feature = "agent-openai", feature = "agent-vllm"))]
-fn build_env_judge() -> Result<Arc<dyn ValidatorPort>, DomainError> {
+fn build_env_judge(
+    metrics: Arc<dyn MetricsRecorderPort>,
+) -> Result<Arc<dyn ValidatorPort>, DomainError> {
     let endpoint = std::env::var("CHOREO_VLLM_ENDPOINT").map_err(|_| DomainError::EmptyField {
         field: "judge.endpoint",
     })?;
@@ -118,6 +123,6 @@ fn build_env_judge() -> Result<Arc<dyn ValidatorPort>, DomainError> {
                     field: "judge.threshold",
                 })
         })?;
-    let judge = judge::LlmJudgeValidator::new(endpoint, model, threshold)?;
+    let judge = judge::LlmJudgeValidator::new(endpoint, model, threshold, metrics)?;
     Ok(Arc::new(judge))
 }

--- a/crates/choreo-adapters/src/metrics/prometheus_recorder.rs
+++ b/crates/choreo-adapters/src/metrics/prometheus_recorder.rs
@@ -27,11 +27,18 @@ const DURATION_BUCKETS_SECONDS: &[f64] = &[
 /// Score buckets across the closed `[0.0, 1.0]` range.
 const SCORE_BUCKETS: &[f64] = &[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0];
 
+/// Latency buckets (seconds) for judge rating calls, weighted toward the
+/// upper end so a p99 creeping toward the judge's 60s timeout is visible.
+const JUDGE_LATENCY_BUCKETS_SECONDS: &[f64] =
+    &[0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 30.0, 45.0, 55.0, 60.0];
+
 pub struct PrometheusMetricsRecorder {
     registry: Registry,
     deliberation_duration_seconds: HistogramVec,
     deliberation_winner_score: HistogramVec,
     deliberation_completed_total: IntCounterVec,
+    judge_latency_seconds: HistogramVec,
+    judge_score: HistogramVec,
 }
 
 impl PrometheusMetricsRecorder {
@@ -74,6 +81,26 @@ impl PrometheusMetricsRecorder {
         )
         .map_err(|err| metrics_error(&err))?;
 
+        let judge_latency_seconds = HistogramVec::new(
+            HistogramOpts::new(
+                "choreo_judge_latency_seconds",
+                "Latency of a single LLM-judge rating call, success or failure.",
+            )
+            .buckets(JUDGE_LATENCY_BUCKETS_SECONDS.to_vec()),
+            &["model"],
+        )
+        .map_err(|err| metrics_error(&err))?;
+
+        let judge_score = HistogramVec::new(
+            HistogramOpts::new(
+                "choreo_judge_score",
+                "Distribution of the LLM judge's 0.0-1.0 verdicts.",
+            )
+            .buckets(SCORE_BUCKETS.to_vec()),
+            &["model"],
+        )
+        .map_err(|err| metrics_error(&err))?;
+
         registry
             .register(Box::new(deliberation_duration_seconds.clone()))
             .map_err(|err| metrics_error(&err))?;
@@ -83,12 +110,20 @@ impl PrometheusMetricsRecorder {
         registry
             .register(Box::new(deliberation_completed_total.clone()))
             .map_err(|err| metrics_error(&err))?;
+        registry
+            .register(Box::new(judge_latency_seconds.clone()))
+            .map_err(|err| metrics_error(&err))?;
+        registry
+            .register(Box::new(judge_score.clone()))
+            .map_err(|err| metrics_error(&err))?;
 
         Ok(Self {
             registry,
             deliberation_duration_seconds,
             deliberation_winner_score,
             deliberation_completed_total,
+            judge_latency_seconds,
+            judge_score,
         })
     }
 
@@ -135,6 +170,18 @@ impl MetricsRecorderPort for PrometheusMetricsRecorder {
             .with_label_values(&[specialty.as_str()])
             .observe(score.get());
     }
+
+    fn observe_judge_latency(&self, model: &str, duration: DurationMs) {
+        self.judge_latency_seconds
+            .with_label_values(&[model])
+            .observe(duration.get() as f64 / 1000.0);
+    }
+
+    fn observe_judge_score(&self, model: &str, score: Score) {
+        self.judge_score
+            .with_label_values(&[model])
+            .observe(score.get());
+    }
 }
 
 /// Map a Prometheus setup failure to a fail-fast wiring error.
@@ -161,11 +208,27 @@ mod tests {
         recorder.observe_deliberation_duration(&specialty(), DurationMs::from_millis(1_000));
         recorder.observe_winner_score(&specialty(), Score::new(0.5).unwrap());
         recorder.record_deliberation_outcome(&specialty(), DeliberationOutcome::Success);
+        recorder.observe_judge_latency("gemma", DurationMs::from_millis(1_000));
+        recorder.observe_judge_score("gemma", Score::new(0.5).unwrap());
 
         let text = recorder.render();
         assert!(text.contains("# TYPE choreo_deliberation_duration_seconds histogram"));
         assert!(text.contains("# TYPE choreo_deliberation_winner_score histogram"));
         assert!(text.contains("# TYPE choreo_deliberation_completed_total counter"));
+        assert!(text.contains("# TYPE choreo_judge_latency_seconds histogram"));
+        assert!(text.contains("# TYPE choreo_judge_score histogram"));
+    }
+
+    #[test]
+    fn observes_judge_latency_in_seconds_and_score_by_model() {
+        let recorder = PrometheusMetricsRecorder::new().unwrap();
+        recorder.observe_judge_latency("gemma", DurationMs::from_millis(45_000));
+        recorder.observe_judge_score("gemma", Score::new(0.9).unwrap());
+
+        let text = recorder.render();
+        assert!(text.contains("choreo_judge_latency_seconds_sum{model=\"gemma\"} 45"));
+        assert!(text.contains("choreo_judge_score_sum{model=\"gemma\"} 0.9"));
+        assert!(text.contains("choreo_judge_score_count{model=\"gemma\"} 1"));
     }
 
     #[test]

--- a/crates/choreo-app/src/usecases/deliberate.rs
+++ b/crates/choreo-app/src/usecases/deliberate.rs
@@ -810,6 +810,8 @@ mod tests {
                 .unwrap()
                 .push((specialty.as_str().to_owned(), score.get()));
         }
+        fn observe_judge_latency(&self, _model: &str, _duration: DurationMs) {}
+        fn observe_judge_score(&self, _model: &str, _score: Score) {}
     }
 
     // --- Fixture helpers --------------------------------------------------

--- a/crates/choreo-core/src/ports/metrics_recorder.rs
+++ b/crates/choreo-core/src/ports/metrics_recorder.rs
@@ -32,6 +32,16 @@ pub trait MetricsRecorderPort: Send + Sync {
     /// Observe the score of the winning proposal. Recorded only on the
     /// success path (a `NoValidProposal` outcome has no winner).
     fn observe_winner_score(&self, specialty: &Specialty, score: Score);
+
+    /// Observe the latency of a single LLM-judge rating call, whether it
+    /// succeeded or failed. A call that times out reports a latency near
+    /// the judge's deadline — the leading signal that the judge is
+    /// approaching its timeout cliff.
+    fn observe_judge_latency(&self, model: &str, duration: DurationMs);
+
+    /// Observe a judge's `[0.0, 1.0]` verdict for one proposal — the
+    /// basis for score calibration and threshold tuning.
+    fn observe_judge_score(&self, model: &str, score: Score);
 }
 
 /// A [`MetricsRecorderPort`] that discards every observation.
@@ -47,4 +57,6 @@ impl MetricsRecorderPort for NoopMetricsRecorder {
     fn observe_deliberation_duration(&self, _specialty: &Specialty, _duration: DurationMs) {}
     fn record_deliberation_outcome(&self, _specialty: &Specialty, _outcome: DeliberationOutcome) {}
     fn observe_winner_score(&self, _specialty: &Specialty, _score: Score) {}
+    fn observe_judge_latency(&self, _model: &str, _duration: DurationMs) {}
+    fn observe_judge_score(&self, _model: &str, _score: Score) {}
 }

--- a/crates/choreo/src/compose.rs
+++ b/crates/choreo/src/compose.rs
@@ -37,7 +37,8 @@ use choreo_core::ports::{
     AgentFactoryPort, AgentRegistryPort, AgentResolverPort, CeremonyContextStorePort,
     CeremonyDefinitionRepositoryPort, CeremonyInstanceRepositoryPort, CeremonyStepHandlerPort,
     ConfigurationPort, ContractRegistryPort, CouncilRegistryPort, DeliberationRepositoryPort,
-    ExecutorPort, MessagingPort, ScoringPort, ServiceConfig, StatisticsPort, ValidatorPort,
+    ExecutorPort, MessagingPort, MetricsRecorderPort, ScoringPort, ServiceConfig, StatisticsPort,
+    ValidatorPort,
 };
 use thiserror::Error;
 use tracing::info;
@@ -93,8 +94,9 @@ pub enum ComposeError {
 /// misconfigured.
 fn wire_scoring(
     validators: &mut Vec<Arc<dyn ValidatorPort>>,
+    metrics: Arc<dyn MetricsRecorderPort>,
 ) -> Result<Arc<dyn ScoringPort>, DomainError> {
-    match choreo_adapters::agents::judge_from_env()? {
+    match choreo_adapters::agents::judge_from_env(metrics)? {
         Some(judge) => {
             validators.push(judge);
             info!("scoring: LLM judge enabled; ranking by judge verdict");
@@ -140,7 +142,7 @@ pub async fn compose() -> Result<Application, ComposeError> {
     ];
     // Choose scoring, and when an LLM judge is configured append it to
     // the validator chain so its verdict drives the ranking.
-    let scoring: Arc<dyn ScoringPort> = wire_scoring(&mut validators)?;
+    let scoring: Arc<dyn ScoringPort> = wire_scoring(&mut validators, metrics_recorder.clone())?;
     let executor = wire_executor().await?;
     let dispatching_factory = DispatchingAgentFactory::from_env()?;
     let supported_agent_kinds = dispatching_factory.supported_kinds().join(",");


### PR DESCRIPTION
Second instrumentation slice (the judge half of the design's §6 step 3). Makes the most failure-prone and costly stage of a deliberation — the LLM judge — observable, building directly on the `MetricsRecorderPort` from #102.

## Metrics
`LlmJudgeValidator` gains a `MetricsRecorderPort` and records:

| Metric | Type | Labels | Why |
|---|---|---|---|
| `choreo_judge_latency_seconds` | histogram | `model` | Timed around every rating call, recorded on **success and failure**. Buckets are weighted toward the 60s timeout, so a p99 creeping toward the deadline (the latency cliff) is visible before deliberations start failing at the Validating gate. |
| `choreo_judge_score` | histogram | `model` | The distribution of 0.0–1.0 verdicts — score calibration and threshold tuning. A collapsed distribution means the judge has lost signal. |

## Wiring
The recorder is threaded through `judge_from_env` → `build_env_judge` and `wire_scoring` in the composition root. `model` is the only label (one value per deploy → low cardinality). 

No change to `scoring.rs`, no wire change, no app-layer coupling. **Judge discrimination** (the killer metric — it has a real coupling question: deliberate.rs would need to know which validator is the judge), **error classes**, and **token cost** (needs the `ChatResponse.usage` wire change) are deliberately deferred to their own slices.

## Validation
On **rust 1.90**: `cargo fmt --check` + `clippy --workspace --all-targets --all-features -D warnings` clean, full unit suite green (incl. the new recorder tests for judge latency/score rendering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)