### PR TITLE
feat(validators): evidence-grounding gate — claims must cite refs from the step's evidence pack

### DIFF
--- a/crates/choreo-adapters/src/ceremony/ceremony_step_config.rs
+++ b/crates/choreo-adapters/src/ceremony/ceremony_step_config.rs
@@ -46,6 +46,15 @@ mod contract_key {
     pub(super) const REQUIRED_FIELDS: &str = "required_fields";
     pub(super) const ALLOWED_VALUES: &str = "allowed_values";
     pub(super) const JSON_SCHEMA: &str = "json_schema";
+    pub(super) const EVIDENCE: &str = "evidence";
+}
+
+/// Keys recognised inside the `output_contract.evidence` block.
+mod evidence_key {
+    pub(super) const CLAIMS_FIELD: &str = "claims_field";
+    pub(super) const REFS_FIELD: &str = "refs_field";
+    pub(super) const ALLOWED_REFS: &str = "allowed_refs";
+    pub(super) const ALLOWED_REFS_FROM_CONTEXT: &str = "allowed_refs_from_context";
 }
 
 /// Stable `DomainError` field names surfaced when a value is malformed.
@@ -64,6 +73,32 @@ mod field {
         "ceremony_step.config.output_contract.allowed_values";
     pub(super) const CONTRACT_JSON_SCHEMA: &str =
         "ceremony_step.config.output_contract.json_schema";
+    pub(super) const CONTRACT_EVIDENCE: &str = "ceremony_step.config.output_contract.evidence";
+    pub(super) const EVIDENCE_CLAIMS_FIELD: &str =
+        "ceremony_step.config.output_contract.evidence.claims_field";
+    pub(super) const EVIDENCE_REFS_FIELD: &str =
+        "ceremony_step.config.output_contract.evidence.refs_field";
+    pub(super) const EVIDENCE_ALLOWED_REFS: &str =
+        "ceremony_step.config.output_contract.evidence.allowed_refs";
+    pub(super) const EVIDENCE_CONTEXT_KEY: &str =
+        "ceremony_step.config.output_contract.evidence.allowed_refs_from_context";
+}
+
+/// Default output field carrying the claims array.
+const DEFAULT_CLAIMS_FIELD: &str = "claims";
+/// Default per-claim field carrying the evidence references.
+const DEFAULT_REFS_FIELD: &str = "evidence_refs";
+
+/// Declared evidence-grounding configuration for a step, before the
+/// context-borne refs are resolved. The step config owns the schema;
+/// the transport layer — which holds the ceremony context — resolves
+/// `context_key` into concrete refs and builds the domain rule.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EvidenceGroundingSpec {
+    pub(crate) claims_field: String,
+    pub(crate) refs_field: String,
+    pub(crate) static_refs: Vec<String>,
+    pub(crate) context_key: Option<String>,
 }
 
 /// A validated, typed view over one ceremony step's handler configuration.
@@ -201,6 +236,7 @@ impl<'a> CeremonyStepConfig<'a> {
             contract_key::REQUIRED_FIELDS,
             contract_key::ALLOWED_VALUES,
             contract_key::JSON_SCHEMA,
+            contract_key::EVIDENCE,
         ];
         if block.keys().any(|key| !known.contains(&key.as_str())) {
             return Err(DomainError::InvalidCharacters {
@@ -266,6 +302,111 @@ impl<'a> CeremonyStepConfig<'a> {
             fields,
             json_schema,
         )?))
+    }
+
+    /// Evidence-grounding declaration inside the step's contract, if
+    /// any.
+    ///
+    /// Shape (inside the `output_contract` block):
+    ///
+    /// ```yaml
+    /// output_contract:
+    ///   contract_id: evidence-bound-decision
+    ///   evidence:
+    ///     claims_field: claims                    # optional, default "claims"
+    ///     refs_field: evidence_refs               # optional, default "evidence_refs"
+    ///     allowed_refs: [ev-static-1]             # optional, static pack entries
+    ///     allowed_refs_from_context: evidence_pack # optional, ceremony-context key
+    /// ```
+    ///
+    /// At least one of `allowed_refs` / `allowed_refs_from_context` is
+    /// required, unknown keys are rejected (same reasoning as the
+    /// contract block: a typo must not silently weaken a policy gate).
+    /// The context key is resolved by the transport layer at request
+    /// time — the context entry must be an array of strings, or of
+    /// objects each carrying a string `id` (the natural shape of an
+    /// evidence pack).
+    pub(crate) fn evidence_grounding_spec(
+        &self,
+    ) -> Result<Option<EvidenceGroundingSpec>, DomainError> {
+        let Some(contract) = self.attributes.get(key::OUTPUT_CONTRACT) else {
+            return Ok(None);
+        };
+        let Some(block) = contract.as_object() else {
+            // output_contract() already rejects this shape; stay quiet here.
+            return Ok(None);
+        };
+        let Some(value) = block.get(contract_key::EVIDENCE) else {
+            return Ok(None);
+        };
+        if value.is_null() {
+            return Ok(None);
+        }
+        let Some(evidence) = value.as_object() else {
+            return Err(DomainError::InvalidCharacters {
+                field: field::CONTRACT_EVIDENCE,
+            });
+        };
+
+        let known = [
+            evidence_key::CLAIMS_FIELD,
+            evidence_key::REFS_FIELD,
+            evidence_key::ALLOWED_REFS,
+            evidence_key::ALLOWED_REFS_FROM_CONTEXT,
+        ];
+        if evidence.keys().any(|key| !known.contains(&key.as_str())) {
+            return Err(DomainError::InvalidCharacters {
+                field: field::CONTRACT_EVIDENCE,
+            });
+        }
+
+        if let Some(value) = evidence.get(evidence_key::CLAIMS_FIELD) {
+            if !value.is_null() && !value.is_string() {
+                return Err(DomainError::InvalidCharacters {
+                    field: field::EVIDENCE_CLAIMS_FIELD,
+                });
+            }
+        }
+        if let Some(value) = evidence.get(evidence_key::REFS_FIELD) {
+            if !value.is_null() && !value.is_string() {
+                return Err(DomainError::InvalidCharacters {
+                    field: field::EVIDENCE_REFS_FIELD,
+                });
+            }
+        }
+        let claims_field = optional_string(evidence.get(evidence_key::CLAIMS_FIELD))
+            .unwrap_or(DEFAULT_CLAIMS_FIELD)
+            .to_owned();
+        let refs_field = optional_string(evidence.get(evidence_key::REFS_FIELD))
+            .unwrap_or(DEFAULT_REFS_FIELD)
+            .to_owned();
+
+        let static_refs = string_array(
+            evidence.get(evidence_key::ALLOWED_REFS),
+            field::EVIDENCE_ALLOWED_REFS,
+        )?;
+        if let Some(value) = evidence.get(evidence_key::ALLOWED_REFS_FROM_CONTEXT) {
+            if !value.is_null() && !value.is_string() {
+                return Err(DomainError::InvalidCharacters {
+                    field: field::EVIDENCE_CONTEXT_KEY,
+                });
+            }
+        }
+        let context_key = optional_string(evidence.get(evidence_key::ALLOWED_REFS_FROM_CONTEXT))
+            .map(str::to_owned);
+
+        if static_refs.is_empty() && context_key.is_none() {
+            return Err(DomainError::EmptyField {
+                field: field::EVIDENCE_ALLOWED_REFS,
+            });
+        }
+
+        Ok(Some(EvidenceGroundingSpec {
+            claims_field,
+            refs_field,
+            static_refs,
+            context_key,
+        }))
     }
 }
 

