### PR TITLE
feat(observability): judge discrimination — does the judge actually re-rank?

### DIFF
--- a/crates/choreo-adapters/src/agents/judge.rs
+++ b/crates/choreo-adapters/src/agents/judge.rs
@@ -339,6 +339,12 @@ mod tests {
         }
         fn inc_provider_in_flight(&self, _provider: &str) {}
         fn dec_provider_in_flight(&self, _provider: &str) {}
+        fn record_discrimination(
+            &self,
+            _specialty: &choreo_core::value_objects::Specialty,
+            _result: choreo_core::value_objects::Discrimination,
+        ) {
+        }
     }
 
     fn judge_with(server: &MockServer, metrics: Arc<dyn MetricsRecorderPort>) -> LlmJudgeValidator {

--- a/crates/choreo-adapters/src/agents/vllm.rs
+++ b/crates/choreo-adapters/src/agents/vllm.rs
@@ -505,6 +505,12 @@ mod tests {
             self.in_flight
                 .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
         }
+        fn record_discrimination(
+            &self,
+            _specialty: &Specialty,
+            _result: choreo_core::value_objects::Discrimination,
+        ) {
+        }
     }
 
     fn test_agent_with_bearer(server: &MockServer, token: &str) -> VllmAgent {

--- a/crates/choreo-adapters/src/metrics/prometheus_recorder.rs
+++ b/crates/choreo-adapters/src/metrics/prometheus_recorder.rs
@@ -14,7 +14,7 @@
 use choreo_core::error::DomainError;
 use choreo_core::ports::MetricsRecorderPort;
 use choreo_core::value_objects::{
-    DeliberationOutcome, DurationMs, LlmErrorKind, Score, Specialty, TokenUsage,
+    DeliberationOutcome, Discrimination, DurationMs, LlmErrorKind, Score, Specialty, TokenUsage,
 };
 use prometheus::{
     Encoder, HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec, Opts, Registry, TextEncoder,
@@ -54,6 +54,7 @@ pub struct PrometheusMetricsRecorder {
     provider_tokens_total: IntCounterVec,
     provider_request_duration_seconds: HistogramVec,
     provider_in_flight: IntGaugeVec,
+    judge_discrimination_total: IntCounterVec,
 }
 
 impl PrometheusMetricsRecorder {
@@ -137,6 +138,12 @@ impl PrometheusMetricsRecorder {
             "In-flight proposing-agent calls per provider; the vLLM serial-saturation signal.",
             &["provider"],
         )?;
+        let judge_discrimination_total = register_counter(
+            &registry,
+            "choreo_judge_discrimination_total",
+            "Whether the scoring policy re-ranked the deliberation winner vs the structural baseline.",
+            &["specialty", "result"],
+        )?;
 
         Ok(Self {
             registry,
@@ -151,6 +158,7 @@ impl PrometheusMetricsRecorder {
             provider_tokens_total,
             provider_request_duration_seconds,
             provider_in_flight,
+            judge_discrimination_total,
         })
     }
 
@@ -253,6 +261,12 @@ impl MetricsRecorderPort for PrometheusMetricsRecorder {
     fn dec_provider_in_flight(&self, provider: &str) {
         self.provider_in_flight.with_label_values(&[provider]).dec();
     }
+
+    fn record_discrimination(&self, specialty: &Specialty, result: Discrimination) {
+        self.judge_discrimination_total
+            .with_label_values(&[specialty.as_str(), result.as_label()])
+            .inc();
+    }
 }
 
 /// Define a labelled histogram, register it on `registry`, and return
@@ -341,6 +355,7 @@ mod tests {
         recorder.record_provider_tokens("vllm", TokenUsage::new(10, 5));
         recorder.observe_provider_request("vllm", "generate", DurationMs::from_millis(1_000));
         recorder.inc_provider_in_flight("vllm");
+        recorder.record_discrimination(&specialty(), Discrimination::Reranked);
 
         let text = recorder.render();
         assert!(text.contains("# TYPE choreo_deliberation_duration_seconds histogram"));
@@ -354,6 +369,23 @@ mod tests {
         assert!(text.contains("# TYPE choreo_provider_tokens_total counter"));
         assert!(text.contains("# TYPE choreo_provider_request_duration_seconds histogram"));
         assert!(text.contains("# TYPE choreo_provider_in_flight gauge"));
+        assert!(text.contains("# TYPE choreo_judge_discrimination_total counter"));
+    }
+
+    #[test]
+    fn records_discrimination_by_specialty_and_result() {
+        let recorder = PrometheusMetricsRecorder::new().unwrap();
+        recorder.record_discrimination(&specialty(), Discrimination::Reranked);
+        recorder.record_discrimination(&specialty(), Discrimination::Reranked);
+        recorder.record_discrimination(&specialty(), Discrimination::Agreed);
+
+        let text = recorder.render();
+        assert!(text.contains(
+            "choreo_judge_discrimination_total{result=\"reranked\",specialty=\"reviewer\"} 2"
+        ));
+        assert!(text.contains(
+            "choreo_judge_discrimination_total{result=\"agreed\",specialty=\"reviewer\"} 1"
+        ));
     }
 
     #[test]

--- a/crates/choreo-adapters/src/scoring.rs
+++ b/crates/choreo-adapters/src/scoring.rs
@@ -7,10 +7,10 @@
 //! implementing `ScoringPort` elsewhere.
 
 use async_trait::async_trait;
-use choreo_core::entities::ValidatorReport;
+use choreo_core::entities::{RankedOutcome, ValidatorReport};
 use choreo_core::error::DomainError;
 use choreo_core::ports::ScoringPort;
-use choreo_core::value_objects::Score;
+use choreo_core::value_objects::{Discrimination, ProposalId, Score};
 use serde_json::Value;
 
 /// Details key under which an LLM judge writes its 0.0–1.0 verdict. This
@@ -84,14 +84,81 @@ impl ScoringPort for JudgeAwareScoring {
         let value = passed as f64 / reports.len() as f64;
         Score::new(value)
     }
+
+    /// Whether the judge's verdict changed the winner. Compares the
+    /// score-ranked top (the judge's pick) against the *structural
+    /// baseline*: the proposal a judge-free ranking would choose — the
+    /// smallest-id proposal among those passing every non-judge report,
+    /// which is exactly the arbitrary id tie-break the judge replaces.
+    ///
+    /// Returns `None` when no judge actually scored (so the metric stays
+    /// judge-specific) or when there are fewer than two proposals (nothing
+    /// to discriminate among).
+    fn discrimination(&self, ranked: &[RankedOutcome]) -> Option<Discrimination> {
+        if ranked.len() < 2 || !ranked.iter().any(has_judge_verdict) {
+            return None;
+        }
+        // A shared top score means the judge did not separate the leaders.
+        let top_score = ranked[0].outcome().score();
+        if ranked
+            .iter()
+            .filter(|outcome| outcome.outcome().score() == top_score)
+            .count()
+            > 1
+        {
+            return Some(Discrimination::Tie);
+        }
+        let judge_winner = ranked[0].proposal().id();
+        let baseline_winner = structural_baseline_winner(ranked)?;
+        Some(if judge_winner == baseline_winner {
+            Discrimination::Agreed
+        } else {
+            Discrimination::Reranked
+        })
+    }
+}
+
+/// Whether a ranked outcome carries the LLM judge's verdict.
+fn has_judge_verdict(outcome: &RankedOutcome) -> bool {
+    outcome.outcome().reports().iter().any(is_judge_report)
+}
+
+/// A report is the judge's iff it carries the judge-score detail key —
+/// the contract between the judge validator and this scorer.
+fn is_judge_report(report: &ValidatorReport) -> bool {
+    report.details().get(JUDGE_SCORE_DETAIL_KEY).is_some()
+}
+
+/// The proposal a judge-free ranking would pick: the smallest-id proposal
+/// among those passing every structural (non-judge) report. Falls back to
+/// the smallest id overall when none pass the structural validators.
+fn structural_baseline_winner(ranked: &[RankedOutcome]) -> Option<&ProposalId> {
+    ranked
+        .iter()
+        .filter(|outcome| structurally_valid(outcome))
+        .map(|outcome| outcome.proposal().id())
+        .min()
+        .or_else(|| ranked.iter().map(|outcome| outcome.proposal().id()).min())
+}
+
+/// Whether every non-judge report on this proposal passed.
+fn structurally_valid(outcome: &RankedOutcome) -> bool {
+    outcome
+        .outcome()
+        .reports()
+        .iter()
+        .filter(|report| !is_judge_report(report))
+        .all(ValidatorReport::passed)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use choreo_core::value_objects::Attributes;
+    use choreo_core::entities::{Proposal, ValidationOutcome};
+    use choreo_core::value_objects::{AgentId, Attributes, Specialty};
     use serde_json::json;
     use std::collections::BTreeMap;
+    use time::macros::datetime;
 
     fn report(passed: bool) -> ValidatorReport {
         ValidatorReport::new("k", passed, "", Attributes::empty()).unwrap()
@@ -104,6 +171,27 @@ mod tests {
         )]))
         .unwrap();
         ValidatorReport::new("llm_judge", score >= 0.5, "", details).unwrap()
+    }
+
+    /// Build a ranked outcome for `id` carrying the given final `score`,
+    /// an optional judge verdict, and whether its structural validator
+    /// passed. Callers pass these in score-descending order.
+    fn ranked(id: &str, score: f64, judge: Option<f64>, structural_pass: bool) -> RankedOutcome {
+        let mut reports = vec![report(structural_pass)];
+        if let Some(verdict) = judge {
+            reports.push(judged(verdict));
+        }
+        let proposal = Proposal::new(
+            ProposalId::new(id).unwrap(),
+            AgentId::new("agent").unwrap(),
+            Specialty::new("reviewer").unwrap(),
+            "content".to_owned(),
+            Attributes::empty(),
+            datetime!(2026-04-15 12:00:00 UTC),
+        )
+        .unwrap();
+        let outcome = ValidationOutcome::new(Score::new(score).unwrap(), reports);
+        RankedOutcome::new(proposal, outcome, 0)
     }
 
     #[tokio::test]
@@ -170,5 +258,81 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(s, Score::MIN);
+    }
+
+    // --- discrimination ---------------------------------------------------
+
+    #[test]
+    fn discrimination_is_reranked_when_judge_top_is_not_the_id_baseline() {
+        // Judge ranks "b" (score 0.9) over "a" (0.5); both structurally
+        // valid, so the id-baseline winner is "a". The judge reranked.
+        let ranking = [
+            ranked("b", 0.9, Some(0.9), true),
+            ranked("a", 0.5, Some(0.5), true),
+        ];
+        assert_eq!(
+            JudgeAwareScoring::new().discrimination(&ranking),
+            Some(Discrimination::Reranked)
+        );
+    }
+
+    #[test]
+    fn discrimination_is_agreed_when_judge_top_is_the_id_baseline() {
+        // Judge's top "a" is also the smallest-id structurally-valid pick.
+        let ranking = [
+            ranked("a", 0.9, Some(0.9), true),
+            ranked("b", 0.5, Some(0.5), true),
+        ];
+        assert_eq!(
+            JudgeAwareScoring::new().discrimination(&ranking),
+            Some(Discrimination::Agreed)
+        );
+    }
+
+    #[test]
+    fn discrimination_is_tie_when_top_score_is_shared() {
+        let ranking = [
+            ranked("a", 0.8, Some(0.8), true),
+            ranked("b", 0.8, Some(0.8), true),
+        ];
+        assert_eq!(
+            JudgeAwareScoring::new().discrimination(&ranking),
+            Some(Discrimination::Tie)
+        );
+    }
+
+    #[test]
+    fn discrimination_reranks_past_a_structurally_invalid_baseline() {
+        // The judge's top "b" is structurally invalid; the only valid
+        // proposal is "a", so the baseline is "a" and the judge reranked.
+        let ranking = [
+            ranked("b", 0.9, Some(0.9), false),
+            ranked("a", 0.5, Some(0.5), true),
+        ];
+        assert_eq!(
+            JudgeAwareScoring::new().discrimination(&ranking),
+            Some(Discrimination::Reranked)
+        );
+    }
+
+    #[test]
+    fn discrimination_is_none_without_a_judge_verdict() {
+        let ranking = [ranked("a", 1.0, None, true), ranked("b", 0.5, None, true)];
+        assert_eq!(JudgeAwareScoring::new().discrimination(&ranking), None);
+    }
+
+    #[test]
+    fn discrimination_is_none_with_a_single_proposal() {
+        let ranking = [ranked("a", 0.9, Some(0.9), true)];
+        assert_eq!(JudgeAwareScoring::new().discrimination(&ranking), None);
+    }
+
+    #[test]
+    fn uniform_scoring_never_reports_discrimination() {
+        let ranking = [
+            ranked("b", 0.9, Some(0.9), true),
+            ranked("a", 0.5, Some(0.5), true),
+        ];
+        assert_eq!(UniformScoring::new().discrimination(&ranking), None);
     }
 }

