### PR TITLE
feat(observability): ceremony run metrics — outcomes, durations, steps

### DIFF
--- a/crates/choreo-adapters/src/agents/judge.rs
+++ b/crates/choreo-adapters/src/agents/judge.rs
@@ -345,6 +345,28 @@ mod tests {
             _result: choreo_core::value_objects::Discrimination,
         ) {
         }
+        fn record_ceremony_outcome(
+            &self,
+            _ceremony: &str,
+            _outcome: choreo_core::value_objects::CeremonyOutcome,
+        ) {
+        }
+        fn observe_ceremony_duration(&self, _ceremony: &str, _duration: DurationMs) {}
+        fn observe_ceremony_step_duration(
+            &self,
+            _ceremony: &str,
+            _step: &str,
+            _duration: DurationMs,
+        ) {
+        }
+        fn record_ceremony_step(
+            &self,
+            _ceremony: &str,
+            _step: &str,
+            _status: choreo_core::value_objects::StepStatus,
+        ) {
+        }
+        fn record_ceremony_transition_blocked(&self, _ceremony: &str, _from_state: &str) {}
     }
 
     fn judge_with(server: &MockServer, metrics: Arc<dyn MetricsRecorderPort>) -> LlmJudgeValidator {

--- a/crates/choreo-adapters/src/agents/vllm.rs
+++ b/crates/choreo-adapters/src/agents/vllm.rs
@@ -511,6 +511,33 @@ mod tests {
             _result: choreo_core::value_objects::Discrimination,
         ) {
         }
+        fn record_ceremony_outcome(
+            &self,
+            _ceremony: &str,
+            _outcome: choreo_core::value_objects::CeremonyOutcome,
+        ) {
+        }
+        fn observe_ceremony_duration(
+            &self,
+            _ceremony: &str,
+            _duration: choreo_core::value_objects::DurationMs,
+        ) {
+        }
+        fn observe_ceremony_step_duration(
+            &self,
+            _ceremony: &str,
+            _step: &str,
+            _duration: choreo_core::value_objects::DurationMs,
+        ) {
+        }
+        fn record_ceremony_step(
+            &self,
+            _ceremony: &str,
+            _step: &str,
+            _status: choreo_core::value_objects::StepStatus,
+        ) {
+        }
+        fn record_ceremony_transition_blocked(&self, _ceremony: &str, _from_state: &str) {}
     }
 
     fn test_agent_with_bearer(server: &MockServer, token: &str) -> VllmAgent {

--- a/crates/choreo-adapters/src/metrics/prometheus_recorder.rs
+++ b/crates/choreo-adapters/src/metrics/prometheus_recorder.rs
@@ -14,7 +14,8 @@
 use choreo_core::error::DomainError;
 use choreo_core::ports::MetricsRecorderPort;
 use choreo_core::value_objects::{
-    DeliberationOutcome, Discrimination, DurationMs, LlmErrorKind, Score, Specialty, TokenUsage,
+    CeremonyOutcome, DeliberationOutcome, Discrimination, DurationMs, LlmErrorKind, Score,
+    Specialty, StepStatus, TokenUsage,
 };
 use prometheus::{
     Encoder, HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec, Opts, Registry, TextEncoder,
@@ -55,6 +56,11 @@ pub struct PrometheusMetricsRecorder {
     provider_request_duration_seconds: HistogramVec,
     provider_in_flight: IntGaugeVec,
     judge_discrimination_total: IntCounterVec,
+    ceremony_completed_total: IntCounterVec,
+    ceremony_duration_seconds: HistogramVec,
+    ceremony_step_duration_seconds: HistogramVec,
+    ceremony_step_total: IntCounterVec,
+    ceremony_transition_blocked_total: IntCounterVec,
 }
 
 impl PrometheusMetricsRecorder {
@@ -65,6 +71,9 @@ impl PrometheusMetricsRecorder {
     /// Returns a [`DomainError::InvariantViolated`] if a metric fails to
     /// register — a duplicate name or malformed label is a wiring bug,
     /// surfaced at composition time rather than silently at runtime.
+    // A flat define-and-register list, one entry per metric family; it
+    // grows by enumeration, not complexity.
+    #[allow(clippy::too_many_lines)]
     pub fn new() -> Result<Self, DomainError> {
         let registry = Registry::new();
         let deliberation_duration_seconds = register_histogram(
@@ -144,6 +153,38 @@ impl PrometheusMetricsRecorder {
             "Whether the scoring policy re-ranked the deliberation winner vs the structural baseline.",
             &["specialty", "result"],
         )?;
+        let ceremony_completed_total = register_counter(
+            &registry,
+            "choreo_ceremony_completed_total",
+            "Ceremony runs that reached a stop, partitioned by terminal outcome.",
+            &["ceremony", "outcome"],
+        )?;
+        let ceremony_duration_seconds = register_histogram(
+            &registry,
+            "choreo_ceremony_duration_seconds",
+            "End-to-end duration of a ceremony run that reached a terminal state.",
+            DURATION_BUCKETS_SECONDS,
+            &["ceremony"],
+        )?;
+        let ceremony_step_duration_seconds = register_histogram(
+            &registry,
+            "choreo_ceremony_step_duration_seconds",
+            "Duration of a single ceremony step.",
+            DURATION_BUCKETS_SECONDS,
+            &["ceremony", "step"],
+        )?;
+        let ceremony_step_total = register_counter(
+            &registry,
+            "choreo_ceremony_step_total",
+            "Ceremony steps that finished, partitioned by step and terminal status.",
+            &["ceremony", "step", "status"],
+        )?;
+        let ceremony_transition_blocked_total = register_counter(
+            &registry,
+            "choreo_ceremony_transition_blocked_total",
+            "Ceremony states from which no transition was satisfiable — a deadlock or missing event.",
+            &["ceremony", "from_state"],
+        )?;
 
         Ok(Self {
             registry,
@@ -159,6 +200,11 @@ impl PrometheusMetricsRecorder {
             provider_request_duration_seconds,
             provider_in_flight,
             judge_discrimination_total,
+            ceremony_completed_total,
+            ceremony_duration_seconds,
+            ceremony_step_duration_seconds,
+            ceremony_step_total,
+            ceremony_transition_blocked_total,
         })
     }
 
@@ -267,6 +313,36 @@ impl MetricsRecorderPort for PrometheusMetricsRecorder {
             .with_label_values(&[specialty.as_str(), result.as_label()])
             .inc();
     }
+
+    fn record_ceremony_outcome(&self, ceremony: &str, outcome: CeremonyOutcome) {
+        self.ceremony_completed_total
+            .with_label_values(&[ceremony, outcome.as_label()])
+            .inc();
+    }
+
+    fn observe_ceremony_duration(&self, ceremony: &str, duration: DurationMs) {
+        self.ceremony_duration_seconds
+            .with_label_values(&[ceremony])
+            .observe(duration.get() as f64 / 1000.0);
+    }
+
+    fn observe_ceremony_step_duration(&self, ceremony: &str, step: &str, duration: DurationMs) {
+        self.ceremony_step_duration_seconds
+            .with_label_values(&[ceremony, step])
+            .observe(duration.get() as f64 / 1000.0);
+    }
+
+    fn record_ceremony_step(&self, ceremony: &str, step: &str, status: StepStatus) {
+        self.ceremony_step_total
+            .with_label_values(&[ceremony, step, status.as_label()])
+            .inc();
+    }
+
+    fn record_ceremony_transition_blocked(&self, ceremony: &str, from_state: &str) {
+        self.ceremony_transition_blocked_total
+            .with_label_values(&[ceremony, from_state])
+            .inc();
+    }
 }
 
 /// Define a labelled histogram, register it on `registry`, and return
@@ -356,6 +432,11 @@ mod tests {
         recorder.observe_provider_request("vllm", "generate", DurationMs::from_millis(1_000));
         recorder.inc_provider_in_flight("vllm");
         recorder.record_discrimination(&specialty(), Discrimination::Reranked);
+        recorder.record_ceremony_outcome("plan", CeremonyOutcome::Completed);
+        recorder.observe_ceremony_duration("plan", DurationMs::from_millis(1_000));
+        recorder.observe_ceremony_step_duration("plan", "frame", DurationMs::from_millis(1_000));
+        recorder.record_ceremony_step("plan", "frame", StepStatus::Completed);
+        recorder.record_ceremony_transition_blocked("plan", "drafting");
 
         let text = recorder.render();
         assert!(text.contains("# TYPE choreo_deliberation_duration_seconds histogram"));
@@ -370,6 +451,28 @@ mod tests {
         assert!(text.contains("# TYPE choreo_provider_request_duration_seconds histogram"));
         assert!(text.contains("# TYPE choreo_provider_in_flight gauge"));
         assert!(text.contains("# TYPE choreo_judge_discrimination_total counter"));
+        assert!(text.contains("# TYPE choreo_ceremony_completed_total counter"));
+        assert!(text.contains("# TYPE choreo_ceremony_duration_seconds histogram"));
+        assert!(text.contains("# TYPE choreo_ceremony_step_duration_seconds histogram"));
+        assert!(text.contains("# TYPE choreo_ceremony_step_total counter"));
+        assert!(text.contains("# TYPE choreo_ceremony_transition_blocked_total counter"));
+    }
+
+    #[test]
+    fn records_ceremony_outcome_and_step_status() {
+        let recorder = PrometheusMetricsRecorder::new().unwrap();
+        recorder.record_ceremony_outcome("engineering_planning", CeremonyOutcome::StepFailed);
+        recorder.record_ceremony_step("engineering_planning", "design", StepStatus::Failed);
+        recorder.record_ceremony_transition_blocked("engineering_planning", "review");
+
+        let text = recorder.render();
+        assert!(text.contains(
+            "choreo_ceremony_completed_total{ceremony=\"engineering_planning\",outcome=\"step_failed\"} 1"
+        ));
+        assert!(text.contains("status=\"failed\""));
+        assert!(text.contains(
+            "choreo_ceremony_transition_blocked_total{ceremony=\"engineering_planning\",from_state=\"review\"} 1"
+        ));
     }
 
     #[test]

--- a/crates/choreo-app/src/usecases/deliberate.rs
+++ b/crates/choreo-app/src/usecases/deliberate.rs
@@ -880,6 +880,28 @@ mod tests {
                 .unwrap()
                 .push((specialty.as_str().to_owned(), result.as_label()));
         }
+        fn record_ceremony_outcome(
+            &self,
+            _ceremony: &str,
+            _outcome: choreo_core::value_objects::CeremonyOutcome,
+        ) {
+        }
+        fn observe_ceremony_duration(&self, _ceremony: &str, _duration: DurationMs) {}
+        fn observe_ceremony_step_duration(
+            &self,
+            _ceremony: &str,
+            _step: &str,
+            _duration: DurationMs,
+        ) {
+        }
+        fn record_ceremony_step(
+            &self,
+            _ceremony: &str,
+            _step: &str,
+            _status: choreo_core::value_objects::StepStatus,
+        ) {
+        }
+        fn record_ceremony_transition_blocked(&self, _ceremony: &str, _from_state: &str) {}
     }
 
     // --- Fixture helpers --------------------------------------------------

--- a/crates/choreo-app/src/usecases/run_ceremony_use_case.rs
+++ b/crates/choreo-app/src/usecases/run_ceremony_use_case.rs
@@ -6,16 +6,24 @@ use choreo_core::entities::{CeremonyDefinition, CeremonyInstance};
 use choreo_core::error::DomainError;
 use choreo_core::ports::{
     CeremonyContextStorePort, CeremonyDefinitionRepositoryPort, CeremonyInstanceRepositoryPort,
-    CeremonyStepHandlerPort, CeremonyStepHandlerRequest, ClockPort,
+    CeremonyStepHandlerPort, CeremonyStepHandlerRequest, ClockPort, MetricsRecorderPort,
+    NoopMetricsRecorder,
 };
 use choreo_core::value_objects::{
-    CeremonyStepContribution, CeremonyTranscript, DurationMs, IdempotencyKey, LeaseOwnerId, RoleId,
-    StepAttempt, StepErrorMessage, StepId, StepLease, StepResult,
+    CeremonyOutcome, CeremonyStepContribution, CeremonyTranscript, DurationMs, IdempotencyKey,
+    LeaseOwnerId, RoleId, StepAttempt, StepErrorMessage, StepId, StepLease, StepResult,
 };
+use time::OffsetDateTime;
 
 use super::ceremony_step_trace::CeremonyStepTrace;
 use super::run_ceremony_input::RunCeremonyInput;
 use super::run_ceremony_output::RunCeremonyOutput;
+
+/// Whole-millisecond duration between two clock readings, saturating at
+/// zero so a non-monotonic clock can never produce a negative latency.
+fn ms_since(start: OffsetDateTime, end: OffsetDateTime) -> DurationMs {
+    DurationMs::from_millis(u64::try_from((end - start).whole_milliseconds()).unwrap_or(0))
+}
 
 pub struct RunCeremonyUseCase {
     definitions: Arc<dyn CeremonyDefinitionRepositoryPort>,
@@ -23,6 +31,7 @@ pub struct RunCeremonyUseCase {
     handler: Arc<dyn CeremonyStepHandlerPort>,
     context_store: Arc<dyn CeremonyContextStorePort>,
     clock: Arc<dyn ClockPort>,
+    metrics: Arc<dyn MetricsRecorderPort>,
 }
 
 impl std::fmt::Debug for RunCeremonyUseCase {
@@ -46,9 +55,22 @@ impl RunCeremonyUseCase {
             handler,
             context_store,
             clock,
+            metrics: Arc::new(NoopMetricsRecorder),
         }
     }
 
+    /// Attach a metrics recorder so ceremony outcomes, durations and step
+    /// status are counted. The composition root wires the real recorder;
+    /// the default no-op keeps tests and bespoke uses free of one.
+    #[must_use]
+    pub fn with_metrics(mut self, metrics: Arc<dyn MetricsRecorderPort>) -> Self {
+        self.metrics = metrics;
+        self
+    }
+
+    // The ceremony driver is one cohesive FSM loop; splitting it would
+    // scatter the state-machine logic and its interleaved instrumentation.
+    #[allow(clippy::too_many_lines)]
     #[tracing::instrument(
         name = "run_ceremony",
         skip_all,
@@ -56,15 +78,18 @@ impl RunCeremonyUseCase {
     )]
     pub async fn execute(&self, input: RunCeremonyInput) -> Result<RunCeremonyOutput, DomainError> {
         let (id, definition, context, lease_owner_id, lease_ttl) = input.into_parts();
+        let ceremony_name = definition.name().as_str().to_owned();
         if self.instances.exists(&id).await? {
+            self.metrics
+                .record_ceremony_outcome(&ceremony_name, CeremonyOutcome::AlreadyExists);
             return Err(DomainError::AlreadyExists {
                 what: "ceremony_instance",
             });
         }
         self.definitions.save(&definition).await?;
 
-        let mut instance =
-            CeremonyInstance::start(id.clone(), &definition, context, self.clock.now());
+        let started_at = self.clock.now();
+        let mut instance = CeremonyInstance::start(id.clone(), &definition, context, started_at);
         self.instances.save(&instance).await?;
 
         let max_iterations = definition
@@ -75,6 +100,12 @@ impl RunCeremonyUseCase {
         let mut step_traces = Vec::new();
         for _ in 0..max_iterations {
             if instance.is_completed(&definition) {
+                self.metrics.observe_ceremony_duration(
+                    &ceremony_name,
+                    ms_since(started_at, self.clock.now()),
+                );
+                self.metrics
+                    .record_ceremony_outcome(&ceremony_name, CeremonyOutcome::Completed);
                 return Ok(RunCeremonyOutput::new(definition, instance, step_traces));
             }
 
@@ -92,6 +123,7 @@ impl RunCeremonyUseCase {
                 }
                 let role_id = definition.role_id_for_step(&step_id)?;
                 let transcript = self.context_store.transcript(&id).await?;
+                let step_started = self.clock.now();
                 let (attempt, step_result) = self
                     .run_step(
                         &definition,
@@ -104,6 +136,16 @@ impl RunCeremonyUseCase {
                         transcript,
                     )
                     .await?;
+                self.metrics.observe_ceremony_step_duration(
+                    &ceremony_name,
+                    step_id.as_str(),
+                    ms_since(step_started, self.clock.now()),
+                );
+                self.metrics.record_ceremony_step(
+                    &ceremony_name,
+                    step_id.as_str(),
+                    step_result.status(),
+                );
                 if step_result.is_success() {
                     self.context_store
                         .append(
@@ -125,6 +167,8 @@ impl RunCeremonyUseCase {
                     step_result.output().clone(),
                 ));
                 if !step_result.is_success() {
+                    self.metrics
+                        .record_ceremony_outcome(&ceremony_name, CeremonyOutcome::StepFailed);
                     return Err(DomainError::InvariantViolated {
                         reason: "ceremony step did not complete successfully",
                     });
@@ -132,13 +176,27 @@ impl RunCeremonyUseCase {
             }
 
             if instance.is_completed(&definition) {
+                self.metrics.observe_ceremony_duration(
+                    &ceremony_name,
+                    ms_since(started_at, self.clock.now()),
+                );
+                self.metrics
+                    .record_ceremony_outcome(&ceremony_name, CeremonyOutcome::Completed);
                 return Ok(RunCeremonyOutput::new(definition, instance, step_traces));
             }
-            let transition = definition
-                .next_satisfied_transition(&state_id, instance.step_records(), instance.context())
-                .ok_or(DomainError::InvariantViolated {
+            let Some(transition) = definition.next_satisfied_transition(
+                &state_id,
+                instance.step_records(),
+                instance.context(),
+            ) else {
+                self.metrics
+                    .record_ceremony_transition_blocked(&ceremony_name, state_id.as_str());
+                self.metrics
+                    .record_ceremony_outcome(&ceremony_name, CeremonyOutcome::NoTransition);
+                return Err(DomainError::InvariantViolated {
                     reason: "no satisfied ceremony transition is available",
-                })?;
+                });
+            };
             let role_id = definition.role_id_for_transition(transition.trigger())?;
             instance.apply_transition_as(
                 &definition,
@@ -149,6 +207,8 @@ impl RunCeremonyUseCase {
             self.instances.save(&instance).await?;
         }
 
+        self.metrics
+            .record_ceremony_outcome(&ceremony_name, CeremonyOutcome::IterationLimit);
         Err(DomainError::InvariantViolated {
             reason: "ceremony execution exceeded transition safety limit",
         })

--- a/crates/choreo-core/src/ports/metrics_recorder.rs
+++ b/crates/choreo-core/src/ports/metrics_recorder.rs
@@ -19,7 +19,8 @@
 //! [`StatisticsPort`]: super::StatisticsPort
 
 use crate::value_objects::{
-    DeliberationOutcome, Discrimination, DurationMs, LlmErrorKind, Score, Specialty, TokenUsage,
+    CeremonyOutcome, DeliberationOutcome, Discrimination, DurationMs, LlmErrorKind, Score,
+    Specialty, StepStatus, TokenUsage,
 };
 
 pub trait MetricsRecorderPort: Send + Sync {
@@ -83,6 +84,27 @@ pub trait MetricsRecorderPort: Send + Sync {
     /// `reranked` ratio near zero means the judge never changes the
     /// outcome and is pure cost.
     fn record_discrimination(&self, specialty: &Specialty, result: Discrimination);
+
+    /// Record the terminal outcome of a ceremony run, by definition name —
+    /// the completion-rate and failure-mode split per ceremony type.
+    fn record_ceremony_outcome(&self, ceremony: &str, outcome: CeremonyOutcome);
+
+    /// Observe the end-to-end duration of a ceremony run that reached a
+    /// terminal state.
+    fn observe_ceremony_duration(&self, ceremony: &str, duration: DurationMs);
+
+    /// Observe the duration of a single ceremony step — slow-step
+    /// isolation within a ceremony.
+    fn observe_ceremony_step_duration(&self, ceremony: &str, step: &str, duration: DurationMs);
+
+    /// Record that a ceremony step finished with `status` — per-step volume
+    /// and the failure split.
+    fn record_ceremony_step(&self, ceremony: &str, step: &str, status: StepStatus);
+
+    /// Record that no transition out of `from_state` was satisfiable — a
+    /// guard deadlock or a missing event, distinct from a normal pending
+    /// wait.
+    fn record_ceremony_transition_blocked(&self, ceremony: &str, from_state: &str);
 }
 
 /// A [`MetricsRecorderPort`] that discards every observation.
@@ -108,4 +130,9 @@ impl MetricsRecorderPort for NoopMetricsRecorder {
     fn inc_provider_in_flight(&self, _provider: &str) {}
     fn dec_provider_in_flight(&self, _provider: &str) {}
     fn record_discrimination(&self, _specialty: &Specialty, _result: Discrimination) {}
+    fn record_ceremony_outcome(&self, _ceremony: &str, _outcome: CeremonyOutcome) {}
+    fn observe_ceremony_duration(&self, _ceremony: &str, _duration: DurationMs) {}
+    fn observe_ceremony_step_duration(&self, _ceremony: &str, _step: &str, _duration: DurationMs) {}
+    fn record_ceremony_step(&self, _ceremony: &str, _step: &str, _status: StepStatus) {}
+    fn record_ceremony_transition_blocked(&self, _ceremony: &str, _from_state: &str) {}
 }

--- a/crates/choreo-core/src/value_objects/ceremony/step_status.rs
+++ b/crates/choreo-core/src/value_objects/ceremony/step_status.rs
@@ -28,6 +28,19 @@ impl StepStatus {
     pub fn is_success(self) -> bool {
         self == Self::Completed
     }
+
+    /// Stable, low-cardinality label value for metrics exposition.
+    #[must_use]
+    pub const fn as_label(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::InProgress => "in_progress",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::WaitingForHuman => "waiting_for_human",
+            Self::Cancelled => "cancelled",
+        }
+    }
 }
 
 impl TryFrom<&str> for StepStatus {

--- a/crates/choreo-core/src/value_objects/ceremony_outcome.rs
+++ b/crates/choreo-core/src/value_objects/ceremony_outcome.rs
@@ -1,0 +1,59 @@
+//! [`CeremonyOutcome`] — the terminal result of a ceremony run.
+//!
+//! A ceremony driven to a stop ends in exactly one of these. Unlike a
+//! step's [`StepStatus`](super::StepStatus), this names *why the whole
+//! ceremony stopped*: it completed, a step failed, no transition could
+//! fire, the safety iteration cap was hit, or the instance already
+//! existed. Adapter-shaped aborts (persistence/transport errors) are not
+//! outcomes — they surface as errors, not as a recorded end-state.
+
+/// How a ceremony run terminated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CeremonyOutcome {
+    /// Reached a terminal state — the ceremony finished.
+    Completed,
+    /// A step did not complete successfully and aborted the run.
+    StepFailed,
+    /// No transition out of the current state was satisfiable (a guard
+    /// deadlock or a missing event).
+    NoTransition,
+    /// The transition safety cap was hit without reaching a terminal
+    /// state.
+    IterationLimit,
+    /// An instance with the same id already existed; the run was rejected.
+    AlreadyExists,
+}
+
+impl CeremonyOutcome {
+    /// Stable, low-cardinality label value for metrics exposition. Part of
+    /// the metric contract; dashboards and alerts match on it.
+    #[must_use]
+    pub const fn as_label(self) -> &'static str {
+        match self {
+            Self::Completed => "completed",
+            Self::StepFailed => "step_failed",
+            Self::NoTransition => "no_transition",
+            Self::IterationLimit => "iteration_limit",
+            Self::AlreadyExists => "already_exists",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn labels_are_distinct_and_stable() {
+        let all = [
+            CeremonyOutcome::Completed,
+            CeremonyOutcome::StepFailed,
+            CeremonyOutcome::NoTransition,
+            CeremonyOutcome::IterationLimit,
+            CeremonyOutcome::AlreadyExists,
+        ];
+        let labels: std::collections::BTreeSet<&str> =
+            all.iter().map(|outcome| outcome.as_label()).collect();
+        assert_eq!(labels.len(), all.len());
+    }
+}

--- a/crates/choreo-core/src/value_objects/mod.rs
+++ b/crates/choreo-core/src/value_objects/mod.rs
@@ -7,6 +7,7 @@
 mod agent_kind;
 mod attributes;
 mod ceremony;
+mod ceremony_outcome;
 mod council_selector;
 mod deliberation_outcome;
 mod discrimination;
@@ -35,6 +36,7 @@ pub use ceremony::{
     StepErrorMessage, StepExecutionRecord, StepHandlerConfig, StepHandlerKind, StepId, StepLease,
     StepOutput, StepResult, StepStatus, StepTimeout, TransitionTrigger,
 };
+pub use ceremony_outcome::CeremonyOutcome;
 pub use council_selector::CouncilSelector;
 pub use deliberation_outcome::DeliberationOutcome;
 pub use discrimination::Discrimination;

--- a/crates/choreo/src/compose.rs
+++ b/crates/choreo/src/compose.rs
@@ -212,13 +212,16 @@ pub async fn compose() -> Result<Application, ComposeError> {
         deliberate.clone(),
         repository.clone(),
     ));
-    let run_ceremony = Arc::new(RunCeremonyUseCase::new(
-        ceremony_definitions,
-        ceremony_instances,
-        ceremony_step_handler,
-        ceremony_context_store,
-        clock.clone(),
-    ));
+    let run_ceremony = Arc::new(
+        RunCeremonyUseCase::new(
+            ceremony_definitions,
+            ceremony_instances,
+            ceremony_step_handler,
+            ceremony_context_store,
+            clock.clone(),
+        )
+        .with_metrics(metrics_recorder.clone()),
+    );
 
     let create_council = Arc::new(CreateCouncilUseCase::new(
         clock.clone(),


### PR DESCRIPTION
Eighth instrumentation slice — makes the **ceremony engine** observable like deliberations. Ceremonies are the second major flow (the multi-step, role-structured "meeting" runner — the drone-planning engine from the article), and were a metrics blind spot.

## Metrics (recorded in `RunCeremonyUseCase::execute`)
| Metric | Type | Labels |
|---|---|---|
| `choreo_ceremony_completed_total` | counter | `ceremony`, `outcome` |
| `choreo_ceremony_duration_seconds` | histogram | `ceremony` |
| `choreo_ceremony_step_duration_seconds` | histogram | `ceremony`, `step` |
| `choreo_ceremony_step_total` | counter | `ceremony`, `step`, `status` |
| `choreo_ceremony_transition_blocked_total` | counter | `ceremony`, `from_state` |

`outcome` ∈ `completed` / `step_failed` / `no_transition` / `iteration_limit` / `already_exists`, recorded at each terminal return point of the FSM driver. `transition_blocked` (a `let-else` on the unsatisfiable transition) distinguishes a guard **deadlock** from a normal pending wait.

## Design
- New `CeremonyOutcome` value object and `StepStatus::as_label`.
- Threaded via the `with_metrics` builder — only the composition root opts in; the six test/fixture constructors keep their signatures.
- `ceremony` = definition name (bounded), `step` = step id (bounded per definition). **No instance ids as labels.**

## Validation
On **rust 1.90**: `fmt --check` + `clippy --workspace --all-targets --all-features -D warnings` clean, full unit suite green (recorder unit tests + the six existing flow tests that drive `execute` through every terminal path). Two `#[allow(clippy::too_many_lines)]` — on the cohesive FSM driver and the flat metric-registration list — both long by enumeration, not complexity, matching the existing `compose` precedent.

With this, both major flows (deliberations and ceremonies) are fully instrumented. Remaining minors: infra RED (gRPC/postgres/NATS) and scoring-mode integrity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)