--- a/crates/choreo-adapters/src/ceremony/deliberating_ceremony_step_handler.rs
+++ b/crates/choreo-adapters/src/ceremony/deliberating_ceremony_step_handler.rs
@@ -451,6 +451,157 @@ mod tests {
         ));
     }
 
+    /// Stub agent that always answers with structured claims citing a
+    /// reference that is NOT in the step's evidence pack — the exact
+    /// failure mode the grounding gate exists for (a fluent, well-formed
+    /// proposal built on fabricated evidence).
+    #[derive(Debug)]
+    struct FabricatingAgent {
+        id: AgentId,
+        specialty: Specialty,
+    }
+
+    #[async_trait::async_trait]
+    impl choreo_core::ports::AgentPort for FabricatingAgent {
+        fn id(&self) -> &AgentId {
+            &self.id
+        }
+
+        fn specialty(&self) -> &Specialty {
+            &self.specialty
+        }
+
+        async fn generate(
+            &self,
+            _request: choreo_core::ports::DraftRequest,
+        ) -> Result<choreo_core::ports::Revision, DomainError> {
+            Ok(choreo_core::ports::Revision {
+                content: json!({
+                    "claims": [
+                        {
+                            "text": "the pod spec sets privileged: true",
+                            "evidence_refs": ["ev-fabricated"],
+                        },
+                    ],
+                    "decision": "accept",
+                })
+                .to_string(),
+            })
+        }
+
+        async fn critique(
+            &self,
+            _peer_content: &str,
+            _constraints: &choreo_core::entities::TaskConstraints,
+        ) -> Result<choreo_core::ports::Critique, DomainError> {
+            Ok(choreo_core::ports::Critique {
+                feedback: "looks fine".to_owned(),
+            })
+        }
+
+        async fn revise(
+            &self,
+            own_content: &str,
+            _critique: &choreo_core::ports::Critique,
+        ) -> Result<choreo_core::ports::Revision, DomainError> {
+            Ok(choreo_core::ports::Revision {
+                content: own_content.to_owned(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn grounding_gate_rejects_fabricated_evidence_end_to_end() {
+        let specialty = Specialty::new("evidence_gate").unwrap();
+        let agent_id = AgentId::new("agent-evidence_gate-0").unwrap();
+        let agent_registry = Arc::new(InMemoryAgentRegistry::new());
+        agent_registry
+            .insert(Arc::new(FabricatingAgent {
+                id: agent_id.clone(),
+                specialty: specialty.clone(),
+            }))
+            .await
+            .unwrap();
+
+        let council_registry = Arc::new(InMemoryCouncilRegistry::new());
+        council_registry
+            .register(
+                Council::new(
+                    CouncilId::new("council-evidence_gate").unwrap(),
+                    specialty.clone(),
+                    vec![agent_id],
+                    SystemClock::new().now(),
+                )
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let deliberate = Arc::new(DeliberateUseCase::new(
+            Arc::new(SystemClock::new()),
+            council_registry,
+            agent_registry,
+            vec![
+                Arc::new(ContentNonEmptyValidator::new()),
+                Arc::new(JsonObjectOutputValidator::new()),
+                Arc::new(RequiredFieldsValidator::new()),
+                Arc::new(crate::validators::ClaimsEvidenceGroundedValidator::new()),
+            ],
+            Arc::new(UniformScoring::new()),
+            Arc::new(InMemoryDeliberationRepository::new()),
+            Arc::new(NoopMessaging::new()),
+            Arc::new(InMemoryStatistics::new()),
+            Arc::new(choreo_core::ports::NoopMetricsRecorder),
+            "ceremony-step-handler-test",
+        ));
+        let handler = DeliberatingCeremonyStepHandler::new(deliberate);
+
+        // The evidence pack arrives through the ceremony context — the
+        // deterministic collector's output — and the step contract
+        // points its grounding rule at it.
+        let request = CeremonyStepHandlerRequest::new(
+            CeremonyId::new("ceremony-1").unwrap(),
+            CeremonyName::new("evidence_review").unwrap(),
+            CeremonyVersion::v1(),
+            StateId::new("REVIEW").unwrap(),
+            StepId::new("evidence_review").unwrap(),
+            StepHandlerKind::new("evidence_gate").unwrap(),
+            StepHandlerConfig::new(
+                Attributes::new(BTreeMap::from([
+                    ("prompt".to_owned(), json!("Review the change")),
+                    ("num_agents".to_owned(), json!(1)),
+                    (
+                        "output_contract".to_owned(),
+                        json!({
+                            "contract_id": "evidence-bound-decision",
+                            "required_fields": ["claims", "decision"],
+                            "evidence": {
+                                "allowed_refs_from_context": "evidence_pack",
+                            },
+                        }),
+                    ),
+                ]))
+                .unwrap(),
+            ),
+            CeremonyContext::new(
+                Attributes::new(BTreeMap::from([(
+                    "evidence_pack".to_owned(),
+                    json!([{"id": "ev-journal-1"}, {"id": "ev-trace-1"}]),
+                )]))
+                .unwrap(),
+            ),
+            StepAttempt::FIRST,
+        );
+
+        let err = handler.execute(request).await.unwrap_err();
+
+        assert!(matches!(
+            err,
+            choreo_core::error::DomainError::NoValidProposal { ref contract_id }
+                if contract_id == "evidence-bound-decision"
+        ));
+    }
+
     #[test]
     fn description_without_role_or_transcript_is_well_formed() {
         let request = request_with_prompt();

--- a/crates/choreo-adapters/src/ceremony/deliberation_step_config.rs
+++ b/crates/choreo-adapters/src/ceremony/deliberation_step_config.rs
@@ -1,6 +1,9 @@
 use choreo_core::error::DomainError;
 use choreo_core::ports::CeremonyStepHandlerRequest;
-use choreo_core::value_objects::{NumAgents, OutputContract, Rounds, Specialty, TaskDescription};
+use choreo_core::value_objects::{
+    EvidenceGroundingRule, NumAgents, OutputContract, Rounds, Specialty, TaskDescription,
+};
+use serde_json::Value;
 
 use super::CeremonyStepConfig;
 
@@ -21,13 +24,32 @@ impl DeliberationStepConfig {
             request.handler_kind(),
         );
 
+        let mut output_contract = config.output_contract()?;
+        // Resolve the evidence-grounding declaration here: the spec may
+        // point at a ceremony-context key, and only the transport layer
+        // holds the context. The resolved rule rides on the contract so
+        // the grounding validator sees it through `TaskConstraints`.
+        if let Some(spec) = config.evidence_grounding_spec()? {
+            let contract = output_contract.take().ok_or(DomainError::EmptyField {
+                // `evidence` nests inside `output_contract`; reaching
+                // here without a contract is a parse invariant breach.
+                field: "ceremony_step.config.output_contract",
+            })?;
+            let mut refs = spec.static_refs;
+            if let Some(key) = spec.context_key {
+                refs.extend(context_refs(request, &key)?);
+            }
+            let rule = EvidenceGroundingRule::new(spec.claims_field, spec.refs_field, refs)?;
+            output_contract = Some(contract.with_evidence_grounding(rule));
+        }
+
         Ok(Self {
             task_description: config.prompt()?,
             specialty: config.specialty()?,
             rounds: config.rounds()?,
             num_agents: config.num_agents()?,
             see_prior: config.see_prior_steps()?,
-            output_contract: config.output_contract()?,
+            output_contract,
         })
     }
 
@@ -64,6 +86,48 @@ impl DeliberationStepConfig {
     pub fn output_contract(&self) -> Option<&OutputContract> {
         self.output_contract.as_ref()
     }
+}
+
+/// Stable error field for a malformed or missing context evidence pack.
+const CONTEXT_REFS_FIELD: &str =
+    "ceremony_step.config.output_contract.evidence.allowed_refs_from_context";
+
+/// Resolve an evidence pack from the ceremony context. The entry must
+/// be an array of strings, or of objects each carrying a string `id`
+/// (the natural shape of an evidence pack: `[{id, kind, uri, …}, …]`).
+/// A grounding gate pointing at an absent or malformed pack fails
+/// loudly — running the step ungrounded would silently void the
+/// policy.
+fn context_refs(
+    request: &CeremonyStepHandlerRequest,
+    key: &str,
+) -> Result<Vec<String>, DomainError> {
+    let Some(value) = request.context().attributes().get(key) else {
+        return Err(DomainError::EmptyField {
+            field: CONTEXT_REFS_FIELD,
+        });
+    };
+    let Some(items) = value.as_array() else {
+        return Err(DomainError::InvalidCharacters {
+            field: CONTEXT_REFS_FIELD,
+        });
+    };
+    items
+        .iter()
+        .map(|item| match item {
+            Value::String(reference) => Ok(reference.clone()),
+            Value::Object(entry) => entry
+                .get("id")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+                .ok_or(DomainError::InvalidCharacters {
+                    field: CONTEXT_REFS_FIELD,
+                }),
+            _ => Err(DomainError::InvalidCharacters {
+                field: CONTEXT_REFS_FIELD,
+            }),
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -150,6 +214,141 @@ mod tests {
         let contract = config.output_contract().unwrap();
         assert_eq!(contract.contract_id(), "evidence-bound-decision");
         assert!(contract.fields()["decision"].required());
+    }
+
+    fn request_with_context(
+        config: BTreeMap<String, Value>,
+        context: BTreeMap<String, Value>,
+    ) -> CeremonyStepHandlerRequest {
+        CeremonyStepHandlerRequest::new(
+            CeremonyId::new("ceremony-1").unwrap(),
+            CeremonyName::new("editorial").unwrap(),
+            CeremonyVersion::v1(),
+            StateId::new("OPENING").unwrap(),
+            StepId::new("open_room").unwrap(),
+            StepHandlerKind::new("facilitation_prompt").unwrap(),
+            StepHandlerConfig::new(Attributes::new(config).unwrap()),
+            CeremonyContext::new(Attributes::new(context).unwrap()),
+            StepAttempt::FIRST,
+        )
+    }
+
+    fn evidence_contract_config(evidence: &Value) -> BTreeMap<String, Value> {
+        BTreeMap::from([
+            ("prompt".to_owned(), json!("Decide with evidence")),
+            (
+                "output_contract".to_owned(),
+                json!({
+                    "contract_id": "evidence-bound-decision",
+                    "required_fields": ["claims"],
+                    "evidence": evidence,
+                }),
+            ),
+        ])
+    }
+
+    #[test]
+    fn resolves_evidence_pack_from_ceremony_context() {
+        let config = DeliberationStepConfig::from_request(&request_with_context(
+            evidence_contract_config(&json!({
+                "allowed_refs_from_context": "evidence_pack",
+            })),
+            BTreeMap::from([(
+                "evidence_pack".to_owned(),
+                json!([
+                    {"id": "ev-trace-1", "kind": "trace"},
+                    {"id": "ev-metric-1", "kind": "metric"},
+                ]),
+            )]),
+        ))
+        .unwrap();
+
+        let rule = config
+            .output_contract()
+            .unwrap()
+            .evidence_grounding()
+            .unwrap();
+        assert_eq!(rule.claims_field(), "claims");
+        assert_eq!(rule.refs_field(), "evidence_refs");
+        assert!(rule.allowed_refs().contains("ev-trace-1"));
+        assert!(rule.allowed_refs().contains("ev-metric-1"));
+    }
+
+    #[test]
+    fn merges_static_refs_with_context_refs_and_custom_fields() {
+        let config = DeliberationStepConfig::from_request(&request_with_context(
+            evidence_contract_config(&json!({
+                "claims_field": "findings",
+                "refs_field": "sources",
+                "allowed_refs": ["ev-static-1"],
+                "allowed_refs_from_context": "evidence_pack",
+            })),
+            BTreeMap::from([("evidence_pack".to_owned(), json!(["ev-ctx-1"]))]),
+        ))
+        .unwrap();
+
+        let rule = config
+            .output_contract()
+            .unwrap()
+            .evidence_grounding()
+            .unwrap();
+        assert_eq!(rule.claims_field(), "findings");
+        assert_eq!(rule.refs_field(), "sources");
+        assert!(rule.allowed_refs().contains("ev-static-1"));
+        assert!(rule.allowed_refs().contains("ev-ctx-1"));
+    }
+
+    #[test]
+    fn grounding_gate_fails_loudly_when_context_pack_is_absent() {
+        let err = DeliberationStepConfig::from_request(&request_with_context(
+            evidence_contract_config(&json!({
+                "allowed_refs_from_context": "evidence_pack",
+            })),
+            BTreeMap::new(),
+        ))
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DomainError::EmptyField {
+                field: "ceremony_step.config.output_contract.evidence.allowed_refs_from_context"
+            }
+        ));
+    }
+
+    #[test]
+    fn evidence_block_without_any_source_is_rejected() {
+        let err = DeliberationStepConfig::from_request(&request_with_context(
+            evidence_contract_config(&json!({ "claims_field": "claims" })),
+            BTreeMap::new(),
+        ))
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DomainError::EmptyField {
+                field: "ceremony_step.config.output_contract.evidence.allowed_refs"
+            }
+        ));
+    }
+
+    #[test]
+    fn evidence_block_with_unknown_key_is_rejected() {
+        let err = DeliberationStepConfig::from_request(&request_with_context(
+            evidence_contract_config(&json!({
+                "allowed_refs": ["ev-1"],
+                "allowd_refs": ["typo"],
+            })),
+            BTreeMap::new(),
+        ))
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DomainError::InvalidCharacters {
+                field: "ceremony_step.config.output_contract.evidence"
+            }
+        ));
     }
 
     #[test]

--- a/crates/choreo-adapters/src/validators.rs
+++ b/crates/choreo-adapters/src/validators.rs
@@ -649,6 +649,216 @@ impl ShapeViolation {
     }
 }
 
+/// A validator that enforces the evidence-grounding rule declared in
+/// the output contract: every claim in the output must cite at least
+/// one evidence reference, and every cited reference must exist in the
+/// contract's allowed evidence pack.
+///
+/// Expected output shape (field names configurable per rule):
+///
+/// ```json
+/// { "claims": [ { "text": "…", "evidence_refs": ["ev-1"] }, … ] }
+/// ```
+///
+/// Semantics:
+///
+/// - no contract, or contract without a grounding rule → pass
+///   (`"no evidence grounding configured"`, the sibling validators'
+///   pattern).
+/// - claims field missing or not an array → fail (a grounding-gated
+///   step must produce inspectable claims).
+/// - an empty claims array passes: grounding judges what is claimed,
+///   not how much — pair with `required_fields`/`json_schema`
+///   (`minItems`) to demand substance.
+/// - each claim must be a JSON object whose refs field is a non-empty
+///   array of strings, all present in the allowed pack. Violations
+///   name the claim index, a text preview and the orphan refs — that
+///   detail lands in spans/logs and becomes part of the decision
+///   record.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ClaimsEvidenceGroundedValidator;
+
+impl ClaimsEvidenceGroundedValidator {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+const CLAIM_TEXT_PREVIEW_LEN: usize = 80;
+
+#[async_trait]
+impl ValidatorPort for ClaimsEvidenceGroundedValidator {
+    fn kind(&self) -> &'static str {
+        "claims-evidence-grounded"
+    }
+
+    async fn validate(
+        &self,
+        proposal_content: &str,
+        constraints: &TaskConstraints,
+    ) -> Result<ValidatorReport, DomainError> {
+        let Some(contract) = constraints.output_contract() else {
+            return ValidatorReport::new(
+                self.kind(),
+                true,
+                "no evidence grounding configured",
+                Attributes::empty(),
+            );
+        };
+        let Some(rule) = contract.evidence_grounding() else {
+            return ValidatorReport::new(
+                self.kind(),
+                true,
+                "no evidence grounding configured",
+                Attributes::empty(),
+            );
+        };
+
+        let object = match parse_json_object(proposal_content) {
+            Ok(object) => object,
+            Err(summary) => {
+                return ValidatorReport::new(
+                    self.kind(),
+                    false,
+                    summary,
+                    attributes(json!({ "contract_id": contract.contract_id() }))?,
+                );
+            }
+        };
+
+        let Some(claims) = object.get(rule.claims_field()).and_then(Value::as_array) else {
+            return ValidatorReport::new(
+                self.kind(),
+                false,
+                format!(
+                    "claims field `{}` is missing or not an array",
+                    rule.claims_field()
+                ),
+                attributes(json!({
+                    "contract_id": contract.contract_id(),
+                    "claims_field": rule.claims_field(),
+                }))?,
+            );
+        };
+
+        let violations: Vec<Value> = claims
+            .iter()
+            .enumerate()
+            .flat_map(|(index, claim)| claim_violations(index, claim, rule))
+            .collect();
+
+        if violations.is_empty() {
+            ValidatorReport::new(
+                self.kind(),
+                true,
+                format!(
+                    "all {} claims grounded in the evidence pack ({} allowed refs)",
+                    claims.len(),
+                    rule.allowed_refs().len()
+                ),
+                Attributes::empty(),
+            )
+        } else {
+            ValidatorReport::new(
+                self.kind(),
+                false,
+                format!(
+                    "{} of {} claims lack grounded evidence",
+                    violations.len(),
+                    claims.len()
+                ),
+                attributes(json!({
+                    "contract_id": contract.contract_id(),
+                    "claims_field": rule.claims_field(),
+                    "refs_field": rule.refs_field(),
+                    "violations": violations,
+                }))?,
+            )
+        }
+    }
+}
+
+/// Grounding violations for one claim: shape problems, absent or empty
+/// refs, non-string refs, and refs outside the allowed pack.
+fn claim_violations(
+    index: usize,
+    claim: &Value,
+    rule: &choreo_core::value_objects::EvidenceGroundingRule,
+) -> Vec<Value> {
+    let Some(claim_object) = claim.as_object() else {
+        return vec![json!({
+            "claim_index": index,
+            "problem": "claim is not a JSON object",
+            "actual_type": value_type_name(claim),
+        })];
+    };
+    let preview = claim_preview(claim_object);
+    let Some(refs) = claim_object
+        .get(rule.refs_field())
+        .and_then(Value::as_array)
+    else {
+        return vec![json!({
+            "claim_index": index,
+            "claim_preview": preview,
+            "problem": format!(
+                "refs field `{}` is missing or not an array",
+                rule.refs_field()
+            ),
+        })];
+    };
+    if refs.is_empty() {
+        return vec![json!({
+            "claim_index": index,
+            "claim_preview": preview,
+            "problem": "claim cites no evidence",
+        })];
+    }
+
+    let mut violations = Vec::new();
+    let mut orphans = Vec::new();
+    for reference in refs {
+        match reference.as_str() {
+            Some(id) if rule.allowed_refs().contains(id) => {}
+            Some(id) => orphans.push(id.to_owned()),
+            None => violations.push(json!({
+                "claim_index": index,
+                "claim_preview": preview,
+                "problem": "evidence ref is not a string",
+                "actual_type": value_type_name(reference),
+            })),
+        }
+    }
+    if !orphans.is_empty() {
+        violations.push(json!({
+            "claim_index": index,
+            "claim_preview": preview,
+            "problem": "evidence refs not present in the allowed pack",
+            "orphan_refs": orphans,
+        }));
+    }
+    violations
+}
+
+/// Short human preview of a claim for violation details: its `text`
+/// field when present, otherwise the serialized object, truncated at a
+/// char boundary.
+fn claim_preview(claim: &Map<String, Value>) -> String {
+    let raw = claim
+        .get("text")
+        .and_then(Value::as_str)
+        .map_or_else(|| Value::Object(claim.clone()).to_string(), str::to_owned);
+    if raw.len() > CLAIM_TEXT_PREVIEW_LEN {
+        let mut end = CLAIM_TEXT_PREVIEW_LEN;
+        while !raw.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}…", &raw[..end])
+    } else {
+        raw
+    }
+}
+
 fn parse_json_object(proposal_content: &str) -> Result<Map<String, Value>, String> {
     let trimmed = proposal_content.trim();
     let value: Value = serde_json::from_str(trimmed)
@@ -705,6 +915,103 @@ mod tests {
             )
             .unwrap(),
         )
+    }
+
+    fn grounded_constraints() -> TaskConstraints {
+        TaskConstraints::default().with_output_contract(
+            OutputContract::json_object("evidence-contract", BTreeMap::new())
+                .unwrap()
+                .with_evidence_grounding(
+                    choreo_core::value_objects::EvidenceGroundingRule::new(
+                        "claims",
+                        "evidence_refs",
+                        ["ev-1", "ev-2"],
+                    )
+                    .unwrap(),
+                ),
+        )
+    }
+
+    #[tokio::test]
+    async fn grounding_passes_without_configuration() {
+        let v = ClaimsEvidenceGroundedValidator::new();
+        let r = v
+            .validate("free prose", &TaskConstraints::default())
+            .await
+            .unwrap();
+        assert!(r.passed());
+        assert_eq!(r.kind(), "claims-evidence-grounded");
+        assert!(r.summary().contains("no evidence grounding configured"));
+
+        // A contract without a grounding rule is also a no-op.
+        let r = v
+            .validate("free prose", &structured_constraints())
+            .await
+            .unwrap();
+        assert!(r.passed());
+    }
+
+    #[tokio::test]
+    async fn grounded_claims_pass() {
+        let v = ClaimsEvidenceGroundedValidator::new();
+        let content = r#"{"claims":[
+            {"text":"typha holds the port","evidence_refs":["ev-1"]},
+            {"text":"crun state is per root","evidence_refs":["ev-1","ev-2"]}
+        ]}"#;
+        let r = v.validate(content, &grounded_constraints()).await.unwrap();
+        assert!(r.passed(), "summary: {}", r.summary());
+        assert!(r.summary().contains("all 2 claims grounded"));
+    }
+
+    #[tokio::test]
+    async fn claim_without_refs_fails() {
+        let v = ClaimsEvidenceGroundedValidator::new();
+        let content = r#"{"claims":[
+            {"text":"grounded","evidence_refs":["ev-1"]},
+            {"text":"vibes only"}
+        ]}"#;
+        let r = v.validate(content, &grounded_constraints()).await.unwrap();
+        assert!(!r.passed());
+        assert!(r.summary().contains("1 of 2 claims"));
+    }
+
+    #[tokio::test]
+    async fn claim_with_empty_refs_fails() {
+        let v = ClaimsEvidenceGroundedValidator::new();
+        let content = r#"{"claims":[{"text":"empty-handed","evidence_refs":[]}]}"#;
+        let r = v.validate(content, &grounded_constraints()).await.unwrap();
+        assert!(!r.passed());
+    }
+
+    #[tokio::test]
+    async fn orphan_ref_fails_and_is_named() {
+        let v = ClaimsEvidenceGroundedValidator::new();
+        let content = r#"{"claims":[{"text":"invented","evidence_refs":["ev-999"]}]}"#;
+        let r = v.validate(content, &grounded_constraints()).await.unwrap();
+        assert!(!r.passed());
+        let details = serde_json::to_string(r.details()).unwrap();
+        assert!(details.contains("ev-999"));
+    }
+
+    #[tokio::test]
+    async fn missing_claims_field_fails() {
+        let v = ClaimsEvidenceGroundedValidator::new();
+        let r = v
+            .validate(r#"{"decision":"accept"}"#, &grounded_constraints())
+            .await
+            .unwrap();
+        assert!(!r.passed());
+        assert!(r.summary().contains("claims"));
+    }
+
+    #[tokio::test]
+    async fn empty_claims_array_passes() {
+        let v = ClaimsEvidenceGroundedValidator::new();
+        let r = v
+            .validate(r#"{"claims":[]}"#, &grounded_constraints())
+            .await
+            .unwrap();
+        assert!(r.passed());
     }
 
     #[tokio::test]

--- a/crates/choreo-core/src/value_objects/mod.rs
+++ b/crates/choreo-core/src/value_objects/mod.rs
@@ -45,7 +45,7 @@ pub use duration::DurationMs;
 pub use ids::{AgentId, CouncilId, EventId, ProposalId, TaskId};
 pub use llm_error_kind::LlmErrorKind;
 pub use num_agents::NumAgents;
-pub use output_contract::{OutputContract, OutputFieldRule, OutputFormat};
+pub use output_contract::{EvidenceGroundingRule, OutputContract, OutputFieldRule, OutputFormat};
 pub use rounds::Rounds;
 pub use rubric::Rubric;
 pub use score::Score;

--- a/crates/choreo-core/src/value_objects/output_contract.rs
+++ b/crates/choreo-core/src/value_objects/output_contract.rs
@@ -21,6 +21,11 @@ const MAX_ALLOWED_VALUE_LEN: usize = 256;
 /// dozen enums; anything larger should live behind a `$ref` and be
 /// fetched by the validator if/when remote schemas are supported.
 const MAX_JSON_SCHEMA_LEN: usize = 256 * 1024;
+/// Cap on the evidence pack an evidence-grounding rule may carry. An
+/// evidence pack is a curated set of reference ids for one
+/// deliberation, not a corpus; anything larger belongs in an external
+/// store that the pack entries reference.
+const MAX_ALLOWED_EVIDENCE_REFS: usize = 1024;
 
 /// Wire- and storage-stable structured output format selector.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -88,6 +93,87 @@ impl OutputFieldRule {
     }
 }
 
