### PR TITLE
feat(observability): Postgres pool-in-use gauge

### DIFF
--- a/crates/choreo-adapters/src/agents/judge.rs
+++ b/crates/choreo-adapters/src/agents/judge.rs
@@ -369,6 +369,7 @@ mod tests {
         fn record_ceremony_transition_blocked(&self, _ceremony: &str, _from_state: &str) {}
         fn observe_nats_publish(&self, _subject_kind: &str, _duration: DurationMs) {}
         fn record_nats_publish_error(&self, _subject_kind: &str, _reason: &str) {}
+        fn set_postgres_pool_in_use(&self, _connections: i64) {}
     }
 
     fn judge_with(server: &MockServer, metrics: Arc<dyn MetricsRecorderPort>) -> LlmJudgeValidator {

--- a/crates/choreo-adapters/src/agents/vllm.rs
+++ b/crates/choreo-adapters/src/agents/vllm.rs
@@ -545,6 +545,7 @@ mod tests {
         ) {
         }
         fn record_nats_publish_error(&self, _subject_kind: &str, _reason: &str) {}
+        fn set_postgres_pool_in_use(&self, _connections: i64) {}
     }
 
     fn test_agent_with_bearer(server: &MockServer, token: &str) -> VllmAgent {

--- a/crates/choreo-adapters/src/metrics/prometheus_recorder.rs
+++ b/crates/choreo-adapters/src/metrics/prometheus_recorder.rs
@@ -18,7 +18,8 @@ use choreo_core::value_objects::{
     Specialty, StepStatus, TokenUsage,
 };
 use prometheus::{
-    Encoder, HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec, Opts, Registry, TextEncoder,
+    Encoder, HistogramOpts, HistogramVec, IntCounterVec, IntGauge, IntGaugeVec, Opts, Registry,
+    TextEncoder,
 };
 
 /// Latency buckets (seconds) sized for serialized vLLM deliberations,
@@ -68,6 +69,7 @@ pub struct PrometheusMetricsRecorder {
     ceremony_transition_blocked_total: IntCounterVec,
     nats_publish_duration_seconds: HistogramVec,
     nats_publish_errors_total: IntCounterVec,
+    postgres_pool_in_use: IntGauge,
 }
 
 impl PrometheusMetricsRecorder {
@@ -205,6 +207,14 @@ impl PrometheusMetricsRecorder {
             "Failed NATS publishes, by subject kind and reason.",
             &["subject_kind", "reason"],
         )?;
+        let postgres_pool_in_use = IntGauge::new(
+            "choreo_postgres_pool_in_use",
+            "Connections currently checked out of the Postgres pool.",
+        )
+        .map_err(|err| metrics_error(&err))?;
+        registry
+            .register(Box::new(postgres_pool_in_use.clone()))
+            .map_err(|err| metrics_error(&err))?;
 
         Ok(Self {
             registry,
@@ -227,6 +237,7 @@ impl PrometheusMetricsRecorder {
             ceremony_transition_blocked_total,
             nats_publish_duration_seconds,
             nats_publish_errors_total,
+            postgres_pool_in_use,
         })
     }
 
@@ -377,6 +388,10 @@ impl MetricsRecorderPort for PrometheusMetricsRecorder {
             .with_label_values(&[subject_kind, reason])
             .inc();
     }
+
+    fn set_postgres_pool_in_use(&self, connections: i64) {
+        self.postgres_pool_in_use.set(connections);
+    }
 }
 
 /// Define a labelled histogram, register it on `registry`, and return
@@ -494,6 +509,17 @@ mod tests {
         assert!(text.contains("# TYPE choreo_ceremony_transition_blocked_total counter"));
         assert!(text.contains("# TYPE choreo_nats_publish_duration_seconds histogram"));
         assert!(text.contains("# TYPE choreo_nats_publish_errors_total counter"));
+        // The single label-less pool gauge renders even unset.
+        assert!(text.contains("# TYPE choreo_postgres_pool_in_use gauge"));
+    }
+
+    #[test]
+    fn postgres_pool_gauge_reflects_the_last_set_value() {
+        let recorder = PrometheusMetricsRecorder::new().unwrap();
+        recorder.set_postgres_pool_in_use(7);
+        assert!(recorder.render().contains("choreo_postgres_pool_in_use 7"));
+        recorder.set_postgres_pool_in_use(3);
+        assert!(recorder.render().contains("choreo_postgres_pool_in_use 3"));
     }
 
     #[test]

--- a/crates/choreo-adapters/src/postgres/pool.rs
+++ b/crates/choreo-adapters/src/postgres/pool.rs
@@ -69,6 +69,15 @@ impl PostgresPool {
         &self.inner
     }
 
+    /// Connections currently checked out of the pool — total open minus
+    /// idle. Sampled by the metrics endpoint as the pool-saturation
+    /// signal (the pool has a small max and a short acquire timeout, so
+    /// exhaustion cascades into readiness failures).
+    #[must_use]
+    pub fn in_use(&self) -> u64 {
+        u64::from(self.inner.size()).saturating_sub(self.inner.num_idle() as u64)
+    }
+
     /// Lightweight liveness probe (`SELECT 1`): acquires a connection and
     /// round-trips a trivial query. Used by the readiness endpoint to
     /// detect a database that became unreachable *after* startup

--- a/crates/choreo-app/src/usecases/deliberate.rs
+++ b/crates/choreo-app/src/usecases/deliberate.rs
@@ -904,6 +904,7 @@ mod tests {
         fn record_ceremony_transition_blocked(&self, _ceremony: &str, _from_state: &str) {}
         fn observe_nats_publish(&self, _subject_kind: &str, _duration: DurationMs) {}
         fn record_nats_publish_error(&self, _subject_kind: &str, _reason: &str) {}
+        fn set_postgres_pool_in_use(&self, _connections: i64) {}
     }
 
     // --- Fixture helpers --------------------------------------------------

--- a/crates/choreo-core/src/ports/metrics_recorder.rs
+++ b/crates/choreo-core/src/ports/metrics_recorder.rs
@@ -113,6 +113,11 @@ pub trait MetricsRecorderPort: Send + Sync {
     /// (serialize vs publish). Completion events drive downstream
     /// orchestration, so a silent publish failure loses work.
     fn record_nats_publish_error(&self, subject_kind: &str, reason: &str);
+
+    /// Set the gauge of Postgres connections currently checked out of the
+    /// pool. Sampled at scrape time; saturation here cascades into
+    /// readiness failures, so it is the leading pool-exhaustion signal.
+    fn set_postgres_pool_in_use(&self, connections: i64);
 }
 
 /// A [`MetricsRecorderPort`] that discards every observation.
@@ -145,4 +150,5 @@ impl MetricsRecorderPort for NoopMetricsRecorder {
     fn record_ceremony_transition_blocked(&self, _ceremony: &str, _from_state: &str) {}
     fn observe_nats_publish(&self, _subject_kind: &str, _duration: DurationMs) {}
     fn record_nats_publish_error(&self, _subject_kind: &str, _reason: &str) {}
+    fn set_postgres_pool_in_use(&self, _connections: i64) {}
 }

--- a/crates/choreo/src/health.rs
+++ b/crates/choreo/src/health.rs
@@ -29,7 +29,7 @@ use axum::{
 };
 use choreo_adapters::metrics::PrometheusMetricsRecorder;
 use choreo_adapters::postgres::PostgresPool;
-use choreo_core::ports::StatisticsPort;
+use choreo_core::ports::{MetricsRecorderPort, StatisticsPort};
 use serde::Serialize;
 
 /// Read-only handles the health endpoints need. Cloning a
@@ -238,6 +238,13 @@ async fn metrics(State(state): State<HealthState>) -> Response {
     body.push_str("# HELP choreo_service_ready 1 when every wired dependency is reachable.\n");
     body.push_str("# TYPE choreo_service_ready gauge\n");
     writeln!(body, "choreo_service_ready {ready_gauge}").unwrap();
+
+    // Sample the Postgres pool gauge at scrape time — no background task.
+    if let Some(pool) = &state.postgres {
+        state
+            .metrics
+            .set_postgres_pool_in_use(i64::try_from(pool.in_use()).unwrap_or(i64::MAX));
+    }
 
     // Append the operational metrics registry (histograms, per-outcome
     // counters) rendered by the Prometheus recorder.


### PR DESCRIPTION
Tenth instrumentation slice — the **pool-saturation signal**. The pool has a small max and a short acquire timeout, so exhaustion cascades straight into readiness failures; this gauge surfaces it before `/readyz` flips.

- **`choreo_postgres_pool_in_use`** (gauge) — connections checked out (total open − idle). **Sampled at `/metrics` scrape time**, so there is no background task and the value is always fresh for the scrape.
- `PostgresPool::in_use()` exposes `size - num_idle`; the health endpoint sets the gauge from the wired pool before rendering the registry.

`query_duration{op}` is **deliberately deferred**: it would mean timing ~36 scattered `sqlx` call sites for a slow-query signal that Postgres's own `pg_stat_statements` serves better.

Validated on **rust 1.90**: `fmt --check` + `clippy --workspace --all-targets --all-features -D warnings` clean, full unit suite green (the gauge reflects the last `set`; it renders even unset, being a single label-less gauge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)