### PR TITLE
feat(observability): judge + provider token-cost metrics

### DIFF
--- a/crates/choreo-adapters/src/agents/anthropic.rs
+++ b/crates/choreo-adapters/src/agents/anthropic.rs
@@ -28,7 +28,7 @@ use choreo_core::error::DomainError;
 use choreo_core::ports::{
     AgentPort, Critique, DraftRequest, MetricsRecorderPort, NoopMetricsRecorder, Revision,
 };
-use choreo_core::value_objects::{AgentId, LlmErrorKind, Specialty};
+use choreo_core::value_objects::{AgentId, LlmErrorKind, Specialty, TokenUsage};
 use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
@@ -276,7 +276,8 @@ impl AnthropicAgent {
             }
         })?;
 
-        extract_text(parsed).inspect_err(|_| {
+        let usage = parsed.usage;
+        let text = extract_text(parsed).inspect_err(|_| {
             self.metrics
                 .record_provider_error(PROVIDER, LlmErrorKind::EmptyContent);
             warn!(
@@ -284,7 +285,14 @@ impl AnthropicAgent {
                 agent_id = self.id.as_str(),
                 "anthropic: empty text content"
             );
-        })
+        })?;
+        if let Some(usage) = usage {
+            self.metrics.record_provider_tokens(
+                PROVIDER,
+                TokenUsage::new(usage.input_tokens, usage.output_tokens),
+            );
+        }
+        Ok(text)
     }
 }
 
@@ -365,6 +373,19 @@ struct Message<'a> {
 struct MessagesResponse {
     #[serde(default)]
     content: Vec<ContentBlock>,
+    #[serde(default)]
+    usage: Option<AnthropicUsage>,
+}
+
+/// Token accounting block of a Messages API response. Anthropic names
+/// the two sides `input_tokens` / `output_tokens`; they map onto the
+/// shared prompt / completion token types.
+#[derive(Deserialize, Clone, Copy, Default)]
+struct AnthropicUsage {
+    #[serde(default)]
+    input_tokens: u32,
+    #[serde(default)]
+    output_tokens: u32,
 }
 
 #[derive(Deserialize)]

--- a/crates/choreo-adapters/src/agents/judge.rs
+++ b/crates/choreo-adapters/src/agents/judge.rs
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 use choreo_core::entities::{TaskConstraints, ValidatorReport};
 use choreo_core::error::DomainError;
 use choreo_core::ports::{MetricsRecorderPort, ValidatorPort};
-use choreo_core::value_objects::{Attributes, DurationMs, LlmErrorKind, Score};
+use choreo_core::value_objects::{Attributes, DurationMs, LlmErrorKind, Score, TokenUsage};
 use reqwest::Client;
 use serde_json::{json, Value};
 use tracing::warn;
@@ -196,10 +196,17 @@ impl LlmJudgeValidator {
                 reason: JUDGE_ERRORS.malformed_body,
             }
         })?;
+        let usage = parsed.usage;
         let text = wire::extract_text(parsed, &JUDGE_ERRORS).inspect_err(|_| {
             self.metrics
                 .record_judge_error(&self.model, LlmErrorKind::EmptyContent);
         })?;