+/// Evidence-grounding rule for one invocation: which output field
+/// carries the claims, which per-claim field carries the evidence
+/// references, and the closed set of reference ids that count as real
+/// evidence for this deliberation (the "evidence pack").
+///
+/// The rule is deliberately shape-only: the core does not know what an
+/// evidence ref points at (a document, a trace, a metric snapshot) —
+/// only that a claim citing a ref outside the pack is ungrounded.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvidenceGroundingRule {
+    claims_field: String,
+    refs_field: String,
+    allowed_refs: BTreeSet<String>,
+}
+
+impl EvidenceGroundingRule {
+    /// Build a grounding rule. `allowed_refs` must be non-empty: an
+    /// evidence-bound deliberation with an empty pack is a
+    /// configuration error, not a stricter gate.
+    pub fn new(
+        claims_field: impl Into<String>,
+        refs_field: impl Into<String>,
+        allowed_refs: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Result<Self, DomainError> {
+        let claims_field = validate_text(
+            &claims_field.into(),
+            "output_contract.evidence.claims_field",
+            MAX_FIELD_NAME_LEN,
+        )?;
+        let refs_field = validate_text(
+            &refs_field.into(),
+            "output_contract.evidence.refs_field",
+            MAX_FIELD_NAME_LEN,
+        )?;
+        let allowed_refs = allowed_refs
+            .into_iter()
+            .map(|reference| {
+                let reference = reference.into();
+                validate_text(
+                    &reference,
+                    "output_contract.evidence.allowed_ref",
+                    MAX_ALLOWED_VALUE_LEN,
+                )
+            })
+            .collect::<Result<BTreeSet<_>, _>>()?;
+        if allowed_refs.is_empty() {
+            return Err(DomainError::EmptyField {
+                field: "output_contract.evidence.allowed_refs",
+            });
+        }
+        if allowed_refs.len() > MAX_ALLOWED_EVIDENCE_REFS {
+            return Err(DomainError::OutOfRange {
+                field: "output_contract.evidence.allowed_refs",
+                value: allowed_refs.len() as f64,
+                min: 1.0,
+                max: MAX_ALLOWED_EVIDENCE_REFS as f64,
+            });
+        }
+        Ok(Self {
+            claims_field,
+            refs_field,
+            allowed_refs,
+        })
+    }
+
+    #[must_use]
+    pub fn claims_field(&self) -> &str {
+        &self.claims_field
+    }
+
+    #[must_use]
+    pub fn refs_field(&self) -> &str {
+        &self.refs_field
+    }
+
+    #[must_use]
+    pub fn allowed_refs(&self) -> &BTreeSet<String> {
+        &self.allowed_refs
+    }
+}
+
 /// Typed structured-output contract attached to one invocation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OutputContract {
@@ -102,6 +188,11 @@ pub struct OutputContract {
     /// schema-engine dependency.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     json_schema: String,
+    /// Optional evidence-grounding rule. When present, the adapter
+    /// grounding validator rejects proposals whose claims do not cite
+    /// evidence from the allowed pack.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    evidence_grounding: Option<EvidenceGroundingRule>,
 }
 
 impl OutputContract {
@@ -154,6 +245,7 @@ impl OutputContract {
             format,
             fields: normalized,
             json_schema,
+            evidence_grounding: None,
         })
     }
 
