### PR TITLE
feat(observability): NATS publish latency + error metrics

### DIFF
--- a/crates/choreo-adapters/src/agents/judge.rs
+++ b/crates/choreo-adapters/src/agents/judge.rs
@@ -367,6 +367,8 @@ mod tests {
         ) {
         }
         fn record_ceremony_transition_blocked(&self, _ceremony: &str, _from_state: &str) {}
+        fn observe_nats_publish(&self, _subject_kind: &str, _duration: DurationMs) {}
+        fn record_nats_publish_error(&self, _subject_kind: &str, _reason: &str) {}
     }
 
     fn judge_with(server: &MockServer, metrics: Arc<dyn MetricsRecorderPort>) -> LlmJudgeValidator {

--- a/crates/choreo-adapters/src/agents/vllm.rs
+++ b/crates/choreo-adapters/src/agents/vllm.rs
@@ -538,6 +538,13 @@ mod tests {
         ) {
         }
         fn record_ceremony_transition_blocked(&self, _ceremony: &str, _from_state: &str) {}
+        fn observe_nats_publish(
+            &self,
+            _subject_kind: &str,
+            _duration: choreo_core::value_objects::DurationMs,
+        ) {
+        }
+        fn record_nats_publish_error(&self, _subject_kind: &str, _reason: &str) {}
     }
 
     fn test_agent_with_bearer(server: &MockServer, token: &str) -> VllmAgent {

--- a/crates/choreo-adapters/src/metrics/prometheus_recorder.rs
+++ b/crates/choreo-adapters/src/metrics/prometheus_recorder.rs
@@ -42,6 +42,11 @@ const PROVIDER_LATENCY_BUCKETS_SECONDS: &[f64] = &[
     0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 30.0, 45.0, 60.0, 90.0, 120.0,
 ];
 
+/// Latency buckets (seconds) for a NATS publish — a fast in-cluster
+/// operation, so the range is sub-second-weighted.
+const NATS_PUBLISH_BUCKETS_SECONDS: &[f64] =
+    &[0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5];
+
 pub struct PrometheusMetricsRecorder {
     registry: Registry,
     deliberation_duration_seconds: HistogramVec,
@@ -61,6 +66,8 @@ pub struct PrometheusMetricsRecorder {
     ceremony_step_duration_seconds: HistogramVec,
     ceremony_step_total: IntCounterVec,
     ceremony_transition_blocked_total: IntCounterVec,
+    nats_publish_duration_seconds: HistogramVec,
+    nats_publish_errors_total: IntCounterVec,
 }
 
 impl PrometheusMetricsRecorder {
@@ -185,6 +192,19 @@ impl PrometheusMetricsRecorder {
             "Ceremony states from which no transition was satisfiable — a deadlock or missing event.",
             &["ceremony", "from_state"],
         )?;
+        let nats_publish_duration_seconds = register_histogram(
+            &registry,
+            "choreo_nats_publish_duration_seconds",
+            "Latency of a NATS publish, by event subject kind.",
+            NATS_PUBLISH_BUCKETS_SECONDS,
+            &["subject_kind"],
+        )?;
+        let nats_publish_errors_total = register_counter(
+            &registry,
+            "choreo_nats_publish_errors_total",
+            "Failed NATS publishes, by subject kind and reason.",
+            &["subject_kind", "reason"],
+        )?;
 
         Ok(Self {
             registry,
@@ -205,6 +225,8 @@ impl PrometheusMetricsRecorder {
             ceremony_step_duration_seconds,
             ceremony_step_total,
             ceremony_transition_blocked_total,
+            nats_publish_duration_seconds,
+            nats_publish_errors_total,
         })
     }
 
@@ -343,6 +365,18 @@ impl MetricsRecorderPort for PrometheusMetricsRecorder {
             .with_label_values(&[ceremony, from_state])
             .inc();
     }
+
+    fn observe_nats_publish(&self, subject_kind: &str, duration: DurationMs) {
+        self.nats_publish_duration_seconds
+            .with_label_values(&[subject_kind])
+            .observe(duration.get() as f64 / 1000.0);
+    }
+
+    fn record_nats_publish_error(&self, subject_kind: &str, reason: &str) {
+        self.nats_publish_errors_total
+            .with_label_values(&[subject_kind, reason])
+            .inc();
+    }
 }
 
 /// Define a labelled histogram, register it on `registry`, and return
@@ -437,6 +471,8 @@ mod tests {
         recorder.observe_ceremony_step_duration("plan", "frame", DurationMs::from_millis(1_000));
         recorder.record_ceremony_step("plan", "frame", StepStatus::Completed);
         recorder.record_ceremony_transition_blocked("plan", "drafting");
+        recorder.observe_nats_publish("deliberation_completed", DurationMs::from_millis(5));
+        recorder.record_nats_publish_error("deliberation_completed", "publish");
 
         let text = recorder.render();
         assert!(text.contains("# TYPE choreo_deliberation_duration_seconds histogram"));
@@ -456,6 +492,24 @@ mod tests {
         assert!(text.contains("# TYPE choreo_ceremony_step_duration_seconds histogram"));
         assert!(text.contains("# TYPE choreo_ceremony_step_total counter"));
         assert!(text.contains("# TYPE choreo_ceremony_transition_blocked_total counter"));
+        assert!(text.contains("# TYPE choreo_nats_publish_duration_seconds histogram"));
+        assert!(text.contains("# TYPE choreo_nats_publish_errors_total counter"));
+    }
+
+    #[test]
+    fn records_nats_publish_errors_by_subject_and_reason() {
+        let recorder = PrometheusMetricsRecorder::new().unwrap();
+        recorder.record_nats_publish_error("deliberation_completed", "publish");
+        recorder.record_nats_publish_error("deliberation_completed", "publish");
+        recorder.record_nats_publish_error("task_dispatched", "serialize");
+
+        let text = recorder.render();
+        assert!(text.contains(
+            "choreo_nats_publish_errors_total{reason=\"publish\",subject_kind=\"deliberation_completed\"} 2"
+        ));
+        assert!(text.contains(
+            "choreo_nats_publish_errors_total{reason=\"serialize\",subject_kind=\"task_dispatched\"} 1"
+        ));
     }
 
     #[test]

--- a/crates/choreo-adapters/src/nats/messaging.rs
+++ b/crates/choreo-adapters/src/nats/messaging.rs
@@ -13,6 +13,9 @@
 //! this crate reads the same header back and surfaces it as span
 //! fields on `nats.trigger.inbound`.
 
+use std::sync::Arc;
+use std::time::Instant;
+
 use async_nats::{header::HeaderMap, Client};
 use async_trait::async_trait;
 use choreo_core::error::DomainError;
@@ -20,8 +23,8 @@ use choreo_core::events::{
     DeliberationCompletedEvent, PhaseChangedEvent, TaskCompletedEvent, TaskDispatchedEvent,
     TaskFailedEvent,
 };
-use choreo_core::ports::MessagingPort;
-use choreo_core::value_objects::TraceContext;
+use choreo_core::ports::{MessagingPort, MetricsRecorderPort, NoopMetricsRecorder};
+use choreo_core::value_objects::{DurationMs, TraceContext};
 use serde::Serialize;
 use tracing::debug;
 
@@ -38,6 +41,7 @@ pub(super) const TRACEPARENT_HEADER: &str = "traceparent";
 pub struct NatsMessaging {
     client: Client,
     subjects: NatsSubjects,
+    metrics: Arc<dyn MetricsRecorderPort>,
 }
 
 impl std::fmt::Debug for NatsMessaging {
@@ -51,15 +55,31 @@ impl std::fmt::Debug for NatsMessaging {
 impl NatsMessaging {
     #[must_use]
     pub fn new(client: Client, subjects: NatsSubjects) -> Self {
-        Self { client, subjects }
+        Self {
+            client,
+            subjects,
+            metrics: Arc::new(NoopMetricsRecorder),
+        }
+    }
+
+    /// Attach a metrics recorder so publish latency and failures are
+    /// counted. The composition root wires the real recorder; the default
+    /// no-op keeps tests free of one.
+    #[must_use]
+    pub fn with_metrics(mut self, metrics: Arc<dyn MetricsRecorderPort>) -> Self {
+        self.metrics = metrics;
+        self
     }
 
     async fn publish_event<E: Serialize>(
         &self,
+        subject_kind: &'static str,
         subject: &str,
         event: &E,
     ) -> Result<(), DomainError> {
         let payload = serde_json::to_vec(event).map_err(|err| {
+            self.metrics
+                .record_nats_publish_error(subject_kind, "serialize");
             debug!(error = %err, "nats payload encoding failed");
             DomainError::InvariantViolated {
                 reason: "nats: failed to serialize outbound event",
@@ -68,15 +88,23 @@ impl NatsMessaging {
         let trace = TraceContext::generate();
         let mut headers = HeaderMap::new();
         headers.insert(TRACEPARENT_HEADER, trace.to_header().as_str());
-        self.client
+        let started = Instant::now();
+        let result = self
+            .client
             .publish_with_headers(subject.to_owned(), headers, payload.into())
-            .await
-            .map_err(|err| {
-                debug!(error = %err, subject, "nats publish failed");
-                DomainError::InvariantViolated {
-                    reason: "nats: publish failed",
-                }
-            })?;
+            .await;
+        self.metrics.observe_nats_publish(
+            subject_kind,
+            DurationMs::from_millis(u64::try_from(started.elapsed().as_millis()).unwrap_or(0)),
+        );
+        result.map_err(|err| {
+            self.metrics
+                .record_nats_publish_error(subject_kind, "publish");
+            debug!(error = %err, subject, "nats publish failed");
+            DomainError::InvariantViolated {
+                reason: "nats: publish failed",
+            }
+        })?;
         debug!(subject, trace_id = trace.trace_id(), "nats event published");
         Ok(())
     }
@@ -88,29 +116,34 @@ impl MessagingPort for NatsMessaging {
         &self,
         event: &TaskDispatchedEvent,
     ) -> Result<(), DomainError> {
-        self.publish_event(&self.subjects.task_dispatched, event)
+        self.publish_event("task_dispatched", &self.subjects.task_dispatched, event)
             .await
     }
 
     async fn publish_task_completed(&self, event: &TaskCompletedEvent) -> Result<(), DomainError> {
-        self.publish_event(&self.subjects.task_completed, event)
+        self.publish_event("task_completed", &self.subjects.task_completed, event)
             .await
     }
 
     async fn publish_task_failed(&self, event: &TaskFailedEvent) -> Result<(), DomainError> {
-        self.publish_event(&self.subjects.task_failed, event).await
+        self.publish_event("task_failed", &self.subjects.task_failed, event)
+            .await
     }
 
     async fn publish_deliberation_completed(
         &self,
         event: &DeliberationCompletedEvent,
     ) -> Result<(), DomainError> {
-        self.publish_event(&self.subjects.deliberation_completed, event)
-            .await
+        self.publish_event(
+            "deliberation_completed",
+            &self.subjects.deliberation_completed,
+            event,
+        )
+        .await
     }
 
     async fn publish_phase_changed(&self, event: &PhaseChangedEvent) -> Result<(), DomainError> {
-        self.publish_event(&self.subjects.phase_changed, event)
+        self.publish_event("phase_changed", &self.subjects.phase_changed, event)
             .await
     }
 }

--- a/crates/choreo-app/src/usecases/deliberate.rs
+++ b/crates/choreo-app/src/usecases/deliberate.rs
@@ -902,6 +902,8 @@ mod tests {
         ) {
         }
         fn record_ceremony_transition_blocked(&self, _ceremony: &str, _from_state: &str) {}
+        fn observe_nats_publish(&self, _subject_kind: &str, _duration: DurationMs) {}
+        fn record_nats_publish_error(&self, _subject_kind: &str, _reason: &str) {}
     }
 
     // --- Fixture helpers --------------------------------------------------

--- a/crates/choreo-core/src/ports/metrics_recorder.rs
+++ b/crates/choreo-core/src/ports/metrics_recorder.rs
@@ -105,6 +105,14 @@ pub trait MetricsRecorderPort: Send + Sync {
     /// guard deadlock or a missing event, distinct from a normal pending
     /// wait.
     fn record_ceremony_transition_blocked(&self, ceremony: &str, from_state: &str);
+
+    /// Observe the latency of one NATS publish, by event `subject_kind`.
+    fn observe_nats_publish(&self, subject_kind: &str, duration: DurationMs);
+
+    /// Record a failed NATS publish, by `subject_kind` and `reason`
+    /// (serialize vs publish). Completion events drive downstream
+    /// orchestration, so a silent publish failure loses work.
+    fn record_nats_publish_error(&self, subject_kind: &str, reason: &str);
 }
 
 /// A [`MetricsRecorderPort`] that discards every observation.
@@ -135,4 +143,6 @@ impl MetricsRecorderPort for NoopMetricsRecorder {
     fn observe_ceremony_step_duration(&self, _ceremony: &str, _step: &str, _duration: DurationMs) {}
     fn record_ceremony_step(&self, _ceremony: &str, _step: &str, _status: StepStatus) {}
     fn record_ceremony_transition_blocked(&self, _ceremony: &str, _from_state: &str) {}
+    fn observe_nats_publish(&self, _subject_kind: &str, _duration: DurationMs) {}
+    fn record_nats_publish_error(&self, _subject_kind: &str, _reason: &str) {}
 }

--- a/crates/choreo/src/compose.rs
+++ b/crates/choreo/src/compose.rs
@@ -179,7 +179,7 @@ pub async fn compose() -> Result<Application, ComposeError> {
         port: messaging,
         subscriber_factory: nats_subscriber_factory,
         nats_client,
-    } = wire_messaging(&service_config).await?;
+    } = wire_messaging(&service_config, metrics_recorder.clone()).await?;
 
     let deliberate = Arc::new(DeliberateUseCase::new(
         clock.clone(),
@@ -370,7 +370,10 @@ struct MessagingWiring {
     nats_client: Option<async_nats::Client>,
 }
 
-async fn wire_messaging(cfg: &ServiceConfig) -> Result<MessagingWiring, ComposeError> {
+async fn wire_messaging(
+    cfg: &ServiceConfig,
+    metrics: Arc<dyn MetricsRecorderPort>,
+) -> Result<MessagingWiring, ComposeError> {
     if !cfg.nats_enabled {
         info!("nats disabled; using noop messaging");
         let port: Arc<dyn MessagingPort> = Arc::new(NoopMessaging::new());
@@ -385,10 +388,9 @@ async fn wire_messaging(cfg: &ServiceConfig) -> Result<MessagingWiring, ComposeE
     let client = connect_nats_with_retry(&nats_cfg.url, NATS_CONNECT_BUDGET).await?;
     info!(url = nats_cfg.url.as_str(), "nats connected");
 
-    let port: Arc<dyn MessagingPort> = Arc::new(NatsMessaging::new(
-        client.clone(),
-        nats_cfg.subjects.clone(),
-    ));
+    let port: Arc<dyn MessagingPort> = Arc::new(
+        NatsMessaging::new(client.clone(), nats_cfg.subjects.clone()).with_metrics(metrics),
+    );
 
     let subjects = nats_cfg.subjects.clone();
     let factory_client = client.clone();


### PR DESCRIPTION
Ninth instrumentation slice — closes a **silent-failure gap** the design called out: NATS publish failures were only `debug!`-logged, so a lost `deliberation_completed` event (and the downstream orchestration it drives) was invisible.

## Metrics
Instruments the single central `publish_event` in `NatsMessaging`:
| Metric | Type | Labels |
|---|---|---|
| `choreo_nats_publish_duration_seconds` | histogram (sub-second buckets) | `subject_kind` |
| `choreo_nats_publish_errors_total` | counter | `subject_kind`, `reason` |

`reason` ∈ `serialize` / `publish` (the two failure sites). The five `publish_*` methods pass their `subject_kind` (`task_dispatched` / `task_completed` / `task_failed` / `deliberation_completed` / `phase_changed`).

## Design
Threaded via the `with_metrics` builder — only `wire_messaging` in the composition root opts in; the two integration-test constructors keep their signatures.

## Validation
On **rust 1.90**: `fmt --check` + `clippy --workspace --all-targets --all-features -D warnings` clean, full unit suite green (recorder unit tests for the new families + error labels; the existing NATS roundtrip integration test drives the instrumented publish path under a real broker).

Remaining infra RED: Postgres (pool gauge + query duration) and the gRPC front-door tower layer (the heavier tonic-middleware piece, needs `grpc-status` trailer extraction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)