+        if let Some(usage) = usage {
+            self.metrics.record_judge_tokens(
+                &self.model,
+                TokenUsage::new(usage.prompt_tokens, usage.completion_tokens),
+            );
+        }
         parse_score(&text).inspect_err(|_| {
             // The call succeeded but the judge's reply was not a usable
             // score object — a malformed body at the contract level.
@@ -321,6 +328,8 @@ mod tests {
             self.errors.lock().unwrap().push(kind.as_label());
         }
         fn record_provider_error(&self, _provider: &str, _kind: LlmErrorKind) {}
+        fn record_judge_tokens(&self, _model: &str, _usage: TokenUsage) {}
+        fn record_provider_tokens(&self, _provider: &str, _usage: TokenUsage) {}
     }
 
     fn judge_with(server: &MockServer, metrics: Arc<dyn MetricsRecorderPort>) -> LlmJudgeValidator {

--- a/crates/choreo-adapters/src/agents/openai.rs
+++ b/crates/choreo-adapters/src/agents/openai.rs
@@ -27,7 +27,7 @@ use choreo_core::error::DomainError;
 use choreo_core::ports::{
     AgentPort, Critique, DraftRequest, MetricsRecorderPort, NoopMetricsRecorder, Revision,
 };
-use choreo_core::value_objects::{AgentId, LlmErrorKind, Specialty};
+use choreo_core::value_objects::{AgentId, LlmErrorKind, Specialty, TokenUsage};
 use reqwest::Client;
 use tracing::{debug, warn};
 
@@ -282,7 +282,8 @@ impl OpenAiAgent {
             }
         })?;
 
-        wire::extract_text(parsed, &OPENAI_ERRORS).inspect_err(|_| {
+        let usage = parsed.usage;
+        let text = wire::extract_text(parsed, &OPENAI_ERRORS).inspect_err(|_| {
             self.metrics
                 .record_provider_error(PROVIDER, LlmErrorKind::EmptyContent);
             warn!(
@@ -290,7 +291,14 @@ impl OpenAiAgent {
                 agent_id = self.id.as_str(),
                 "openai: empty text content"
             );
-        })
+        })?;
+        if let Some(usage) = usage {
+            self.metrics.record_provider_tokens(
+                PROVIDER,
+                TokenUsage::new(usage.prompt_tokens, usage.completion_tokens),
+            );
+        }
+        Ok(text)
     }
 }
 

--- a/crates/choreo-adapters/src/agents/openai_compat.rs
+++ b/crates/choreo-adapters/src/agents/openai_compat.rs
@@ -55,6 +55,21 @@ pub(super) struct ChatMessage<'a> {
 pub(super) struct ChatResponse {
     #[serde(default)]
     pub choices: Vec<ChatChoice>,
+    /// Token accounting. Present on a successful completion for OpenAI
+    /// and vLLM; absent on some streamed or error-shaped bodies, hence
+    /// `Option`. Dropped before this change — the reason judge/provider
+    /// token cost was previously unreadable.
+    #[serde(default)]
+    pub usage: Option<Usage>,
+}
+
+/// Token usage block of a Chat Completions response.
+#[derive(Deserialize, Clone, Copy, Default)]
+pub(super) struct Usage {
+    #[serde(default)]
+    pub prompt_tokens: u32,
+    #[serde(default)]
+    pub completion_tokens: u32,
 }
 
 #[derive(Deserialize)]

--- a/crates/choreo-adapters/src/agents/vllm.rs
+++ b/crates/choreo-adapters/src/agents/vllm.rs
@@ -30,7 +30,7 @@ use choreo_core::error::DomainError;
 use choreo_core::ports::{
     AgentPort, Critique, DraftRequest, MetricsRecorderPort, NoopMetricsRecorder, Revision,
 };
-use choreo_core::value_objects::{AgentId, LlmErrorKind, Specialty};
+use choreo_core::value_objects::{AgentId, LlmErrorKind, Specialty, TokenUsage};
 use reqwest::{Client, RequestBuilder};
 use tracing::{debug, warn};
 
@@ -360,11 +360,19 @@ impl VllmAgent {
             }
         })?;
 
-        wire::extract_text(parsed, &VLLM_ERRORS).inspect_err(|_| {
+        let usage = parsed.usage;
+        let text = wire::extract_text(parsed, &VLLM_ERRORS).inspect_err(|_| {
             self.metrics
                 .record_provider_error(PROVIDER, LlmErrorKind::EmptyContent);
             warn!(op, agent_id = self.id.as_str(), "vllm: empty text content");
-        })
+        })?;
+        if let Some(usage) = usage {
+            self.metrics.record_provider_tokens(
+                PROVIDER,
+                TokenUsage::new(usage.prompt_tokens, usage.completion_tokens),
+            );
+        }
+        Ok(text)
     }
 }
 