@@ -185,6 +277,20 @@ impl OutputContract {
     #[must_use]
     pub fn json_schema(&self) -> &str {
         &self.json_schema
+    }
+
+    /// Attach an evidence-grounding rule to this contract.
+    #[must_use]
+    pub fn with_evidence_grounding(mut self, rule: EvidenceGroundingRule) -> Self {
+        self.evidence_grounding = Some(rule);
+        self
+    }
+
+    /// Evidence-grounding rule, when the contract declares one. `None`
+    /// means the grounding validator is a no-op for this invocation.
+    #[must_use]
+    pub fn evidence_grounding(&self) -> Option<&EvidenceGroundingRule> {
+        self.evidence_grounding.as_ref()
     }
 }
 
@@ -323,6 +429,60 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn evidence_grounding_rule_keeps_fields_and_refs() {
+        let rule = EvidenceGroundingRule::new("claims", "evidence_refs", ["ev-1", "ev-2"]).unwrap();
+        assert_eq!(rule.claims_field(), "claims");
+        assert_eq!(rule.refs_field(), "evidence_refs");
+        assert!(rule.allowed_refs().contains("ev-1"));
+        assert_eq!(rule.allowed_refs().len(), 2);
+    }
+
+    #[test]
+    fn evidence_grounding_rule_rejects_empty_pack() {
+        let err = EvidenceGroundingRule::new("claims", "evidence_refs", Vec::<String>::new())
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::EmptyField {
+                field: "output_contract.evidence.allowed_refs"
+            }
+        ));
+    }
+
+    #[test]
+    fn evidence_grounding_rule_rejects_blank_ref() {
+        let err = EvidenceGroundingRule::new("claims", "evidence_refs", ["  "]).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::EmptyField {
+                field: "output_contract.evidence.allowed_ref"
+            }
+        ));
+    }
+
+    #[test]
+    fn contract_with_evidence_grounding_roundtrips() {
+        let contract = OutputContract::json_object("c1", BTreeMap::new())
+            .unwrap()
+            .with_evidence_grounding(
+                EvidenceGroundingRule::new("claims", "evidence_refs", ["ev-1"]).unwrap(),
+            );
+        let serialized = serde_json::to_string(&contract).unwrap();
+        let back: OutputContract = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(back, contract);
+        assert_eq!(back.evidence_grounding().unwrap().claims_field(), "claims");
+    }
+
+    #[test]
+    fn contract_without_grounding_deserializes_from_legacy_wire_shape() {
+        // Contracts serialized before the grounding field existed must
+        // keep deserializing (registry/persistence compatibility).
+        let legacy = r#"{"contract_id":"c1","format":"JsonObject","fields":{}}"#;
+        let back: OutputContract = serde_json::from_str(legacy).unwrap();
+        assert!(back.evidence_grounding().is_none());
     }
 
     #[test]

