### PR TITLE
docs(readme): tagline and capability overview match the shipped scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,41 @@
 
 > Part of [Underpass AI](https://underpassai.com) — memory and execution infrastructure for reliable AI agents.
 
-Event-driven coordination plane for specialist agents. Domain-agnostic port of
-the `swe-ai-fleet` orchestrator service to Rust.
+Event-driven coordination plane for councils of specialist agents. It runs
+structured deliberations (propose → peer-critique → revise → validate →
+score → winner) and longer declarative YAML ceremonies as explicit state
+machines, enforces output contracts on what agents produce, can score with
+an LLM judge, and ships observability that shows *why* an answer won.
+Domain- and provider-agnostic (vLLM, Anthropic, OpenAI, local, rule-based,
+human-in-the-loop). Kubernetes-first.
+
+Lineage: started as a domain-agnostic Rust port of the `swe-ai-fleet`
+orchestrator service, and has since grown well beyond that port.
+
+## What it does
+
+- **Structured deliberation** — a strict one-way FSM per council run
+  (`Proposing → Revising → Validating → Scoring → Completed`) with
+  deterministic peer critique between agents and a bounded, total-order
+  score for ranking.
+- **Declarative ceremonies** — longer multi-step meetings defined in YAML as
+  explicit state machines (states, transitions, guards, retries, leases).
+  The winning contribution of every step is an **API artifact** — a meeting
+  record with a Mermaid diagram of the conversation — not a log line.
+- **Output contracts** — JSON Schema plus field rules enforced by shipped
+  validators, with deterministic rejection (`NoValidProposal`) when no
+  proposal satisfies the contract: unsupported output does not become a
+  decision.
+- **Optional LLM-as-judge** — judge-aware scoring with fail-fast
+  configuration, plus a judge *discrimination* metric that tells you whether
+  the judge actually re-ranks proposals or just burns tokens.
+- **Deliberation-native observability** — every deliberation is a replayable
+  OpenTelemetry trace (the debate itself, span by span, exported over mTLS)
+  and Prometheus metrics designed for this domain: winner-score
+  distribution, `NoValidProposal` rate, per-step ceremony outcomes. See
+  [`docs/choreographer-observability-design.md`](docs/choreographer-observability-design.md).
+- **Two surfaces** — a contract-first gRPC API, and a stdio MCP server
+  exposing the same RPCs 1:1 to coding agents (Codex CLI, Claude Desktop).
 
 ## The Underpass platform
 


### PR DESCRIPTION
## Why

The README body and the Status section are honest and complete, but the first two lines undersell the project: they stop at "coordination plane / port of swe-ai-fleet". A reader who only sees the tagline never learns that the repo ships a declarative ceremony engine, output contracts with deterministic rejection, an optional LLM judge with a discrimination metric, an MCP server, and observability that can replay a whole deliberation span by span.

## What

- Tagline rewritten to name the shipped capabilities (deliberation FSM, YAML ceremonies, output contracts, LLM judge, debate observability). Provider list kept verbatim from the chart/proto description.
- "Port of swe-ai-fleet" demoted to a lineage note — accurate, but no longer the headline.
- New **What it does** section (6 bullets) between the tagline and the platform table, written in capability language and sourced from the existing Status bullets, `docs/choreographer-architecture-and-differentiation.md` and `docs/choreographer-observability-design.md`.
- Two buried differentiators surfaced: the meeting record as an **API artifact** (not a log line), and the deliberation as a **replayable OTel trace**.
- Observability design doc linked from the header.

## What this PR does NOT do

No new claims, no scope inflation: every bullet maps to something already implemented and CI-backed. The Status section and its caveats (StreamDeliberation granularity, ceremony timeouts not yet enforced, no public tag) are untouched — per `docs/PRINCIPLES.md`, they are an asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)