@@ -446,6 +454,7 @@ mod tests {
     #[derive(Default)]
     struct CapturingMetrics {
         provider_errors: std::sync::Mutex<Vec<&'static str>>,
+        provider_tokens: std::sync::Mutex<Vec<(u32, u32)>>,
     }
     impl MetricsRecorderPort for CapturingMetrics {
         fn observe_deliberation_duration(
@@ -466,6 +475,13 @@ mod tests {
         fn record_judge_error(&self, _m: &str, _k: LlmErrorKind) {}
         fn record_provider_error(&self, _provider: &str, kind: LlmErrorKind) {
             self.provider_errors.lock().unwrap().push(kind.as_label());
+        }
+        fn record_judge_tokens(&self, _model: &str, _usage: TokenUsage) {}
+        fn record_provider_tokens(&self, _provider: &str, usage: TokenUsage) {
+            self.provider_tokens
+                .lock()
+                .unwrap()
+                .push((usage.prompt(), usage.completion()));
         }
     }
 
@@ -811,6 +827,33 @@ mod tests {
                 reason: "vllm: rate-limited"
             }
         ));
+    }
+
+    #[tokio::test]
+    async fn successful_response_records_provider_token_usage() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "cmpl-test",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok proposal"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 130, "completion_tokens": 47, "total_tokens": 177}
+            })))
+            .mount(&server)
+            .await;
+
+        let metrics = Arc::new(CapturingMetrics::default());
+        let agent = test_agent(&server).with_metrics(metrics.clone());
+        agent.generate(draft()).await.unwrap();
+
+        assert_eq!(
+            metrics.provider_tokens.lock().unwrap().as_slice(),
+            &[(130, 47)]
+        );
     }
 
     #[tokio::test]

--- a/crates/choreo-adapters/src/metrics/prometheus_recorder.rs
+++ b/crates/choreo-adapters/src/metrics/prometheus_recorder.rs
@@ -13,7 +13,9 @@
 
 use choreo_core::error::DomainError;
 use choreo_core::ports::MetricsRecorderPort;
-use choreo_core::value_objects::{DeliberationOutcome, DurationMs, LlmErrorKind, Score, Specialty};
+use choreo_core::value_objects::{
+    DeliberationOutcome, DurationMs, LlmErrorKind, Score, Specialty, TokenUsage,
+};
 use prometheus::{
     Encoder, HistogramOpts, HistogramVec, IntCounterVec, Opts, Registry, TextEncoder,
 };
