### PR TITLE
refactor(deliberate): extract winner-selection policy and finalize

### DIFF
--- a/crates/choreo-app/src/usecases/deliberate.rs
+++ b/crates/choreo-app/src/usecases/deliberate.rs
@@ -33,10 +33,14 @@ use choreo_core::ports::{
     DeliberationRepositoryPort, DraftRequest, MessagingPort, MetricsRecorderPort, NullObserver,
     ScoringPort, StatisticsPort, ValidatorPort,
 };
-use choreo_core::value_objects::{AgentId, DeliberationOutcome, EventId, ProposalId};
+use choreo_core::value_objects::{
+    AgentId, DeliberationOutcome, Discrimination, EventId, ProposalId,
+};
 use time::OffsetDateTime;
 use tracing::{debug, info};
 use uuid::Uuid;
+
+use super::winner_selection;
 
 /// Result returned by [`DeliberateUseCase::execute`].
 #[derive(Debug, Clone)]
@@ -168,9 +172,26 @@ impl DeliberateUseCase {
             .on_phase_changed(deliberation.task_id(), deliberation.phase(), completed_at)
             .await;
         if task.constraints().output_contract().is_some() {
-            ranked = Self::prioritize_valid_outputs(&mut deliberation, &ranked)?;
+            ranked = winner_selection::prioritize_valid_outputs(&mut deliberation, &ranked)?;
         }
 
+        self.finalize(deliberation, ranked, &task, completed_at, discrimination)
+            .await
+    }
+
+    /// Persist and emit a completed deliberation: record statistics and
+    /// metrics, select the winner (recording the terminal outcome),
+    /// publish the completion event, and return the output. Split out from
+    /// the pipeline so `execute_with_observer` reads as the algorithm and
+    /// this reads as its close-out effects.
+    async fn finalize(
+        &self,
+        deliberation: Deliberation,
+        ranked: Vec<choreo_core::entities::RankedOutcome>,
+        task: &Task,
+        completed_at: OffsetDateTime,
+        discrimination: Option<Discrimination>,
+    ) -> Result<DeliberateOutput, DomainError> {
         self.repository.save(&deliberation).await?;
 
         let duration = deliberation.duration().unwrap_or_default();
@@ -187,7 +208,7 @@ impl DeliberateUseCase {
                 .record_discrimination(deliberation.specialty(), result);
         }
 
-        let winner = match Self::pick_winner(&ranked, task.constraints()) {
+        let winner = match winner_selection::pick_winner(&ranked, task.constraints()) {
             Ok(winner) => winner,
             Err(err) => {
                 self.metrics.record_deliberation_outcome(
@@ -229,41 +250,6 @@ impl DeliberateUseCase {
         Ok(DeliberateOutput {
             winner_proposal_id: winner.proposal().id().clone(),
             deliberation,
-        })
-    }
-
-    fn prioritize_valid_outputs(
-        deliberation: &mut Deliberation,
-        ranked: &[choreo_core::entities::RankedOutcome],
-    ) -> Result<Vec<choreo_core::entities::RankedOutcome>, DomainError> {
-        let reordered = ranked
-            .iter()
-            .filter(|candidate| candidate.outcome().all_passed())
-            .chain(
-                ranked
-                    .iter()
-                    .filter(|candidate| !candidate.outcome().all_passed()),
-            )
-            .map(|candidate| candidate.proposal().id().clone())
-            .collect::<Vec<_>>();
-        deliberation.reprioritize(reordered)
-    }
-
-    fn pick_winner<'a>(
-        ranked: &'a [choreo_core::entities::RankedOutcome],
-        constraints: &TaskConstraints,
-    ) -> Result<&'a choreo_core::entities::RankedOutcome, DomainError> {
-        if let Some(contract) = constraints.output_contract() {
-            return ranked
-                .iter()
-                .find(|candidate| candidate.outcome().all_passed())
-                .ok_or(DomainError::NoValidProposal {
-                    contract_id: contract.contract_id().to_owned(),
-                });
-        }
-
-        ranked.first().ok_or(DomainError::EmptyCollection {
-            field: "deliberation.ranked",
         })
     }
 

--- a/crates/choreo-app/src/usecases/mod.rs
+++ b/crates/choreo-app/src/usecases/mod.rs
@@ -38,6 +38,7 @@ mod start_ceremony_step_input;
 mod start_ceremony_step_use_case;
 mod start_ceremony_use_case;
 mod unregister_agent;
+mod winner_selection;
 
 pub use apply_ceremony_transition_input::ApplyCeremonyTransitionInput;
 pub use apply_ceremony_transition_use_case::ApplyCeremonyTransitionUseCase;

--- a/crates/choreo-app/src/usecases/winner_selection.rs
+++ b/crates/choreo-app/src/usecases/winner_selection.rs
@@ -1,0 +1,130 @@
+//! Winner-selection policy for a completed deliberation.
+//!
+//! Given the ranked outcomes and the task constraints, decide which
+//! proposal wins. This is policy, distinct from the deliberation pipeline
+//! that produced the ranking: under an output contract the winner must be
+//! *valid* (it passed every validator), and valid proposals are surfaced
+//! ahead of invalid ones; without a contract the top-ranked proposal wins.
+
+use choreo_core::entities::{Deliberation, RankedOutcome, TaskConstraints};
+use choreo_core::error::DomainError;
+
+/// Reorder the deliberation's sealed ranking so contract-valid proposals
+/// (those that passed every validator) come before invalid ones, and
+/// return the reordered outcomes. Used only when an output contract is in
+/// force, so a valid proposal is never ranked behind an invalid one.
+pub(super) fn prioritize_valid_outputs(
+    deliberation: &mut Deliberation,
+    ranked: &[RankedOutcome],
+) -> Result<Vec<RankedOutcome>, DomainError> {
+    let reordered = ranked
+        .iter()
+        .filter(|candidate| candidate.outcome().all_passed())
+        .chain(
+            ranked
+                .iter()
+                .filter(|candidate| !candidate.outcome().all_passed()),
+        )
+        .map(|candidate| candidate.proposal().id().clone())
+        .collect::<Vec<_>>();
+    deliberation.reprioritize(reordered)
+}
+
+/// Pick the winning outcome. Under an output contract the winner is the
+/// first proposal that passed every validator (a [`DomainError::NoValidProposal`]
+/// when none did); otherwise it is the top-ranked proposal.
+pub(super) fn pick_winner<'a>(
+    ranked: &'a [RankedOutcome],
+    constraints: &TaskConstraints,
+) -> Result<&'a RankedOutcome, DomainError> {
+    if let Some(contract) = constraints.output_contract() {
+        return ranked
+            .iter()
+            .find(|candidate| candidate.outcome().all_passed())
+            .ok_or(DomainError::NoValidProposal {
+                contract_id: contract.contract_id().to_owned(),
+            });
+    }
+
+    ranked.first().ok_or(DomainError::EmptyCollection {
+        field: "deliberation.ranked",
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use choreo_core::entities::{Proposal, ValidationOutcome, ValidatorReport};
+    use choreo_core::value_objects::{
+        AgentId, Attributes, OutputContract, OutputFieldRule, ProposalId, Rounds, Rubric, Score,
+        Specialty,
+    };
+    use std::collections::BTreeMap;
+    use time::macros::datetime;
+
+    fn outcome(id: &str, score: f64, all_passed: bool) -> RankedOutcome {
+        let report =
+            ValidatorReport::new("structural", all_passed, "", Attributes::empty()).unwrap();
+        let proposal = Proposal::new(
+            ProposalId::new(id).unwrap(),
+            AgentId::new("agent").unwrap(),
+            Specialty::new("reviewer").unwrap(),
+            "content".to_owned(),
+            Attributes::empty(),
+            datetime!(2026-04-15 12:00:00 UTC),
+        )
+        .unwrap();
+        RankedOutcome::new(
+            proposal,
+            ValidationOutcome::new(Score::new(score).unwrap(), vec![report]),
+            0,
+        )
+    }
+
+    fn contract_constraints() -> TaskConstraints {
+        TaskConstraints::new(Rubric::empty(), Rounds::new(0).unwrap(), None, None)
+            .with_output_contract(
+                OutputContract::json_object(
+                    "c",
+                    BTreeMap::from([(
+                        "decision".to_owned(),
+                        OutputFieldRule::new(true, ["emit_event"]).unwrap(),
+                    )]),
+                )
+                .unwrap(),
+            )
+    }
+
+    #[test]
+    fn picks_top_ranked_without_a_contract() {
+        let ranked = [outcome("a", 0.9, true), outcome("b", 0.5, true)];
+        let winner = pick_winner(&ranked, &TaskConstraints::default()).unwrap();
+        assert_eq!(winner.proposal().id().as_str(), "a");
+    }
+
+    #[test]
+    fn picks_first_valid_under_a_contract() {
+        // "a" is top-ranked but invalid; "b" is the first valid proposal.
+        let ranked = [outcome("a", 0.9, false), outcome("b", 0.5, true)];
+        let winner = pick_winner(&ranked, &contract_constraints()).unwrap();
+        assert_eq!(winner.proposal().id().as_str(), "b");
+    }
+
+    #[test]
+    fn no_valid_proposal_under_a_contract_when_none_pass() {
+        let ranked = [outcome("a", 0.9, false), outcome("b", 0.5, false)];
+        let err = pick_winner(&ranked, &contract_constraints()).unwrap_err();
+        assert!(matches!(err, DomainError::NoValidProposal { .. }));
+    }
+
+    #[test]
+    fn empty_ranking_without_a_contract_is_rejected() {
+        let err = pick_winner(&[], &TaskConstraints::default()).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::EmptyCollection {
+                field: "deliberation.ranked"
+            }
+        ));
+    }
+}


### PR DESCRIPTION
Behaviour-preserving SRP refactor of `DeliberateUseCase`, deferred during the metrics roadmap and now landed (the noted follow-up).

## What moved
- **`winner_selection` module** — `pick_winner` + `prioritize_valid_outputs` leave the use case. They are the contract-aware ranking *policy* (valid-first reorder; first-valid pick or `NoValidProposal`), distinct from the pipeline that produced the ranking, and are now **unit-tested in isolation**: top-ranked without a contract, first-valid under a contract, `NoValidProposal` when none pass, empty ranking rejected.
- **`finalize` method** — the post-`complete()` close-out (persist → record statistics + metrics → select winner → publish completion event → log) splits out of `execute_with_observer`. The orchestrator now reads as the five-phase algorithm; `finalize` reads as its effects. Also brings `execute_with_observer` comfortably back under the line limit.

## Safety
**No behaviour change.** The extensive existing `DeliberateUseCase` suite is the net — happy path, peer-review rotation, contract / `NoValidProposal`, validator-error abort, and the metrics-recording tests — all green, plus the new `winner_selection` unit tests.

## Validation
On **rust 1.90**: `fmt --check` + `clippy --workspace --all-targets --all-features -D warnings` clean, full unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)