### PR TITLE
feat(observability): provider call latency + in-flight gauge

### DIFF
--- a/crates/choreo-adapters/src/agents/anthropic.rs
+++ b/crates/choreo-adapters/src/agents/anthropic.rs
@@ -33,6 +33,7 @@ use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 
+use super::instrument::ProviderCallGuard;
 use super::prompts;
 
 /// Provider label for this adapter's error metrics.
@@ -206,6 +207,9 @@ impl AnthropicAgent {
         user: String,
         op: &str,
     ) -> Result<String, DomainError> {
+        // Records latency + in-flight on every return path (incl. the `?`
+        // error sites) when dropped at the end of the call.
+        let _guard = ProviderCallGuard::enter(self.metrics.as_ref(), PROVIDER, op);
         let body = MessagesRequest {
             model: &self.config.model,
             max_tokens: self.config.max_tokens,

--- a/crates/choreo-adapters/src/agents/instrument.rs
+++ b/crates/choreo-adapters/src/agents/instrument.rs
@@ -1,0 +1,46 @@
+//! Shared instrumentation for HTTP provider-agent calls.
+//!
+//! [`ProviderCallGuard`] wraps a single completion call so its latency
+//! and in-flight accounting are recorded on **every** return path —
+//! including the `?` early-returns of the four error sites — without a
+//! hand-written `finally`. Increment-on-enter / record-and-decrement-on-
+//! drop keeps the in-flight gauge balanced even when a call fails.
+
+use std::time::Instant;
+
+use choreo_core::ports::MetricsRecorderPort;
+use choreo_core::value_objects::DurationMs;
+
+pub(super) struct ProviderCallGuard<'a> {
+    metrics: &'a dyn MetricsRecorderPort,
+    provider: &'static str,
+    operation: &'a str,
+    started: Instant,
+}
+
+impl<'a> ProviderCallGuard<'a> {
+    /// Mark a call as started: increment the provider's in-flight gauge
+    /// and begin timing. Hold the returned guard for the call's duration.
+    pub(super) fn enter(
+        metrics: &'a dyn MetricsRecorderPort,
+        provider: &'static str,
+        operation: &'a str,
+    ) -> Self {
+        metrics.inc_provider_in_flight(provider);
+        Self {
+            metrics,
+            provider,
+            operation,
+            started: Instant::now(),
+        }
+    }
+}
+
+impl Drop for ProviderCallGuard<'_> {
+    fn drop(&mut self) {
+        let elapsed = DurationMs::from_millis(self.started.elapsed().as_millis() as u64);
+        self.metrics
+            .observe_provider_request(self.provider, self.operation, elapsed);
+        self.metrics.dec_provider_in_flight(self.provider);
+    }
+}

