### PR TITLE
feat(observability): classify provider-agent errors by kind

### DIFF
--- a/crates/choreo-adapters/src/agents/anthropic.rs
+++ b/crates/choreo-adapters/src/agents/anthropic.rs
@@ -19,18 +19,24 @@
 //! leaks the credential.
 
 use std::fmt;
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use choreo_core::entities::TaskConstraints;
 use choreo_core::error::DomainError;
-use choreo_core::ports::{AgentPort, Critique, DraftRequest, Revision};
-use choreo_core::value_objects::{AgentId, Specialty};
+use choreo_core::ports::{
+    AgentPort, Critique, DraftRequest, MetricsRecorderPort, NoopMetricsRecorder, Revision,
+};
+use choreo_core::value_objects::{AgentId, LlmErrorKind, Specialty};
 use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 
 use super::prompts;
+
+/// Provider label for this adapter's error metrics.
+const PROVIDER: &str = "anthropic";
 
 const ANTHROPIC_VERSION_HEADER: &str = "2023-06-01";
 const DEFAULT_ENDPOINT: &str = "https://api.anthropic.com";
@@ -148,6 +154,7 @@ pub struct AnthropicAgent {
     specialty: Specialty,
     config: AnthropicConfig,
     http: Client,
+    metrics: Arc<dyn MetricsRecorderPort>,
 }
 
 impl fmt::Debug for AnthropicAgent {
@@ -180,7 +187,17 @@ impl AnthropicAgent {
             specialty,
             config,
             http,
+            metrics: Arc::new(NoopMetricsRecorder),
         })