--- a/crates/choreo/src/compose.rs
+++ b/crates/choreo/src/compose.rs
@@ -23,8 +23,9 @@ use choreo_adapters::runtime::{
 };
 use choreo_adapters::scoring::{JudgeAwareScoring, UniformScoring};
 use choreo_adapters::validators::{
-    AllowedStringValuesValidator, BoundedEventShapeValidator, ContentNonEmptyValidator,
-    JsonObjectOutputValidator, JsonSchemaValidator, RequiredFieldsValidator,
+    AllowedStringValuesValidator, BoundedEventShapeValidator, ClaimsEvidenceGroundedValidator,
+    ContentNonEmptyValidator, JsonObjectOutputValidator, JsonSchemaValidator,
+    RequiredFieldsValidator,
 };
 use choreo_app::services::AutoDispatchService;
 use choreo_app::usecases::{
@@ -133,6 +134,11 @@ pub async fn compose() -> Result<Application, ComposeError> {
         Arc::new(RequiredFieldsValidator::new()),
         Arc::new(AllowedStringValuesValidator::new()),
         Arc::new(JsonSchemaValidator::new()),
+        // Evidence grounding: rejects claims citing refs outside the
+        // contract's evidence pack (no-op unless a contract declares a
+        // grounding rule). Runs before the shape-budget guard so orphan
+        // refs are named even when the output is otherwise well-formed.
+        Arc::new(ClaimsEvidenceGroundedValidator::new()),
         // Final shape-budget guard: defends downstream bus consumers
         // against pathological JSON (deeply nested, huge arrays,
         // bloated strings). Uses the validator's conservative


### PR DESCRIPTION
## Why

Multi-round councils amplify fluency, not grounding. In a real ceremony run (`csi-typha-appeal`, 2026-07-03) a fact-checker agent **canonised a fabricated evidence claim** ('privileged: true is in the pod spec' — never in the case file) and the judge ruled on it with high confidence. Nothing in the pipeline could tell a grounded claim from an invented one. This PR adds that gate — the metric it serves: `unsupported_claim_escape_count == 0`.

## What

- **core**: `OutputContract` grows an optional `EvidenceGroundingRule` (`claims_field`, `refs_field`, `allowed_refs` — the evidence pack). Wire/storage shape stays backward-compatible (field skipped when absent; legacy contracts deserialize, covered by test).
- **adapters**: `ClaimsEvidenceGroundedValidator` (kind `claims-evidence-grounded`). No-op without a rule (`"no evidence grounding configured"`, the siblings' pattern); otherwise every claim must be an object citing ≥1 evidence ref and every ref must exist in the pack. Violations name the claim index, a text preview and the orphan refs — that detail rides the `ValidatorReport` into spans/logs and becomes part of the decision record.
- **ceremony YAML** (extends the `output_contract` block from #118):

  ```yaml
  output_contract:
    contract_id: evidence-bound-decision
    required_fields: [claims, decision]
    evidence:
      claims_field: claims                      # optional, default
      refs_field: evidence_refs                 # optional, default
      allowed_refs: [ev-static-1]               # optional, static entries
      allowed_refs_from_context: evidence_pack  # optional, ceremony-context key
  ```

  At least one source is required; unknown keys are rejected (same reasoning as #118: a typo must not silently weaken a policy gate). Context packs (`[{id,…},…]` or `["id",…]`) resolve at request time in the transport layer — a gate pointing at an absent/malformed pack **fails loudly** instead of running ungrounded.
- **compose**: registered with the production validators.

## Design decision (alternatives considered)

The pack rides on the **contract** (option: extend `OutputContract`), because the contract already IS the policy surface and `TaskConstraints` already carries it to every validator — no `ValidatorPort` signature change. Discarded: (i) threading the raw ceremony context into validators (port-breaking, leaks transport into domain); (ii) reusing `OutputFieldRule.allowed_string_values` (validates scalar strings, cannot express per-claim nested refs).

## Expected output shape

`{ "claims": [ { "text": "…", "evidence_refs": ["ev-1"] } ], … }` — empty `claims` array passes (grounding judges what is claimed, not how much; pair with `json_schema` `minItems` to demand substance).

## Validation

E2E test: a `FabricatingAgent` emitting a fluent, well-formed proposal citing `ev-fabricated` dies as `NoValidProposal{evidence-bound-decision}` through the real deliberation pipeline. 262 adapter + 216 core tests green; fmt clean; clippy adds no new warnings.

**Stacked on #118** (`feat/ceremony-step-output-contract`) — the YAML `evidence` block nests inside the contract block introduced there. Retarget to `main` after #118 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)