### PR TITLE
feat(chart): NOTES.txt warns loudly when trace export is not configured

### DIFF
--- a/charts/choreographer/templates/NOTES.txt
+++ b/charts/choreographer/templates/NOTES.txt
@@ -1,0 +1,60 @@
+{{- /*
+Post-install notes. The one thing an operator must not discover weeks
+later is that deliberations ran without exported traces: auditable
+decision traces are the product's core promise, and the `otel` feature
+stays dormant unless CHOREO_OTLP_ENDPOINT is present (see
+crates/choreo/src/telemetry.rs). Mirror the deployment template's
+providerEnv introspection (and its providerEnvFrom escape hatch, since a
+Secret/ConfigMap cannot be introspected at render time) and shout when
+tracing is off.
+*/ -}}
+{{- $penv := dict }}
+{{- range (.Values.providerEnv | default list) }}
+{{- $penv = set $penv .name ((.value | default "from-ref") | toString) }}
+{{- end }}
+{{- $tracingOn := hasKey $penv "CHOREO_OTLP_ENDPOINT" }}
+{{ include "choreographer.fullname" . }} deployed in namespace {{ .Release.Namespace }}.
+
+  gRPC (ChoreographerService): {{ include "choreographer.fullname" . }}:{{ .Values.service.port }}
+  HTTP (healthz, /metrics):    {{ include "choreographer.fullname" . }}:{{ .Values.service.httpPort }}
+{{- if $tracingOn }}
+
+  Tracing: CHOREO_OTLP_ENDPOINT = {{ get $penv "CHOREO_OTLP_ENDPOINT" }}
+  Every deliberation and ceremony is exported as a distributed trace
+  (per-proposal and judge-verdict span events included).
+{{- else if .Values.providerEnvFrom }}
+
+  Tracing: CHOREO_OTLP_ENDPOINT not found in providerEnv. If your
+  providerEnvFrom Secret/ConfigMap sets it, traces are being exported and
+  you can ignore this note. If it does not, see the warning below — the
+  chart cannot introspect envFrom sources at render time.
+{{- end }}
+{{- if and (not $tracingOn) (not .Values.providerEnvFrom) }}
+
+  ##############################################################################
+  ##                                                                          ##
+  ##   ██     ██  █████  ██████  ███    ██ ██ ███    ██  ██████               ##
+  ##   ██     ██ ██   ██ ██   ██ ████   ██ ██ ████   ██ ██                    ##
+  ##   ██  █  ██ ███████ ██████  ██ ██  ██ ██ ██ ██  ██ ██   ███              ##
+  ##   ██ ███ ██ ██   ██ ██   ██ ██  ██ ██ ██ ██  ██ ██ ██    ██              ##
+  ##    ███ ███  ██   ██ ██   ██ ██   ████ ██ ██   ████  ██████               ##
+  ##                                                                          ##
+  ##   DECISION TRACES ARE NOT BEING EXPORTED                                 ##
+  ##                                                                          ##
+  ##   CHOREO_OTLP_ENDPOINT is not set. Deliberations, councils and           ##
+  ##   ceremonies will run, but their traces stay inside the pod's            ##
+  ##   stdout logs: no distributed trace, no per-proposal spans, no           ##
+  ##   judge-verdict span events, no cross-service correlation.               ##
+  ##                                                                          ##
+  ##   Auditable decision traces are the point of this product. Wire          ##
+  ##   the exporter before you rely on any deliberation outcome:              ##
+  ##                                                                          ##
+  ##     providerEnv:                                                         ##
+  ##       - name: CHOREO_OTLP_ENDPOINT                                       ##
+  ##         value: "http://<your-otlp-collector>:4317"                       ##
+  ##                                                                          ##
+  ##   (mTLS deployments: add the CHOREO_OTLP_TLS_* variables; see            ##
+  ##   values.underpass-runtime.yaml for a worked example.)                   ##
+  ##                                                                          ##
+  ##############################################################################
+{{- end }}


### PR DESCRIPTION
## Why

Auditable decision traces are the product's core promise, yet the `otel` feature stays dormant unless `CHOREO_OTLP_ENDPOINT` is present in the environment — and today an operator only finds out by reading `crates/choreo/src/telemetry.rs`. A cluster can run deliberations, councils and ceremonies for weeks with the traces confined to pod stdout, and nothing in the install flow says so.

## What

Adds `templates/NOTES.txt` to the Helm chart:

- **No `CHOREO_OTLP_ENDPOINT` in `providerEnv` and no `providerEnvFrom`** → a large, unmissable post-install banner: decision traces are NOT being exported, with the exact `providerEnv` snippet to fix it (and a pointer to `values.underpass-runtime.yaml` for the mTLS variant).
- **`providerEnvFrom` set** → softer note (envFrom sources cannot be introspected at render time), mirroring the escape hatch the deployment template already uses for the judge fail-fast.
- **Endpoint configured** → confirmation line with the endpoint value.

Also prints the gRPC/HTTP service endpoints on every install.

## Validation

`helm lint` clean; `helm install --dry-run=client` rendered for all three cases (banner / softer note / confirmation) against `values.embedded-nats.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)