--- a/crates/choreo-adapters/src/agents/judge.rs
+++ b/crates/choreo-adapters/src/agents/judge.rs
@@ -330,6 +330,15 @@ mod tests {
         fn record_provider_error(&self, _provider: &str, _kind: LlmErrorKind) {}
         fn record_judge_tokens(&self, _model: &str, _usage: TokenUsage) {}
         fn record_provider_tokens(&self, _provider: &str, _usage: TokenUsage) {}
+        fn observe_provider_request(
+            &self,
+            _provider: &str,
+            _operation: &str,
+            _duration: DurationMs,
+        ) {
+        }
+        fn inc_provider_in_flight(&self, _provider: &str) {}
+        fn dec_provider_in_flight(&self, _provider: &str) {}
     }
 
     fn judge_with(server: &MockServer, metrics: Arc<dyn MetricsRecorderPort>) -> LlmJudgeValidator {

--- a/crates/choreo-adapters/src/agents/mod.rs
+++ b/crates/choreo-adapters/src/agents/mod.rs
@@ -32,6 +32,10 @@ mod openai_compat;
 #[cfg(feature = "_http")]
 mod endpoint;
 
+// Shared latency + in-flight instrumentation for HTTP provider calls.
+#[cfg(feature = "_http")]
+mod instrument;
+
 #[cfg(any(feature = "agent-openai", feature = "agent-vllm"))]
 pub mod judge;
 

--- a/crates/choreo-adapters/src/agents/openai.rs
+++ b/crates/choreo-adapters/src/agents/openai.rs
@@ -31,6 +31,7 @@ use choreo_core::value_objects::{AgentId, LlmErrorKind, Specialty, TokenUsage};
 use reqwest::Client;
 use tracing::{debug, warn};
 
+use super::instrument::ProviderCallGuard;
 use super::openai_compat::{self as wire, ChatMessage, ChatRequest, ChatResponse, ErrorStrings};
 use super::prompts;
 
@@ -209,6 +210,9 @@ impl OpenAiAgent {
         user: String,
         op: &str,
     ) -> Result<String, DomainError> {
+        // Records latency + in-flight on every return path (incl. the `?`
+        // error sites) when dropped at the end of the call.
+        let _guard = ProviderCallGuard::enter(self.metrics.as_ref(), PROVIDER, op);
         let body = ChatRequest {
             model: &self.config.model,
             max_tokens: self.config.max_tokens,

--- a/crates/choreo-adapters/src/agents/vllm.rs
+++ b/crates/choreo-adapters/src/agents/vllm.rs
@@ -34,6 +34,7 @@ use choreo_core::value_objects::{AgentId, LlmErrorKind, Specialty, TokenUsage};
 use reqwest::{Client, RequestBuilder};
 use tracing::{debug, warn};
 
+use super::instrument::ProviderCallGuard;
 use super::openai_compat::{self as wire, ChatMessage, ChatRequest, ChatResponse, ErrorStrings};
 use super::prompts;
 
@@ -288,6 +289,9 @@ impl VllmAgent {
         user: String,
         op: &str,
     ) -> Result<String, DomainError> {
+        // Records latency + in-flight on every return path (incl. the `?`
+        // error sites) when dropped at the end of the call.
+        let _guard = ProviderCallGuard::enter(self.metrics.as_ref(), PROVIDER, op);
         let body = ChatRequest {
             model: &self.config.model,
             max_tokens: self.config.max_tokens,
@@ -455,6 +459,8 @@ mod tests {
     struct CapturingMetrics {
         provider_errors: std::sync::Mutex<Vec<&'static str>>,
         provider_tokens: std::sync::Mutex<Vec<(u32, u32)>>,
+        in_flight: std::sync::atomic::AtomicI64,
+        requests: std::sync::Mutex<Vec<String>>,
     }
     impl MetricsRecorderPort for CapturingMetrics {
         fn observe_deliberation_duration(
@@ -482,6 +488,22 @@ mod tests {
                 .lock()
                 .unwrap()
                 .push((usage.prompt(), usage.completion()));
+        }
+        fn observe_provider_request(
+            &self,
+            _provider: &str,
+            operation: &str,
+            _duration: choreo_core::value_objects::DurationMs,
+        ) {
+            self.requests.lock().unwrap().push(operation.to_owned());
+        }
+        fn inc_provider_in_flight(&self, _provider: &str) {
+            self.in_flight
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+        fn dec_provider_in_flight(&self, _provider: &str) {
+            self.in_flight
+                .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
         }
     }
 
@@ -853,6 +875,32 @@ mod tests {
         assert_eq!(
             metrics.provider_tokens.lock().unwrap().as_slice(),
             &[(130, 47)]
+        );
+    }
+
+    #[tokio::test]
+    async fn call_balances_in_flight_and_records_its_operation_latency() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(chat_response("ok")))
+            .mount(&server)
+            .await;
+
+        let metrics = Arc::new(CapturingMetrics::default());
+        let agent = test_agent(&server).with_metrics(metrics.clone());
+        agent.generate(draft()).await.unwrap();
+
+        // The guard incremented on entry and decremented on drop, so the
+        // gauge is back to zero, and the call's latency was recorded once
+        // under its operation.
+        assert_eq!(
+            metrics.in_flight.load(std::sync::atomic::Ordering::SeqCst),
+            0
+        );
+        assert_eq!(
+            metrics.requests.lock().unwrap().as_slice(),
+            &["generate".to_owned()]
         );
     }
 

--- a/crates/choreo-adapters/src/metrics/prometheus_recorder.rs
+++ b/crates/choreo-adapters/src/metrics/prometheus_recorder.rs
@@ -17,7 +17,7 @@ use choreo_core::value_objects::{
     DeliberationOutcome, DurationMs, LlmErrorKind, Score, Specialty, TokenUsage,
 };
 use prometheus::{
-    Encoder, HistogramOpts, HistogramVec, IntCounterVec, Opts, Registry, TextEncoder,
+    Encoder, HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec, Opts, Registry, TextEncoder,
 };
 
 /// Latency buckets (seconds) sized for serialized vLLM deliberations,
@@ -34,6 +34,13 @@ const SCORE_BUCKETS: &[f64] = &[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0
 const JUDGE_LATENCY_BUCKETS_SECONDS: &[f64] =
     &[0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 30.0, 45.0, 55.0, 60.0];
 
+/// Latency buckets (seconds) for a single proposing-agent call. A
+/// generate/critique/revise on a serialised vLLM model can run to tens of
+/// seconds, so the range reaches past two minutes.
+const PROVIDER_LATENCY_BUCKETS_SECONDS: &[f64] = &[
+    0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 30.0, 45.0, 60.0, 90.0, 120.0,
+];
+
 pub struct PrometheusMetricsRecorder {
     registry: Registry,
     deliberation_duration_seconds: HistogramVec,
@@ -45,6 +52,8 @@ pub struct PrometheusMetricsRecorder {
     provider_errors_total: IntCounterVec,
     judge_tokens_total: IntCounterVec,
     provider_tokens_total: IntCounterVec,
+    provider_request_duration_seconds: HistogramVec,
+    provider_in_flight: IntGaugeVec,
 }
 
 impl PrometheusMetricsRecorder {
@@ -115,6 +124,19 @@ impl PrometheusMetricsRecorder {
             "Tokens consumed by proposing-agent calls, partitioned by provider and token type.",
             &["provider", "token_type"],
         )?;
+        let provider_request_duration_seconds = register_histogram(
+            &registry,
+            "choreo_provider_request_duration_seconds",
+            "Latency of a single proposing-agent call, by provider and operation.",
+            PROVIDER_LATENCY_BUCKETS_SECONDS,
+            &["provider", "operation"],
+        )?;
+        let provider_in_flight = register_gauge(
+            &registry,
+            "choreo_provider_in_flight",
+            "In-flight proposing-agent calls per provider; the vLLM serial-saturation signal.",
+            &["provider"],
+        )?;
 
         Ok(Self {
             registry,
@@ -127,6 +149,8 @@ impl PrometheusMetricsRecorder {
             provider_errors_total,
             judge_tokens_total,
             provider_tokens_total,
+            provider_request_duration_seconds,
+            provider_in_flight,
         })
     }
 
@@ -215,6 +239,20 @@ impl MetricsRecorderPort for PrometheusMetricsRecorder {
             .with_label_values(&[provider, "completion"])
             .inc_by(u64::from(usage.completion()));
     }
+
+    fn observe_provider_request(&self, provider: &str, operation: &str, duration: DurationMs) {
+        self.provider_request_duration_seconds
+            .with_label_values(&[provider, operation])
+            .observe(duration.get() as f64 / 1000.0);
+    }
+
+    fn inc_provider_in_flight(&self, provider: &str) {
+        self.provider_in_flight.with_label_values(&[provider]).inc();
+    }
+
+    fn dec_provider_in_flight(&self, provider: &str) {
+        self.provider_in_flight.with_label_values(&[provider]).dec();
+    }
 }
 
 /// Define a labelled histogram, register it on `registry`, and return
@@ -255,6 +293,22 @@ fn register_counter(
     Ok(metric)
 }
 
+/// Define a labelled gauge, register it on `registry`, and return the
+/// handle. See [`register_histogram`] for the pairing rationale.
+fn register_gauge(
+    registry: &Registry,
+    name: &str,
+    help: &str,
+    labels: &[&str],
+) -> Result<IntGaugeVec, DomainError> {
+    let metric =
+        IntGaugeVec::new(Opts::new(name, help), labels).map_err(|err| metrics_error(&err))?;
+    registry
+        .register(Box::new(metric.clone()))
+        .map_err(|err| metrics_error(&err))?;
+    Ok(metric)
+}
+
 /// Map a Prometheus setup failure to a fail-fast wiring error.
 fn metrics_error(err: &prometheus::Error) -> DomainError {
     tracing::error!(error = %err, "prometheus metrics setup failed");
@@ -285,6 +339,8 @@ mod tests {
         recorder.record_provider_error("vllm", LlmErrorKind::RateLimited);
         recorder.record_judge_tokens("gemma", TokenUsage::new(10, 5));
         recorder.record_provider_tokens("vllm", TokenUsage::new(10, 5));
+        recorder.observe_provider_request("vllm", "generate", DurationMs::from_millis(1_000));
+        recorder.inc_provider_in_flight("vllm");
 
         let text = recorder.render();
         assert!(text.contains("# TYPE choreo_deliberation_duration_seconds histogram"));
@@ -296,6 +352,24 @@ mod tests {
         assert!(text.contains("# TYPE choreo_provider_errors_total counter"));
         assert!(text.contains("# TYPE choreo_judge_tokens_total counter"));
         assert!(text.contains("# TYPE choreo_provider_tokens_total counter"));
+        assert!(text.contains("# TYPE choreo_provider_request_duration_seconds histogram"));
+        assert!(text.contains("# TYPE choreo_provider_in_flight gauge"));
+    }
+
+    #[test]
+    fn provider_in_flight_gauge_tracks_inc_and_dec() {
+        let recorder = PrometheusMetricsRecorder::new().unwrap();
+        recorder.inc_provider_in_flight("vllm");
+        recorder.inc_provider_in_flight("vllm");
+        recorder.dec_provider_in_flight("vllm");
+        recorder.observe_provider_request("vllm", "generate", DurationMs::from_millis(2_000));
+
+        let text = recorder.render();
+        // Two starts, one finish -> depth 1.
+        assert!(text.contains("choreo_provider_in_flight{provider=\"vllm\"} 1"));
+        assert!(text.contains(
+            "choreo_provider_request_duration_seconds_sum{operation=\"generate\",provider=\"vllm\"} 2"
+        ));
     }
 
     #[test]

--- a/crates/choreo-app/src/usecases/deliberate.rs
+++ b/crates/choreo-app/src/usecases/deliberate.rs
@@ -836,6 +836,15 @@ mod tests {
             _usage: choreo_core::value_objects::TokenUsage,
         ) {
         }
+        fn observe_provider_request(
+            &self,
+            _provider: &str,
+            _operation: &str,
+            _duration: DurationMs,
+        ) {
+        }
+        fn inc_provider_in_flight(&self, _provider: &str) {}
+        fn dec_provider_in_flight(&self, _provider: &str) {}
     }
 
     // --- Fixture helpers --------------------------------------------------

--- a/crates/choreo-core/src/ports/metrics_recorder.rs
+++ b/crates/choreo-core/src/ports/metrics_recorder.rs
@@ -63,6 +63,20 @@ pub trait MetricsRecorderPort: Send + Sync {
     /// Record token usage for one proposing-agent call, by provider —
     /// cost attribution and prompt-bloat detection.
     fn record_provider_tokens(&self, provider: &str, usage: TokenUsage);
+
+    /// Observe the latency of one proposing-agent call, by `provider` and
+    /// `operation` (generate / critique / revise). Recorded on every path.
+    fn observe_provider_request(&self, provider: &str, operation: &str, duration: DurationMs);
+
+    /// Increment the in-flight gauge for `provider` at the start of a
+    /// call. With vLLM serialised (`max-num-seqs=1`), a sustained
+    /// in-flight depth above 1 is the leading indicator of the latency
+    /// cliff — concurrency that any other backend would absorb queues here.
+    fn inc_provider_in_flight(&self, provider: &str);
+
+    /// Decrement the in-flight gauge for `provider` when a call returns,
+    /// whether it succeeded or failed.
+    fn dec_provider_in_flight(&self, provider: &str);
 }
 
 /// A [`MetricsRecorderPort`] that discards every observation.
@@ -84,4 +98,7 @@ impl MetricsRecorderPort for NoopMetricsRecorder {
     fn record_provider_error(&self, _provider: &str, _kind: LlmErrorKind) {}
     fn record_judge_tokens(&self, _model: &str, _usage: TokenUsage) {}
     fn record_provider_tokens(&self, _provider: &str, _usage: TokenUsage) {}
+    fn observe_provider_request(&self, _provider: &str, _operation: &str, _duration: DurationMs) {}
+    fn inc_provider_in_flight(&self, _provider: &str) {}
+    fn dec_provider_in_flight(&self, _provider: &str) {}
 }


### PR DESCRIPTION
Sixth instrumentation slice — surfaces **vLLM serial saturation**, the differentiating signal the design calls out: with `max-num-seqs=1`, concurrency any other backend would absorb queues here, and per-request latency hides it.

## What it adds
| Metric | Type | Labels |
|---|---|---|
| `choreo_provider_request_duration_seconds` | histogram | `provider`, `operation` |
| `choreo_provider_in_flight` | gauge | `provider` |

`operation` ∈ generate / critique / revise. A sustained in-flight depth above 1 against vLLM means requests are queueing server-side — the leading indicator of the timeout cliff.

## The guard
A shared `ProviderCallGuard` (`agents/instrument.rs`) increments the gauge on entry and, on **drop**, records the call's latency and decrements the gauge. So both happen on *every* return path — including the four `?` error sites — with one line per adapter and no hand-written `finally`. The gauge stays balanced even when a call fails. Adds a `register_gauge` helper alongside the histogram/counter pair from #106.

## Validation
On **rust 1.90**: `fmt --check` + `clippy --workspace --all-targets --all-features -D warnings` clean, full unit suite green — the recorder tracks inc/dec (two starts, one finish → depth 1), and a vLLM call balances the gauge back to zero and records its operation latency.

With this slice the **RED + saturation + cost** picture for the LLM call paths (judge + 3 providers) is complete. The remaining design metric is **judge discrimination** — deferred pending its coupling design (deliberate.rs would need to know which validator is the judge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)