--- a/crates/choreo-app/src/usecases/deliberate.rs
+++ b/crates/choreo-app/src/usecases/deliberate.rs
@@ -160,6 +160,10 @@ impl DeliberateUseCase {
 
         let completed_at = self.clock.now();
         let mut ranked = deliberation.complete(completed_at)?;
+        // Whether the scoring policy re-ranked the winner — computed on the
+        // pure score order, before the contract-driven valid-first reorder.
+        // The policy owns the judge contract, so this stays judge-agnostic.
+        let discrimination = self.scoring.discrimination(&ranked);
         observer
             .on_phase_changed(deliberation.task_id(), deliberation.phase(), completed_at)
             .await;
@@ -178,6 +182,10 @@ impl DeliberateUseCase {
         // winner is picked, so a `NoValidProposal` is still timed.
         self.metrics
             .observe_deliberation_duration(deliberation.specialty(), duration);
+        if let Some(result) = discrimination {
+            self.metrics
+                .record_discrimination(deliberation.specialty(), result);
+        }
 
         let winner = match Self::pick_winner(&ranked, task.constraints()) {
             Ok(winner) => winner,
@@ -756,6 +764,26 @@ mod tests {
         }
     }
 
+    /// Scores like [`LinearScoring`] but always reports a `Reranked`
+    /// discrimination, so a test can assert the use case forwards it.
+    struct RerankingScoring;
+    #[async_trait]
+    impl ScoringPort for RerankingScoring {
+        async fn score(&self, reports: &[ValidatorReport]) -> Result<Score, DomainError> {
+            if reports.is_empty() {
+                return Score::new(0.0);
+            }
+            let passed = reports.iter().filter(|r| r.passed()).count() as f64;
+            Score::new(passed / reports.len() as f64)
+        }
+        fn discrimination(
+            &self,
+            _ranked: &[choreo_core::entities::RankedOutcome],
+        ) -> Option<choreo_core::value_objects::Discrimination> {
+            Some(choreo_core::value_objects::Discrimination::Reranked)
+        }
+    }
+
     #[derive(Default)]
     struct NullStats;
     #[async_trait]
@@ -781,7 +809,7 @@ mod tests {
     // --- Metrics ----------------------------------------------------------
 
     use choreo_core::ports::{MetricsRecorderPort, NoopMetricsRecorder};
-    use choreo_core::value_objects::{DeliberationOutcome, DurationMs};
+    use choreo_core::value_objects::{DeliberationOutcome, Discrimination, DurationMs};
 
     /// Captures every observation so tests can assert what the use case
     /// recorded, keyed by specialty.
@@ -790,6 +818,7 @@ mod tests {
         durations: Mutex<Vec<(String, u64)>>,
         outcomes: Mutex<Vec<(String, &'static str)>>,
         winner_scores: Mutex<Vec<(String, f64)>>,
+        discriminations: Mutex<Vec<(String, &'static str)>>,
     }
     impl MetricsRecorderPort for RecordingMetrics {
         fn observe_deliberation_duration(&self, specialty: &Specialty, duration: DurationMs) {
@@ -845,6 +874,12 @@ mod tests {
         }
         fn inc_provider_in_flight(&self, _provider: &str) {}
         fn dec_provider_in_flight(&self, _provider: &str) {}
+        fn record_discrimination(&self, specialty: &Specialty, result: Discrimination) {
+            self.discriminations
+                .lock()
+                .unwrap()
+                .push((specialty.as_str().to_owned(), result.as_label()));
+        }
     }
 
     // --- Fixture helpers --------------------------------------------------
@@ -1603,5 +1638,39 @@ mod tests {
         );
         assert!(metrics.winner_scores.lock().unwrap().is_empty());
         assert_eq!(metrics.durations.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn records_the_scoring_policys_discrimination() {
+        let council = council_with(&["a1", "a2"]);
+        let sp = specialty();
+        let agents: Vec<Arc<dyn AgentPort>> = vec![
+            StubAgent::new("a1", &sp, "a valid proposal", vec![]) as Arc<dyn AgentPort>,
+            StubAgent::new("a2", &sp, "another valid proposal", vec![]) as Arc<dyn AgentPort>,
+        ];
+        let metrics = Arc::new(RecordingMetrics::default());
+        let (usecase, _repo, _bus) = build_usecase(
+            agents,
+            council,
+            Arc::new(RerankingScoring),
+            vec![Arc::new(ContentLengthValidator)],
+            metrics.clone(),
+        );
+
+        usecase
+            .execute(task(TaskConstraints::new(
+                Rubric::empty(),
+                Rounds::new(0).unwrap(),
+                None,
+                None,
+            )))
+            .await
+            .unwrap();
+
+        // The use case forwarded the policy's discrimination verdict.
+        assert_eq!(
+            metrics.discriminations.lock().unwrap().as_slice(),
+            &[("reviewer".to_owned(), "reranked")]
+        );
     }
 }

--- a/crates/choreo-core/src/entities/deliberation.rs
+++ b/crates/choreo-core/src/entities/deliberation.rs
@@ -74,6 +74,18 @@ pub struct RankedOutcome {
 }
 
 impl RankedOutcome {
+    /// Pair a proposal with its validation outcome and a rank. The real
+    /// ranking is produced by [`Deliberation::complete`]; this constructor
+    /// also lets scoring policies and tests assemble outcomes directly.
+    #[must_use]
+    pub fn new(proposal: Proposal, outcome: ValidationOutcome, rank: u32) -> Self {
+        Self {
+            proposal,
+            outcome,
+            rank,
+        }
+    }
+
     #[must_use]
     pub fn proposal(&self) -> &Proposal {
         &self.proposal

--- a/crates/choreo-core/src/ports/metrics_recorder.rs
+++ b/crates/choreo-core/src/ports/metrics_recorder.rs
@@ -19,7 +19,7 @@
 //! [`StatisticsPort`]: super::StatisticsPort
 
 use crate::value_objects::{
-    DeliberationOutcome, DurationMs, LlmErrorKind, Score, Specialty, TokenUsage,
+    DeliberationOutcome, Discrimination, DurationMs, LlmErrorKind, Score, Specialty, TokenUsage,
 };
 
 pub trait MetricsRecorderPort: Send + Sync {
@@ -77,6 +77,12 @@ pub trait MetricsRecorderPort: Send + Sync {
     /// Decrement the in-flight gauge for `provider` when a call returns,
     /// whether it succeeded or failed.
     fn dec_provider_in_flight(&self, provider: &str);
+
+    /// Record whether the scoring policy re-ranked the winner of a
+    /// deliberation. The killer signal for the LLM judge's worth: a
+    /// `reranked` ratio near zero means the judge never changes the
+    /// outcome and is pure cost.
+    fn record_discrimination(&self, specialty: &Specialty, result: Discrimination);
 }
 
 /// A [`MetricsRecorderPort`] that discards every observation.
@@ -101,4 +107,5 @@ impl MetricsRecorderPort for NoopMetricsRecorder {
     fn observe_provider_request(&self, _provider: &str, _operation: &str, _duration: DurationMs) {}
     fn inc_provider_in_flight(&self, _provider: &str) {}
     fn dec_provider_in_flight(&self, _provider: &str) {}
+    fn record_discrimination(&self, _specialty: &Specialty, _result: Discrimination) {}
 }

--- a/crates/choreo-core/src/ports/scoring.rs
+++ b/crates/choreo-core/src/ports/scoring.rs
@@ -7,12 +7,25 @@
 
 use async_trait::async_trait;
 
-use crate::entities::ValidatorReport;
+use crate::entities::{RankedOutcome, ValidatorReport};
 use crate::error::DomainError;
-use crate::value_objects::Score;
+use crate::value_objects::{Discrimination, Score};
 
 #[async_trait]
 pub trait ScoringPort: Send + Sync {
     /// Combine a list of validator reports into a single score.
     async fn score(&self, reports: &[ValidatorReport]) -> Result<Score, DomainError>;
+
+    /// Report whether this policy's ranking re-ordered the winner relative
+    /// to a structural baseline — the basis for the judge-discrimination
+    /// metric. `ranked` is the policy's final ranking (score-descending).
+    ///
+    /// The default is `None`: a policy with no notion of a baseline (plain
+    /// pass-fraction scoring) has nothing to discriminate. A judge-aware
+    /// policy overrides this, comparing its winner against the proposal a
+    /// judge-free ranking would have picked. `None` means "do not record",
+    /// keeping the metric specific to policies that add a ranking signal.
+    fn discrimination(&self, _ranked: &[RankedOutcome]) -> Option<Discrimination> {
+        None
+    }
 }

--- a/crates/choreo-core/src/value_objects/discrimination.rs
+++ b/crates/choreo-core/src/value_objects/discrimination.rs
@@ -1,0 +1,44 @@
+//! [`Discrimination`] — whether a scoring policy re-ordered the winner.
+//!
+//! The signal behind the judge-discrimination metric: does the policy's
+//! ranking pick a *different* winner than a structural baseline would, or
+//! does it merely confirm it? A policy that almost never reranks is
+//! expensive dead weight; one that always reranks is doing real work.
+
+/// How a scoring policy's winner compares to the structural baseline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Discrimination {
+    /// The policy picked a different winner than the baseline — it
+    /// changed the outcome.
+    Reranked,
+    /// The policy's winner is the same the baseline would pick.
+    Agreed,
+    /// The top score is shared by more than one proposal — the policy did
+    /// not separate the leaders.
+    Tie,
+}
+
+impl Discrimination {
+    /// Stable, low-cardinality label value for metrics exposition. Part
+    /// of the metric contract; dashboards match on it.
+    #[must_use]
+    pub const fn as_label(self) -> &'static str {
+        match self {
+            Self::Reranked => "reranked",
+            Self::Agreed => "agreed",
+            Self::Tie => "tie",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn labels_are_distinct_and_stable() {
+        assert_eq!(Discrimination::Reranked.as_label(), "reranked");
+        assert_eq!(Discrimination::Agreed.as_label(), "agreed");
+        assert_eq!(Discrimination::Tie.as_label(), "tie");
+    }
+}

--- a/crates/choreo-core/src/value_objects/mod.rs
+++ b/crates/choreo-core/src/value_objects/mod.rs
@@ -9,6 +9,7 @@ mod attributes;
 mod ceremony;
 mod council_selector;
 mod deliberation_outcome;
+mod discrimination;
 mod duration;
 mod ids;
 mod llm_error_kind;
@@ -36,6 +37,7 @@ pub use ceremony::{
 };
 pub use council_selector::CouncilSelector;
 pub use deliberation_outcome::DeliberationOutcome;
+pub use discrimination::Discrimination;
 pub use duration::DurationMs;
 pub use ids::{AgentId, CouncilId, EventId, ProposalId, TaskId};
 pub use llm_error_kind::LlmErrorKind;


### PR DESCRIPTION
Seventh instrumentation slice — the design's **killer metric** (differentiator #1): is the expensive LLM judge changing outcomes, or burning tokens to confirm the first proposal? A near-zero re-rank ratio means the judge is dead weight.

## The coupling, resolved
The hard part was placement: `deliberate.rs` (app layer) is judge-agnostic, but discrimination needs to know which validator is the judge. The clean answer — **tell, don't ask**:

- `ScoringPort` gains `discrimination(&[RankedOutcome]) -> Option<Discrimination>` with a **`None` default**.
- `JudgeAwareScoring` — the adapter that *already* owns the judge contract (the `judge.score` detail key) — computes it.
- `DeliberateUseCase` just calls `self.scoring.discrimination(&ranked)` and records the result.

No app→adapter coupling, and the metric stays judge-specific: `UniformScoring` uses the default `None` and never reports.

## The verdict
Compares the score-ranked top (the judge's pick) against the **structural baseline** — the smallest-id proposal among those passing every *non-judge* report, which is exactly the arbitrary id tie-break the judge is there to replace:
- shared top score → `Tie`
- different winner → `Reranked`
- same winner → `Agreed`

Computed on the pure score order, before the contract-driven valid-first reorder.

## Adds
- `Discrimination` value object (`reranked` / `agreed` / `tie`).
- `choreo_judge_discrimination_total{specialty, result}` — `rate(reranked) / rate(total)` answers the design's question directly.
- `RankedOutcome::new`, so scoring policies and tests can assemble outcomes (the real ranking is still produced by `Deliberation::complete`).

## Validation
On **rust 1.90**: `fmt --check` + `clippy --workspace --all-targets --all-features -D warnings` clean, full unit suite green — **seven** unit tests of the verdict logic (reranked / agreed / tie / no-judge / single-proposal / invalid-baseline / uniform-never-reports), an end-to-end use-case test (the policy's verdict is forwarded and recorded), and the recorder.

With this the design's core metric set (deliberation quality, judge RED + discrimination + cost, provider RED + saturation + cost) is complete. Remaining are the minor infra/ceremony/scoring-mode metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)