@@ -41,6 +43,8 @@ pub struct PrometheusMetricsRecorder {
     judge_score: HistogramVec,
     judge_errors_total: IntCounterVec,
     provider_errors_total: IntCounterVec,
+    judge_tokens_total: IntCounterVec,
+    provider_tokens_total: IntCounterVec,
 }
 
 impl PrometheusMetricsRecorder {
@@ -53,95 +57,64 @@ impl PrometheusMetricsRecorder {
     /// surfaced at composition time rather than silently at runtime.
     pub fn new() -> Result<Self, DomainError> {
         let registry = Registry::new();
-
-        let deliberation_duration_seconds = HistogramVec::new(
-            HistogramOpts::new(
-                "choreo_deliberation_duration_seconds",
-                "End-to-end wall-clock duration of a deliberation that ran to completion.",
-            )
-            .buckets(DURATION_BUCKETS_SECONDS.to_vec()),
+        let deliberation_duration_seconds = register_histogram(
+            &registry,
+            "choreo_deliberation_duration_seconds",
+            "End-to-end wall-clock duration of a deliberation that ran to completion.",
+            DURATION_BUCKETS_SECONDS,
             &["specialty"],
-        )
-        .map_err(|err| metrics_error(&err))?;
-
-        let deliberation_winner_score = HistogramVec::new(
-            HistogramOpts::new(
-                "choreo_deliberation_winner_score",
-                "Score of the winning proposal of a deliberation.",
-            )
-            .buckets(SCORE_BUCKETS.to_vec()),
+        )?;
+        let deliberation_winner_score = register_histogram(
+            &registry,
+            "choreo_deliberation_winner_score",
+            "Score of the winning proposal of a deliberation.",
+            SCORE_BUCKETS,
             &["specialty"],
-        )
-        .map_err(|err| metrics_error(&err))?;
-
-        let deliberation_completed_total = IntCounterVec::new(
-            Opts::new(
-                "choreo_deliberation_completed_total",
-                "Deliberations that ran to completion, partitioned by terminal outcome.",
-            ),
+        )?;
+        let deliberation_completed_total = register_counter(
+            &registry,
+            "choreo_deliberation_completed_total",
+            "Deliberations that ran to completion, partitioned by terminal outcome.",
             &["specialty", "outcome"],
-        )
-        .map_err(|err| metrics_error(&err))?;
-
-        let judge_latency_seconds = HistogramVec::new(
-            HistogramOpts::new(
-                "choreo_judge_latency_seconds",
-                "Latency of a single LLM-judge rating call, success or failure.",
-            )
-            .buckets(JUDGE_LATENCY_BUCKETS_SECONDS.to_vec()),
+        )?;
+        let judge_latency_seconds = register_histogram(
+            &registry,
+            "choreo_judge_latency_seconds",
+            "Latency of a single LLM-judge rating call, success or failure.",
+            JUDGE_LATENCY_BUCKETS_SECONDS,
             &["model"],
-        )
-        .map_err(|err| metrics_error(&err))?;
-
-        let judge_score = HistogramVec::new(
-            HistogramOpts::new(
-                "choreo_judge_score",
-                "Distribution of the LLM judge's 0.0-1.0 verdicts.",
-            )
-            .buckets(SCORE_BUCKETS.to_vec()),
+        )?;
+        let judge_score = register_histogram(
+            &registry,
+            "choreo_judge_score",
+            "Distribution of the LLM judge's 0.0-1.0 verdicts.",
+            SCORE_BUCKETS,
             &["model"],
-        )
-        .map_err(|err| metrics_error(&err))?;
-
-        let judge_errors_total = IntCounterVec::new(
-            Opts::new(
-                "choreo_judge_errors_total",
-                "Failed LLM-judge calls, partitioned by error classification.",
-            ),
+        )?;
+        let judge_errors_total = register_counter(
+            &registry,
+            "choreo_judge_errors_total",
+            "Failed LLM-judge calls, partitioned by error classification.",
             &["model", "error_kind"],
-        )
-        .map_err(|err| metrics_error(&err))?;
-
-        let provider_errors_total = IntCounterVec::new(
-            Opts::new(
-                "choreo_provider_errors_total",
-                "Failed proposing-agent calls, partitioned by provider and error classification.",
-            ),
+        )?;
+        let provider_errors_total = register_counter(
+            &registry,
+            "choreo_provider_errors_total",
+            "Failed proposing-agent calls, partitioned by provider and error classification.",
             &["provider", "error_kind"],
-        )
-        .map_err(|err| metrics_error(&err))?;
-
-        registry
-            .register(Box::new(deliberation_duration_seconds.clone()))
-            .map_err(|err| metrics_error(&err))?;
-        registry
-            .register(Box::new(deliberation_winner_score.clone()))
-            .map_err(|err| metrics_error(&err))?;
-        registry
-            .register(Box::new(deliberation_completed_total.clone()))
-            .map_err(|err| metrics_error(&err))?;
-        registry
-            .register(Box::new(judge_latency_seconds.clone()))
-            .map_err(|err| metrics_error(&err))?;
-        registry
-            .register(Box::new(judge_score.clone()))
-            .map_err(|err| metrics_error(&err))?;
-        registry
-            .register(Box::new(judge_errors_total.clone()))
-            .map_err(|err| metrics_error(&err))?;
-        registry
-            .register(Box::new(provider_errors_total.clone()))
-            .map_err(|err| metrics_error(&err))?;
+        )?;
+        let judge_tokens_total = register_counter(
+            &registry,
+            "choreo_judge_tokens_total",
+            "Tokens consumed by LLM-judge calls, partitioned by token type.",
+            &["model", "token_type"],
+        )?;
+        let provider_tokens_total = register_counter(
+            &registry,
+            "choreo_provider_tokens_total",
+            "Tokens consumed by proposing-agent calls, partitioned by provider and token type.",
+            &["provider", "token_type"],
+        )?;
 
         Ok(Self {
             registry,
@@ -152,6 +125,8 @@ impl PrometheusMetricsRecorder {
             judge_score,
             judge_errors_total,
             provider_errors_total,
+            judge_tokens_total,
+            provider_tokens_total,
         })
     }
 
@@ -222,6 +197,62 @@ impl MetricsRecorderPort for PrometheusMetricsRecorder {
             .with_label_values(&[provider, kind.as_label()])
             .inc();
     }
+
+    fn record_judge_tokens(&self, model: &str, usage: TokenUsage) {
+        self.judge_tokens_total
+            .with_label_values(&[model, "prompt"])
+            .inc_by(u64::from(usage.prompt()));
+        self.judge_tokens_total
+            .with_label_values(&[model, "completion"])
+            .inc_by(u64::from(usage.completion()));
+    }
+
+    fn record_provider_tokens(&self, provider: &str, usage: TokenUsage) {
+        self.provider_tokens_total
+            .with_label_values(&[provider, "prompt"])
+            .inc_by(u64::from(usage.prompt()));
+        self.provider_tokens_total
+            .with_label_values(&[provider, "completion"])
+            .inc_by(u64::from(usage.completion()));
+    }
+}
+
+/// Define a labelled histogram, register it on `registry`, and return
+/// the handle. Definition and registration are paired so a metric can
+/// never be defined but left unregistered (it would then be invisible at
+/// `/metrics`).
+fn register_histogram(
+    registry: &Registry,
+    name: &str,
+    help: &str,
+    buckets: &[f64],
+    labels: &[&str],
+) -> Result<HistogramVec, DomainError> {
+    let metric = HistogramVec::new(
+        HistogramOpts::new(name, help).buckets(buckets.to_vec()),
+        labels,
+    )
+    .map_err(|err| metrics_error(&err))?;
+    registry
+        .register(Box::new(metric.clone()))
+        .map_err(|err| metrics_error(&err))?;
+    Ok(metric)
+}
+
+/// Define a labelled counter, register it on `registry`, and return the
+/// handle. See [`register_histogram`] for the pairing rationale.
+fn register_counter(
+    registry: &Registry,
+    name: &str,
+    help: &str,
+    labels: &[&str],
+) -> Result<IntCounterVec, DomainError> {
+    let metric =
+        IntCounterVec::new(Opts::new(name, help), labels).map_err(|err| metrics_error(&err))?;
+    registry
+        .register(Box::new(metric.clone()))
+        .map_err(|err| metrics_error(&err))?;
+    Ok(metric)
 }
 
 /// Map a Prometheus setup failure to a fail-fast wiring error.
@@ -252,6 +283,8 @@ mod tests {
         recorder.observe_judge_score("gemma", Score::new(0.5).unwrap());
         recorder.record_judge_error("gemma", LlmErrorKind::Timeout);
         recorder.record_provider_error("vllm", LlmErrorKind::RateLimited);
+        recorder.record_judge_tokens("gemma", TokenUsage::new(10, 5));
+        recorder.record_provider_tokens("vllm", TokenUsage::new(10, 5));
 
         let text = recorder.render();
         assert!(text.contains("# TYPE choreo_deliberation_duration_seconds histogram"));
@@ -261,6 +294,27 @@ mod tests {
         assert!(text.contains("# TYPE choreo_judge_score histogram"));
         assert!(text.contains("# TYPE choreo_judge_errors_total counter"));
         assert!(text.contains("# TYPE choreo_provider_errors_total counter"));
+        assert!(text.contains("# TYPE choreo_judge_tokens_total counter"));
+        assert!(text.contains("# TYPE choreo_provider_tokens_total counter"));
+    }
+
+    #[test]
+    fn records_tokens_split_by_type_and_summed() {
+        let recorder = PrometheusMetricsRecorder::new().unwrap();
+        recorder.record_provider_tokens("vllm", TokenUsage::new(100, 40));
+        recorder.record_provider_tokens("vllm", TokenUsage::new(50, 10));
+        recorder.record_judge_tokens("gemma", TokenUsage::new(200, 8));
+
+        let text = recorder.render();
+        // Counters accumulate the token counts (100+50 prompt, 40+10 completion).
+        assert!(text
+            .contains("choreo_provider_tokens_total{provider=\"vllm\",token_type=\"prompt\"} 150"));
+        assert!(text.contains(
+            "choreo_provider_tokens_total{provider=\"vllm\",token_type=\"completion\"} 50"
+        ));
+        assert!(
+            text.contains("choreo_judge_tokens_total{model=\"gemma\",token_type=\"prompt\"} 200")
+        );
     }
 
     #[test]

--- a/crates/choreo-app/src/usecases/deliberate.rs
+++ b/crates/choreo-app/src/usecases/deliberate.rs
@@ -824,6 +824,18 @@ mod tests {
             _kind: choreo_core::value_objects::LlmErrorKind,
         ) {
         }
+        fn record_judge_tokens(
+            &self,
+            _model: &str,
+            _usage: choreo_core::value_objects::TokenUsage,
+        ) {
+        }
+        fn record_provider_tokens(
+            &self,
+            _provider: &str,
+            _usage: choreo_core::value_objects::TokenUsage,
+        ) {
+        }
     }
 
     // --- Fixture helpers --------------------------------------------------

--- a/crates/choreo-core/src/ports/metrics_recorder.rs
+++ b/crates/choreo-core/src/ports/metrics_recorder.rs
@@ -18,7 +18,9 @@
 //!
 //! [`StatisticsPort`]: super::StatisticsPort
 
-use crate::value_objects::{DeliberationOutcome, DurationMs, LlmErrorKind, Score, Specialty};
+use crate::value_objects::{
+    DeliberationOutcome, DurationMs, LlmErrorKind, Score, Specialty, TokenUsage,
+};
 
 pub trait MetricsRecorderPort: Send + Sync {
     /// Observe the end-to-end wall-clock duration of a deliberation that
@@ -53,6 +55,14 @@ pub trait MetricsRecorderPort: Send + Sync {
     /// (vllm / openai / anthropic) and [`LlmErrorKind`]. A 429 here is
     /// backpressure into every deliberation that routes to the provider.
     fn record_provider_error(&self, provider: &str, kind: LlmErrorKind);
+
+    /// Record token usage for one LLM-judge call. Combined with judge
+    /// discrimination, this is the cost side of the judge's ROI.
+    fn record_judge_tokens(&self, model: &str, usage: TokenUsage);
+
+    /// Record token usage for one proposing-agent call, by provider —
+    /// cost attribution and prompt-bloat detection.
+    fn record_provider_tokens(&self, provider: &str, usage: TokenUsage);
 }
 
 /// A [`MetricsRecorderPort`] that discards every observation.
@@ -72,4 +82,6 @@ impl MetricsRecorderPort for NoopMetricsRecorder {
     fn observe_judge_score(&self, _model: &str, _score: Score) {}
     fn record_judge_error(&self, _model: &str, _kind: LlmErrorKind) {}
     fn record_provider_error(&self, _provider: &str, _kind: LlmErrorKind) {}
+    fn record_judge_tokens(&self, _model: &str, _usage: TokenUsage) {}
+    fn record_provider_tokens(&self, _provider: &str, _usage: TokenUsage) {}
 }

--- a/crates/choreo-core/src/value_objects/mod.rs
+++ b/crates/choreo-core/src/value_objects/mod.rs
@@ -19,6 +19,7 @@ mod rubric;
 mod score;
 mod specialty;
 mod task_description;
+mod token_usage;
 mod trace_context;
 mod validation_mode;
 
@@ -45,5 +46,6 @@ pub use rubric::Rubric;
 pub use score::Score;
 pub use specialty::Specialty;
 pub use task_description::TaskDescription;
+pub use token_usage::TokenUsage;
 pub use trace_context::TraceContext;
 pub use validation_mode::ValidationMode;

--- a/crates/choreo-core/src/value_objects/token_usage.rs
+++ b/crates/choreo-core/src/value_objects/token_usage.rs
@@ -1,0 +1,50 @@
+//! [`TokenUsage`] — prompt + completion token counts for one LLM call.
+//!
+//! A small, immutable record of what a single model call cost in tokens.
+//! Naming the two counts as one value object keeps the metric port free
+//! of bare `u32` pairs that are trivial to transpose.
+
+/// Token counts reported by a model for a single call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct TokenUsage {
+    prompt: u32,
+    completion: u32,
+}
+
+impl TokenUsage {
+    /// Build a usage record from prompt (input) and completion (output)
+    /// token counts.
+    #[must_use]
+    pub const fn new(prompt: u32, completion: u32) -> Self {
+        Self { prompt, completion }
+    }
+
+    /// Tokens consumed by the request (the "prompt" / "input" side).
+    #[must_use]
+    pub const fn prompt(self) -> u32 {
+        self.prompt
+    }
+
+    /// Tokens produced in the response (the "completion" / "output" side).
+    #[must_use]
+    pub const fn completion(self) -> u32 {
+        self.completion
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accessors_return_constructed_counts() {
+        let usage = TokenUsage::new(120, 45);
+        assert_eq!(usage.prompt(), 120);
+        assert_eq!(usage.completion(), 45);
+    }
+
+    #[test]
+    fn default_is_zero() {
+        assert_eq!(TokenUsage::default(), TokenUsage::new(0, 0));
+    }
+}


### PR DESCRIPTION
Fifth instrumentation slice — makes **token cost observable**, which the design flagged as *structurally unreadable today*: the OpenAI-compat `ChatResponse` dropped the `usage` block entirely, so every judge/provider call's token count was thrown away at the wire.

## What it adds
- **`TokenUsage`** value object (prompt + completion) in the core — the port exchanges a named record, not a transposable `u32` pair.
- **Wire fix**: `usage` restored on `ChatResponse` (shared by `vllm` + `openai` + the judge) and an `AnthropicUsage` block on the Messages response (`input`/`output` → `prompt`/`completion`).
- **`choreo_judge_tokens_total{model, token_type}`** and **`choreo_provider_tokens_total{provider, token_type}`** — read after a successful parse, recorded by all three providers and the judge. Reuses the `with_metrics` wiring already in place from #103/#105, so this slice is mostly the wire change + the read.

## Why it matters
Combined with judge discrimination (a later slice), this is the **cost-per-rerank ROI** signal — the basis for "keep / cheaper model / disable judge" decisions. For providers it is cost attribution + prompt-bloat detection.

## Also: a small recorder refactor
`PrometheusMetricsRecorder::new()` had grown to ~130 lines (it tripped `clippy::too_many_lines`). A `register_histogram` / `register_counter` pair now defines-and-registers each family in one call — pairing the two so a metric can never be defined-but-unregistered (invisible at `/metrics`), and keeping `new()` well under the limit as the registry keeps growing.

## Validation
On **rust 1.90**: `fmt --check` + `clippy --workspace --all-targets --all-features -D warnings` clean, full unit suite green — recorder accumulates by token type, and a vLLM response carrying `usage` records `(130, 47)`. The recorder refactor is behaviour-preserving (the existing render-assertion tests verify identical metric output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)