+    }
+
+    /// Attach a metrics recorder so provider failures are counted. The
+    /// composition root wires the real recorder; the default is a no-op,
+    /// so tests and bespoke uses need not supply one.
+    #[must_use]
+    pub fn with_metrics(mut self, metrics: Arc<dyn MetricsRecorderPort>) -> Self {
+        self.metrics = metrics;
+        self
     }
 
     async fn complete(
@@ -213,6 +230,12 @@ impl AnthropicAgent {
             .send()
             .await
             .map_err(|err| {
+                let kind = if err.is_timeout() {
+                    LlmErrorKind::Timeout
+                } else {
+                    LlmErrorKind::Transport
+                };
+                self.metrics.record_provider_error(PROVIDER, kind);
                 warn!(
                     op,
                     agent_id = self.id.as_str(),
@@ -226,6 +249,8 @@ impl AnthropicAgent {
 
         let status = response.status();
         if !status.is_success() {
+            self.metrics
+                .record_provider_error(PROVIDER, LlmErrorKind::from_status(status.as_u16()));
             let body_text = response.text().await.unwrap_or_default();
             warn!(
                 op,
@@ -238,6 +263,8 @@ impl AnthropicAgent {
         }
 
         let parsed: MessagesResponse = response.json().await.map_err(|err| {
+            self.metrics
+                .record_provider_error(PROVIDER, LlmErrorKind::MalformedBody);
             warn!(
                 op,
                 agent_id = self.id.as_str(),
@@ -250,6 +277,8 @@ impl AnthropicAgent {
         })?;
 
         extract_text(parsed).inspect_err(|_| {
+            self.metrics
+                .record_provider_error(PROVIDER, LlmErrorKind::EmptyContent);
             warn!(
                 op,
                 agent_id = self.id.as_str(),

--- a/crates/choreo-adapters/src/agents/factory.rs
+++ b/crates/choreo-adapters/src/agents/factory.rs
@@ -27,6 +27,7 @@
 //! - `provider.max_tokens` (number, ≤ `u32::MAX`)
 //! - `provider.timeout_secs` (number, ≤ `u32::MAX`; vLLM only)
 
+use std::fmt;
 use std::sync::Arc;
 #[cfg(any(
     feature = "agent-anthropic",
@@ -37,7 +38,9 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use choreo_core::error::DomainError;
-use choreo_core::ports::{AgentDescriptor, AgentFactoryPort, AgentPort};
+use choreo_core::ports::{
+    AgentDescriptor, AgentFactoryPort, AgentPort, MetricsRecorderPort, NoopMetricsRecorder,
+};
 #[cfg(any(
     feature = "agent-anthropic",
     feature = "agent-openai",
@@ -86,7 +89,7 @@ const ATTR_TIMEOUT_SECS: &str = "provider.timeout_secs";
 ///
 /// Built via [`DispatchingAgentFactory::from_env`] in production; the
 /// `with_*` builders are kept for tests and bespoke composition.
-#[derive(Debug, Default, Clone)]
+#[derive(Clone)]
 pub struct DispatchingAgentFactory {
     #[cfg(feature = "agent-anthropic")]
     anthropic: Option<AnthropicConfig>,
@@ -94,12 +97,46 @@ pub struct DispatchingAgentFactory {
     openai: Option<OpenAiConfig>,
     #[cfg(feature = "agent-vllm")]
     vllm: Option<VllmConfig>,
+    /// Recorder forwarded to every agent this factory materializes, so
+    /// provider failures are counted. Defaults to a no-op.
+    metrics: Arc<dyn MetricsRecorderPort>,
+}
+
+impl Default for DispatchingAgentFactory {
+    fn default() -> Self {
+        Self {
+            #[cfg(feature = "agent-anthropic")]
+            anthropic: None,
+            #[cfg(feature = "agent-openai")]
+            openai: None,
+            #[cfg(feature = "agent-vllm")]
+            vllm: None,
+            metrics: Arc::new(NoopMetricsRecorder),
+        }
+    }
+}
+
+impl fmt::Debug for DispatchingAgentFactory {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DispatchingAgentFactory")
+            .field("supported_kinds", &self.supported_kinds())
+            .finish()
+    }
 }
 
 impl DispatchingAgentFactory {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Attach a metrics recorder, forwarded to every agent this factory
+    /// materializes. The composition root wires the real recorder; the
+    /// default no-op keeps tests and minimal builds free of one.
+    #[must_use]
+    pub fn with_metrics(mut self, metrics: Arc<dyn MetricsRecorderPort>) -> Self {
+        self.metrics = metrics;
+        self
     }
 
     /// Read provider configurations from `CHOREO_*` env vars.
@@ -223,11 +260,10 @@ impl AgentFactoryPort for DispatchingAgentFactory {
                         reason: "agent factory: anthropic kind requested but not configured",
                     })?;
                 let config = apply_anthropic_attributes(base.clone(), &descriptor.attributes)?;
-                Ok(Arc::new(AnthropicAgent::new(
-                    descriptor.id,
-                    descriptor.specialty,
-                    config,
-                )?))
+                Ok(Arc::new(
+                    AnthropicAgent::new(descriptor.id, descriptor.specialty, config)?
+                        .with_metrics(self.metrics.clone()),
+                ))
             }
 
             #[cfg(feature = "agent-openai")]
@@ -236,11 +272,10 @@ impl AgentFactoryPort for DispatchingAgentFactory {
                     reason: "agent factory: openai kind requested but not configured",
                 })?;
                 let config = apply_openai_attributes(base.clone(), &descriptor.attributes)?;
-                Ok(Arc::new(OpenAiAgent::new(
-                    descriptor.id,
-                    descriptor.specialty,
-                    config,
-                )?))
+                Ok(Arc::new(
+                    OpenAiAgent::new(descriptor.id, descriptor.specialty, config)?
+                        .with_metrics(self.metrics.clone()),
+                ))
             }
 
             #[cfg(feature = "agent-vllm")]
@@ -249,11 +284,10 @@ impl AgentFactoryPort for DispatchingAgentFactory {
                     reason: "agent factory: vllm kind requested but not configured",
                 })?;
                 let config = apply_vllm_attributes(base.clone(), &descriptor.attributes)?;
-                Ok(Arc::new(VllmAgent::new(
-                    descriptor.id,
-                    descriptor.specialty,
-                    config,
-                )?))
+                Ok(Arc::new(
+                    VllmAgent::new(descriptor.id, descriptor.specialty, config)?
+                        .with_metrics(self.metrics.clone()),
+                ))
             }
 
             _ => Err(DomainError::InvariantViolated {

--- a/crates/choreo-adapters/src/agents/judge.rs
+++ b/crates/choreo-adapters/src/agents/judge.rs
@@ -320,6 +320,7 @@ mod tests {
         fn record_judge_error(&self, _model: &str, kind: LlmErrorKind) {
             self.errors.lock().unwrap().push(kind.as_label());
         }
+        fn record_provider_error(&self, _provider: &str, _kind: LlmErrorKind) {}
     }
 
     fn judge_with(server: &MockServer, metrics: Arc<dyn MetricsRecorderPort>) -> LlmJudgeValidator {

--- a/crates/choreo-adapters/src/agents/openai.rs
+++ b/crates/choreo-adapters/src/agents/openai.rs
@@ -18,18 +18,24 @@
 //! never leaks the credential.
 
 use std::fmt;
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use choreo_core::entities::TaskConstraints;
 use choreo_core::error::DomainError;
-use choreo_core::ports::{AgentPort, Critique, DraftRequest, Revision};
-use choreo_core::value_objects::{AgentId, Specialty};
+use choreo_core::ports::{
+    AgentPort, Critique, DraftRequest, MetricsRecorderPort, NoopMetricsRecorder, Revision,
+};
+use choreo_core::value_objects::{AgentId, LlmErrorKind, Specialty};
 use reqwest::Client;
 use tracing::{debug, warn};
 
 use super::openai_compat::{self as wire, ChatMessage, ChatRequest, ChatResponse, ErrorStrings};
 use super::prompts;
+
+/// Provider label for this adapter's error metrics.
+const PROVIDER: &str = "openai";
 
 /// Static error reasons for the OpenAI provider.
 const OPENAI_ERRORS: ErrorStrings = ErrorStrings {
@@ -151,6 +157,7 @@ pub struct OpenAiAgent {
     specialty: Specialty,
     config: OpenAiConfig,
     http: Client,
+    metrics: Arc<dyn MetricsRecorderPort>,
 }
 
 impl fmt::Debug for OpenAiAgent {
@@ -183,7 +190,17 @@ impl OpenAiAgent {
             specialty,
             config,
             http,
+            metrics: Arc::new(NoopMetricsRecorder),
         })
+    }
+
+    /// Attach a metrics recorder so provider failures are counted. The
+    /// composition root wires the real recorder; the default is a no-op,
+    /// so tests and bespoke uses need not supply one.
+    #[must_use]
+    pub fn with_metrics(mut self, metrics: Arc<dyn MetricsRecorderPort>) -> Self {
+        self.metrics = metrics;
+        self
     }
 
     async fn complete(
@@ -219,6 +236,12 @@ impl OpenAiAgent {
             .send()
             .await
             .map_err(|err| {
+                let kind = if err.is_timeout() {
+                    LlmErrorKind::Timeout
+                } else {
+                    LlmErrorKind::Transport
+                };
+                self.metrics.record_provider_error(PROVIDER, kind);
                 warn!(
                     op,
                     agent_id = self.id.as_str(),
@@ -232,6 +255,8 @@ impl OpenAiAgent {
 
         let status = response.status();
         if !status.is_success() {
+            self.metrics
+                .record_provider_error(PROVIDER, LlmErrorKind::from_status(status.as_u16()));
             let body_text = response.text().await.unwrap_or_default();
             warn!(
                 op,
@@ -244,6 +269,8 @@ impl OpenAiAgent {
         }
 
         let parsed: ChatResponse = response.json().await.map_err(|err| {
+            self.metrics
+                .record_provider_error(PROVIDER, LlmErrorKind::MalformedBody);
             warn!(
                 op,
                 agent_id = self.id.as_str(),
@@ -256,6 +283,8 @@ impl OpenAiAgent {
         })?;
 
         wire::extract_text(parsed, &OPENAI_ERRORS).inspect_err(|_| {
+            self.metrics
+                .record_provider_error(PROVIDER, LlmErrorKind::EmptyContent);
             warn!(
                 op,
                 agent_id = self.id.as_str(),

--- a/crates/choreo-adapters/src/agents/vllm.rs
+++ b/crates/choreo-adapters/src/agents/vllm.rs
@@ -21,18 +21,24 @@
 //! redaction so it cannot slip through logs.
 
 use std::fmt;
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use choreo_core::entities::TaskConstraints;
 use choreo_core::error::DomainError;
-use choreo_core::ports::{AgentPort, Critique, DraftRequest, Revision};
-use choreo_core::value_objects::{AgentId, Specialty};
+use choreo_core::ports::{
+    AgentPort, Critique, DraftRequest, MetricsRecorderPort, NoopMetricsRecorder, Revision,
+};
+use choreo_core::value_objects::{AgentId, LlmErrorKind, Specialty};
 use reqwest::{Client, RequestBuilder};
 use tracing::{debug, warn};
 
 use super::openai_compat::{self as wire, ChatMessage, ChatRequest, ChatResponse, ErrorStrings};
 use super::prompts;
+
+/// Provider label for this adapter's error metrics.
+const PROVIDER: &str = "vllm";
 
 /// Static error reasons for the vLLM provider.
 const VLLM_ERRORS: ErrorStrings = ErrorStrings {
@@ -227,6 +233,7 @@ pub struct VllmAgent {
     specialty: Specialty,
     config: VllmConfig,
     http: Client,
+    metrics: Arc<dyn MetricsRecorderPort>,
 }
 
 impl fmt::Debug for VllmAgent {
@@ -262,7 +269,17 @@ impl VllmAgent {
             specialty,
             config,
             http,
+            metrics: Arc::new(NoopMetricsRecorder),
         })
+    }
+
+    /// Attach a metrics recorder so provider failures are counted. The
+    /// composition root wires the real recorder; the default is a no-op,
+    /// so tests and bespoke uses need not supply one.
+    #[must_use]
+    pub fn with_metrics(mut self, metrics: Arc<dyn MetricsRecorderPort>) -> Self {
+        self.metrics = metrics;
+        self
     }
 
     async fn complete(
@@ -297,6 +314,12 @@ impl VllmAgent {
         };
 
         let response = request.send().await.map_err(|err| {
+            let kind = if err.is_timeout() {
+                LlmErrorKind::Timeout
+            } else {
+                LlmErrorKind::Transport
+            };
+            self.metrics.record_provider_error(PROVIDER, kind);
             warn!(
                 op,
                 agent_id = self.id.as_str(),
@@ -310,6 +333,8 @@ impl VllmAgent {
 
         let status = response.status();
         if !status.is_success() {
+            self.metrics
+                .record_provider_error(PROVIDER, LlmErrorKind::from_status(status.as_u16()));
             let body_text = response.text().await.unwrap_or_default();
             warn!(
                 op,
@@ -322,6 +347,8 @@ impl VllmAgent {
         }
 
         let parsed: ChatResponse = response.json().await.map_err(|err| {
+            self.metrics
+                .record_provider_error(PROVIDER, LlmErrorKind::MalformedBody);
             warn!(
                 op,
                 agent_id = self.id.as_str(),
@@ -334,6 +361,8 @@ impl VllmAgent {
         })?;
 
         wire::extract_text(parsed, &VLLM_ERRORS).inspect_err(|_| {
+            self.metrics
+                .record_provider_error(PROVIDER, LlmErrorKind::EmptyContent);
             warn!(op, agent_id = self.id.as_str(), "vllm: empty text content");
         })
     }
@@ -409,6 +438,35 @@ mod tests {
             config,
         )
         .unwrap()
+    }
+
+    /// Captures `record_provider_error` so a test can assert the
+    /// classification an agent failure produced. Every other method is a
+    /// no-op.
+    #[derive(Default)]
+    struct CapturingMetrics {
+        provider_errors: std::sync::Mutex<Vec<&'static str>>,
+    }
+    impl MetricsRecorderPort for CapturingMetrics {
+        fn observe_deliberation_duration(
+            &self,
+            _s: &Specialty,
+            _d: choreo_core::value_objects::DurationMs,
+        ) {
+        }
+        fn record_deliberation_outcome(
+            &self,
+            _s: &Specialty,
+            _o: choreo_core::value_objects::DeliberationOutcome,
+        ) {
+        }
+        fn observe_winner_score(&self, _s: &Specialty, _sc: choreo_core::value_objects::Score) {}
+        fn observe_judge_latency(&self, _m: &str, _d: choreo_core::value_objects::DurationMs) {}
+        fn observe_judge_score(&self, _m: &str, _sc: choreo_core::value_objects::Score) {}
+        fn record_judge_error(&self, _m: &str, _k: LlmErrorKind) {}
+        fn record_provider_error(&self, _provider: &str, kind: LlmErrorKind) {
+            self.provider_errors.lock().unwrap().push(kind.as_label());
+        }
     }
 
     fn test_agent_with_bearer(server: &MockServer, token: &str) -> VllmAgent {
@@ -753,6 +811,24 @@ mod tests {
                 reason: "vllm: rate-limited"
             }
         ));
+    }
+
+    #[tokio::test]
+    async fn rate_limited_response_records_a_provider_error() {
+        let server = MockServer::start().await;
+        Mock::given(any())
+            .respond_with(ResponseTemplate::new(429))
+            .mount(&server)
+            .await;
+
+        let metrics = Arc::new(CapturingMetrics::default());
+        let agent = test_agent(&server).with_metrics(metrics.clone());
+        let _ = agent.generate(draft()).await.unwrap_err();
+
+        assert_eq!(
+            metrics.provider_errors.lock().unwrap().as_slice(),
+            &["rate_limited"]
+        );
     }
 
     #[tokio::test]

--- a/crates/choreo-adapters/src/metrics/prometheus_recorder.rs
+++ b/crates/choreo-adapters/src/metrics/prometheus_recorder.rs
@@ -40,6 +40,7 @@ pub struct PrometheusMetricsRecorder {
     judge_latency_seconds: HistogramVec,
     judge_score: HistogramVec,
     judge_errors_total: IntCounterVec,
+    provider_errors_total: IntCounterVec,
 }
 
 impl PrometheusMetricsRecorder {
@@ -111,6 +112,15 @@ impl PrometheusMetricsRecorder {
         )
         .map_err(|err| metrics_error(&err))?;
 
+        let provider_errors_total = IntCounterVec::new(
+            Opts::new(
+                "choreo_provider_errors_total",
+                "Failed proposing-agent calls, partitioned by provider and error classification.",
+            ),
+            &["provider", "error_kind"],
+        )
+        .map_err(|err| metrics_error(&err))?;
+
         registry
             .register(Box::new(deliberation_duration_seconds.clone()))
             .map_err(|err| metrics_error(&err))?;
@@ -129,6 +139,9 @@ impl PrometheusMetricsRecorder {
         registry
             .register(Box::new(judge_errors_total.clone()))
             .map_err(|err| metrics_error(&err))?;
+        registry
+            .register(Box::new(provider_errors_total.clone()))
+            .map_err(|err| metrics_error(&err))?;
 
         Ok(Self {
             registry,
@@ -138,6 +151,7 @@ impl PrometheusMetricsRecorder {
             judge_latency_seconds,
             judge_score,
             judge_errors_total,
+            provider_errors_total,
         })
     }
 
@@ -202,6 +216,12 @@ impl MetricsRecorderPort for PrometheusMetricsRecorder {
             .with_label_values(&[model, kind.as_label()])
             .inc();
     }
+
+    fn record_provider_error(&self, provider: &str, kind: LlmErrorKind) {
+        self.provider_errors_total
+            .with_label_values(&[provider, kind.as_label()])
+            .inc();
+    }
 }
 
 /// Map a Prometheus setup failure to a fail-fast wiring error.
@@ -231,6 +251,7 @@ mod tests {
         recorder.observe_judge_latency("gemma", DurationMs::from_millis(1_000));
         recorder.observe_judge_score("gemma", Score::new(0.5).unwrap());
         recorder.record_judge_error("gemma", LlmErrorKind::Timeout);
+        recorder.record_provider_error("vllm", LlmErrorKind::RateLimited);
 
         let text = recorder.render();
         assert!(text.contains("# TYPE choreo_deliberation_duration_seconds histogram"));
@@ -239,6 +260,25 @@ mod tests {
         assert!(text.contains("# TYPE choreo_judge_latency_seconds histogram"));
         assert!(text.contains("# TYPE choreo_judge_score histogram"));
         assert!(text.contains("# TYPE choreo_judge_errors_total counter"));
+        assert!(text.contains("# TYPE choreo_provider_errors_total counter"));
+    }
+
+    #[test]
+    fn records_provider_errors_by_provider_and_kind() {
+        let recorder = PrometheusMetricsRecorder::new().unwrap();
+        recorder.record_provider_error("vllm", LlmErrorKind::RateLimited);
+        recorder.record_provider_error("vllm", LlmErrorKind::Timeout);
+        recorder.record_provider_error("openai", LlmErrorKind::Unauthorized);
+
+        let text = recorder.render();
+        assert!(text.contains(
+            "choreo_provider_errors_total{error_kind=\"rate_limited\",provider=\"vllm\"} 1"
+        ));
+        assert!(text
+            .contains("choreo_provider_errors_total{error_kind=\"timeout\",provider=\"vllm\"} 1"));
+        assert!(text.contains(
+            "choreo_provider_errors_total{error_kind=\"unauthorized\",provider=\"openai\"} 1"
+        ));
     }
 
     #[test]

--- a/crates/choreo-app/src/usecases/deliberate.rs
+++ b/crates/choreo-app/src/usecases/deliberate.rs
@@ -818,6 +818,12 @@ mod tests {
             _kind: choreo_core::value_objects::LlmErrorKind,
         ) {
         }
+        fn record_provider_error(
+            &self,
+            _provider: &str,
+            _kind: choreo_core::value_objects::LlmErrorKind,
+        ) {
+        }
     }
 
     // --- Fixture helpers --------------------------------------------------

--- a/crates/choreo-core/src/ports/metrics_recorder.rs
+++ b/crates/choreo-core/src/ports/metrics_recorder.rs
@@ -48,6 +48,11 @@ pub trait MetricsRecorderPort: Send + Sync {
     /// the kind dictates the response (timeout vs rate-limit vs
     /// credential rotation).
     fn record_judge_error(&self, model: &str, kind: LlmErrorKind);
+
+    /// Record a failed proposing-agent call, partitioned by `provider`
+    /// (vllm / openai / anthropic) and [`LlmErrorKind`]. A 429 here is
+    /// backpressure into every deliberation that routes to the provider.
+    fn record_provider_error(&self, provider: &str, kind: LlmErrorKind);
 }
 
 /// A [`MetricsRecorderPort`] that discards every observation.
@@ -66,4 +71,5 @@ impl MetricsRecorderPort for NoopMetricsRecorder {
     fn observe_judge_latency(&self, _model: &str, _duration: DurationMs) {}
     fn observe_judge_score(&self, _model: &str, _score: Score) {}
     fn record_judge_error(&self, _model: &str, _kind: LlmErrorKind) {}
+    fn record_provider_error(&self, _provider: &str, _kind: LlmErrorKind) {}
 }

--- a/crates/choreo/src/compose.rs
+++ b/crates/choreo/src/compose.rs
@@ -144,7 +144,8 @@ pub async fn compose() -> Result<Application, ComposeError> {
     // the validator chain so its verdict drives the ranking.
     let scoring: Arc<dyn ScoringPort> = wire_scoring(&mut validators, metrics_recorder.clone())?;
     let executor = wire_executor().await?;
-    let dispatching_factory = DispatchingAgentFactory::from_env()?;
+    let dispatching_factory =
+        DispatchingAgentFactory::from_env()?.with_metrics(metrics_recorder.clone());
     let supported_agent_kinds = dispatching_factory.supported_kinds().join(",");
     let agent_factory: Arc<dyn AgentFactoryPort> = Arc::new(dispatching_factory);
 


### PR DESCRIPTION
Fourth instrumentation slice — completes the RED picture for the proposing agents, mirroring the judge-errors slice (#104) and reusing the same `LlmErrorKind`.

## What it adds
- **`choreo_provider_errors_total{provider, error_kind}`** — all three provider adapters (`vllm`, `openai`, `anthropic`) record at each failure site of a completion call:
  - connection error → `timeout` vs `transport` (via `reqwest::Error::is_timeout`)
  - HTTP status → `LlmErrorKind::from_status`
  - response body → `malformed_body` / `empty_content`
- `provider` distinguishes the three; reuses the eight-class `LlmErrorKind` from #104.

## Threading (the reusable part)
Each agent and the `DispatchingAgentFactory` default their recorder to `NoopMetricsRecorder` and expose a `with_metrics` builder. The composition root attaches the real recorder **once** — the factory forwards it to every agent it materializes. Existing constructors and tests keep their signatures; only `compose` opts in. This is the infrastructure every future provider metric (latency, in-flight, tokens) reuses, so it is paid for once here.

The factory's derived `Debug`/`Default` are replaced with manual impls because `Arc<dyn MetricsRecorderPort>` is neither.

## Why it matters
A 429 here is backpressure into every deliberation that routes to the provider — the design's `ProviderRateLimited` page alert keys off exactly this metric. With vLLM serialised (`max-num-seqs=1`), provider errors are the first symptom of saturation.

## Validation
On **rust 1.90**: `fmt --check` + `clippy --workspace --all-targets --all-features -D warnings` clean, full unit suite green — including a vLLM `429 → rate_limited` provider-error integration test, plus the existing per-provider error-mapping tests (unchanged, still green, proving no behavioural regression).

Token cost (`ChatResponse.usage`), provider latency + in-flight, and judge discrimination remain as later slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)